### PR TITLE
Live camera capture for camera_control app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,25 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Camera control App",
+            "name": "Camera control App (Live)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "camera_control/src/camera_control/camera_control_app.py",
+            "console": "integratedTerminal",
+            "redirectOutput": true,
+            "env": {"GST_DEBUG": "2"},
+            "args": [
+            ],
+        },
+        {
+            "name": "Camera control App (From file)",
             "type": "debugpy",
             "request": "launch",
             "program": "camera_control/src/camera_control/camera_control_app.py",
             "console": "integratedTerminal",
             "redirectOutput": true,
             "args": [
-                "datasets/${input:dataset}/video/video.mp4"
+                "--video-path=datasets/${input:dataset}/video/video.mp4"
             ],
         },
         {
@@ -62,7 +73,7 @@
             "description": "Dataset",
             "options": [
                 "rabbits_2024_08_12_25_10min_div2",
-                "rabbits_2024_08_12_25_15sec"
+                "rabbits_2024_08_12_25_15sec",
             ]
         }
     ]

--- a/camera_control/README.md
+++ b/camera_control/README.md
@@ -1,0 +1,8 @@
+### Installation
+
+Install GStreamer and it's python interface.
+```
+sudo apt install python3-gst-1.0 gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad gstreamer1.0-libav \
+    gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0
+```

--- a/camera_control/README.md
+++ b/camera_control/README.md
@@ -1,8 +1,30 @@
 ### Installation
 
+Create a python virtual environment. You must use the `--system-site-packages`
+option, since gstreamer's python api can only be installed with apt, not pip.
+```
+virtualenv .venv --system-site-packages
+```
+
 Install GStreamer and it's python interface.
 ```
 sudo apt install python3-gst-1.0 gstreamer1.0-plugins-good \
     gstreamer1.0-plugins-bad gstreamer1.0-libav \
     gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0
 ```
+
+### Configuration
+
+If you want to capture live images from a camera using gstreamer, you must specify the
+`rtsp` URI for the camera. To do this, create a file called `camera_control.yml` in
+`~/.config` with the following content:
+```yaml
+{
+  camera_uri: "rtsp://<username>:<password>@<camera_ip_address>:<camera_rtsp_ port>/<path_to_stream>
+}
+```
+
+### Running the App
+
+Use one of the two configuration in this repo's launch.json. One captures live images from
+the camera; the other loads a video file from disk.

--- a/camera_control/requirements.txt
+++ b/camera_control/requirements.txt
@@ -1,3 +1,5 @@
 imutils
+numpy
 opencv-python
 PySide6
+pyyaml

--- a/camera_control/requirements.txt
+++ b/camera_control/requirements.txt
@@ -3,3 +3,4 @@ numpy
 opencv-python
 PySide6
 pyyaml
+

--- a/camera_control/src/camera_control/camera_control_app.py
+++ b/camera_control/src/camera_control/camera_control_app.py
@@ -3,7 +3,6 @@ import cv2
 import sys
 from PySide6.QtWidgets import (
     QApplication,
-    QLabel,
     QMainWindow,
     QSlider,
     QTabWidget,
@@ -12,10 +11,10 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QImage, QPixmap
 
-from camera_control.camera_control_signals import CameraControlSignals
+from camera_control.common import CameraControlSignals, cv_image_to_q_image
 from camera_control.detection_control_widget import DetectionControlWidget, DetectionParameters
+from camera_control.image_widget import ImageWidget
 
 class CameraControlApp(QMainWindow):
     def __init__(self, video_path):
@@ -31,27 +30,15 @@ class CameraControlApp(QMainWindow):
         self.setCentralWidget(self.central_widget)
 
         # This label will display the video frames
-        self.frame_display = QLabel(self)
-        self.detection_mask_display = QLabel(self)
-
-        self.seek_slider = QSlider(Qt.Horizontal, self)
-        self.seek_slider.setMinimum(0)
-        self.seek_slider.setMaximum(100)
-        self.seek_slider.setValue(0)
-        self.seek_slider.valueChanged.connect(self.seek_frame)
+        self.frame_display = ImageWidget(self)
+        self.detection_mask_display = ImageWidget(self)
 
         default_detection_parameters = DetectionParameters(10, 11, "MOG2", 0.001)
         self.detection_control_widget = DetectionControlWidget(self.app_signals, self.video_path, default_detection_parameters)
 
-        self.app_signals.frame_updated.connect(
-            lambda q_img: self.frame_display.setPixmap(QPixmap.fromImage(q_img))
-        )
-        self.app_signals.detection_completed.connect(
-            lambda q_img: self.frame_display.setPixmap(QPixmap.fromImage(q_img))
-        )
-        self.app_signals.detection_mask_updated.connect(
-            lambda q_img: self.detection_mask_display.setPixmap(QPixmap.fromImage(q_img))
-        )
+        self.app_signals.frame_updated.connect(self.frame_display.display_image)
+        self.app_signals.detection_completed.connect(self.frame_display.display_image)
+        self.app_signals.detection_mask_updated.connect(self.detection_mask_display.display_image)
         self.app_signals.frame_number_updated.connect(self.detection_control_widget.set_frame_number)
 
         self.running = True
@@ -60,6 +47,12 @@ class CameraControlApp(QMainWindow):
         if not self.cap.isOpened():
             raise ValueError(f"Failed to open video: {self.video_path}")
         self.total_frames = int(self.cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        self.seek_slider = QSlider(Qt.Horizontal, self)
+        self.seek_slider.setMinimum(0)
+        self.seek_slider.setMaximum(self.total_frames-1)
+        self.seek_slider.setValue(0)
+        self.seek_slider.valueChanged.connect(self.seek_frame)
 
         self.main_layout = QHBoxLayout(self.central_widget)
         self.video_layout = QVBoxLayout()
@@ -77,19 +70,12 @@ class CameraControlApp(QMainWindow):
         # Manually trigger the first frame update.
         self.seek_slider.valueChanged.emit(0)
 
-    def seek_frame(self, value):
-        frame_number = int((value / 100) * self.total_frames)
+    def seek_frame(self, frame_number):
         self.cap.set(cv2.CAP_PROP_POS_FRAMES, frame_number)
 
         ret, frame = self.cap.read()
         if ret:
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            height, width, num_channels = frame.shape
-            bytes_per_line = num_channels * width
-            q_img = QImage(
-                frame.data, width, height, bytes_per_line, QImage.Format.Format_RGB888
-            )
-            self.app_signals.frame_updated.emit(q_img)
+            self.app_signals.frame_updated.emit(cv_image_to_q_image(frame))
             self.app_signals.frame_number_updated.emit(frame_number)
         else:
             print(f"Error reading frame {frame_number}")

--- a/camera_control/src/camera_control/camera_control_signals.py
+++ b/camera_control/src/camera_control/camera_control_signals.py
@@ -1,8 +1,0 @@
-from PySide6.QtCore import Signal, QObject
-from PySide6.QtGui import QImage
-
-class CameraControlSignals(QObject):
-    frame_updated = Signal(QImage)
-    frame_number_updated = Signal(int)
-    detection_completed = Signal(QImage)
-    detection_mask_updated = Signal(QImage)

--- a/camera_control/src/camera_control/common.py
+++ b/camera_control/src/camera_control/common.py
@@ -1,0 +1,16 @@
+import cv2
+from PySide6.QtCore import Signal, QObject
+from PySide6.QtGui import QImage
+
+class CameraControlSignals(QObject):
+    frame_updated = Signal(QImage)
+    frame_number_updated = Signal(int)
+    detection_completed = Signal(QImage)
+    detection_mask_updated = Signal(QImage)
+
+def cv_image_to_q_image(cv_image):
+    cv_image_rgb = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
+    height, width, channels = cv_image_rgb.shape
+    bytes_per_line = channels * width
+    q_image = QImage(cv_image.data, width, height, bytes_per_line, QImage.Format.Format_RGB888)
+    return q_image

--- a/camera_control/src/camera_control/gstreamer_camera_capture.py
+++ b/camera_control/src/camera_control/gstreamer_camera_capture.py
@@ -1,0 +1,47 @@
+import gi
+import numpy as np
+
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
+
+class GStreamerCameraCapture:
+    """
+    Class to read frames from a GStreamer pipeline using the appsink element.
+
+    We don't use the opencv VideoCapture class with the GStreamer backend because
+    it isn't included in the default opencv installation.
+    """
+    def __init__(self, camera_uri):
+        Gst.init(None)
+        pipeline_str = " " .join([
+            f"rtspsrc location={camera_uri} latency=30 ! rtph265depay ! h265parse",
+            " ! avdec_h265 ! videoconvert ! video/x-raw,format=BGR ! appsink name=appsink"
+             ])
+        print('Creating gstreamer pipeline: {}'.format(pipeline_str))
+        self.pipeline = Gst.parse_launch(pipeline_str)
+            
+        self.appsink = self.pipeline.get_by_name("appsink")
+        if not self.appsink:
+            raise ValueError("Pipeline must contain an element named 'appsink'")
+
+        self.pipeline.set_state(Gst.State.PLAYING)
+
+    def read_next_frame(self):
+        sample = self.appsink.emit("pull-sample")
+        if not sample:
+            raise ValueError("Failed to read frame from pipeline")
+        buf = sample.get_buffer()
+        caps = sample.get_caps()
+        new_image = np.ndarray(
+            (
+                caps.get_structure(0).get_value("height"),
+                caps.get_structure(0).get_value("width"),
+                3,
+            ),
+            buffer=buf.extract_dup(0, buf.get_size()),
+            dtype=np.uint8,
+        )
+        return new_image
+
+    def release(self):
+        self.pipeline.set_state(Gst.State.NULL)

--- a/camera_control/src/camera_control/image_widget.py
+++ b/camera_control/src/camera_control/image_widget.py
@@ -12,6 +12,8 @@ class ImageWidget(QLabel):
 
     def display_image(self, q_img):
         self.raw_pixmap = QPixmap.fromImage(q_img)
+        # trigger a paintevent
+        self.update()
 
     def paintEvent(self, event):
         if self.raw_pixmap is not None:

--- a/camera_control/src/camera_control/image_widget.py
+++ b/camera_control/src/camera_control/image_widget.py
@@ -1,0 +1,22 @@
+from PySide6.QtWidgets import QLabel
+from PySide6.QtGui import QPixmap, QPainter
+from PySide6.QtCore import Qt
+
+class ImageWidget(QLabel):
+    """
+    A widget to display an image, resizing it as the window size changes.
+    """
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.raw_pixmap = None
+
+    def display_image(self, q_img):
+        self.raw_pixmap = QPixmap.fromImage(q_img)
+
+    def paintEvent(self, event):
+        if self.raw_pixmap is not None:
+            painter = QPainter(self)
+            painter.setRenderHint(QPainter.SmoothPixmapTransform)
+            painter.drawPixmap(self.rect(), self.raw_pixmap)
+            painter.end()
+        super().paintEvent(event)


### PR DESCRIPTION
Now camera_control can get frames from _either_ a video file on disk, _or_ a live RTSP stream from a camera. Also added automatic image resizing with window size changes, so this should be usable for high res images. The app doesn't do anything yet with the live captured images; applying the motion detection to them to pick camera targets is my next task.

There are instructions for running the code in `camera_control/README.md` if you're curious. But  unless you've got a camera that supports RTSP, the only change you'll notice is resizing of the images when you resize the app window.