### PR TITLE
WIP: Cropping via sliding window

### DIFF
--- a/object_tracker_0/tests/test_inference.py
+++ b/object_tracker_0/tests/test_inference.py
@@ -9,3 +9,19 @@ def test_convert_bbox_format():
     # Assert all coordinates are within 5% of the expected result (manually labeled)
     threshold = max(shape) * 0.05
     assert all(abs(a - b) < threshold for a, b in zip(result, expected_result)), f"Expected {expected_result}, got {result}"
+
+def test_calculate_croppings():
+    from inference import calculate_croppings
+    from PIL import Image
+    import numpy as np
+    pil_frame = Image.fromarray(np.zeros((2048, 3072, 3), dtype=np.uint8))
+    sub_frame_height = 800
+    sub_frame_width = 1200
+    croppings = calculate_croppings(pil_frame, sub_frame_height, sub_frame_width)
+    assert len(croppings) == 9, f"Expected 9 croppings, got {len(croppings)}"
+
+def test_is_similar():
+    from inference import is_similar
+    box1 = [1135.3022, 401.4587, 50.4141, 73.8211]
+    box2 = [1135.0023, 399.2978, 50.8004, 76.1039]
+    assert is_similar(box1, box2), f"Expected {box1} and {box2} to be similar"


### PR DESCRIPTION
Adds the ability to process each image in batches, using a sliding window of the configured model input size, to avoid resizing and use the maximum available resolution for object detection.
As a result, it's of course much slower (it requires multiple inference calls instead of one).

TODO: Make all these configurable and move them to arguments:
 - box and label thresholds
 - model input size (need to figure out how to modify the model input file, if that's possible at all)
 - every how many frames to run object detection
 - whether to use tiling or not (aka use resizing)