### PR TITLE
Script to describe annotations and update visualization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,6 +65,19 @@
                 "0.5"
             ]
         },
+        {
+            "name": "Describe Annotations",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "object_tracker_0/src/describe_annotations.py",
+            "console": "integratedTerminal",
+            "args": [
+                "-a",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json",
+                "-d",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/annotation_description.txt",
+            ]
+        },
     ],
     "inputs": [
         {

--- a/object_tracker_0/src/describe_annotations.py
+++ b/object_tracker_0/src/describe_annotations.py
@@ -62,7 +62,8 @@ def describe_annotations(filename: str, output_filename: str):
     annotation_map = defaultdict(lambda: {})
 
     for annotation in data['annotations']:
-        annotation_map[annotation['image_id']][annotation['attributes']['track_id']] = {'category_id': annotation['category_id'], 'bbox': annotation['bbox']}
+        track_id = annotation.get('attributes', {}).get('track_id', 0)
+        annotation_map[annotation['image_id']][track_id] = {'category_id': annotation['category_id'], 'bbox': annotation['bbox']}
 
     min_image_id = min(annotation_map.keys())
     max_image_id = max(annotation_map.keys())

--- a/object_tracker_0/src/describe_annotations.py
+++ b/object_tracker_0/src/describe_annotations.py
@@ -1,0 +1,118 @@
+import argparse
+from io import TextIOWrapper
+import json
+from collections import defaultdict
+
+def directions_of_movement(prev_x, prev_y, x, y, THRESHOLD = 1):
+    dx = x - prev_x
+    dy = y - prev_y
+
+    adx = abs(dx)
+    ady = abs(dy)
+
+    horizontal = ""
+    if (adx) > THRESHOLD:
+        horizontal = "R" if dx > 0 else "L"
+
+    vertical = ""
+    if (ady) > THRESHOLD:
+        vertical = "D" if dy > 0 else "U"
+
+    # TODO: we want to show diagonal movements, but need to tune it so that we're not too sensitive to changes in direction
+    # if adx > 2 * ady:
+    #     vertical = ""
+
+    # if ady > 2 * adx:
+    #     horizontal = ""
+
+    if adx > ady:
+        vertical = ""
+    else:
+        horizontal = ""
+
+    return (horizontal, vertical)    
+
+def describe_movement(h, v):
+    d = []
+    if h == "R":
+        d.append("right")
+    elif h == "L":
+        d.append("left")
+
+    if v == "D":
+        d.append("down")
+    elif v == "U":
+        d.append("up")
+
+    return " and ".join(d)
+
+
+    
+def describe_annotations(filename: str, output_filename: str):
+
+    def log(file: TextIOWrapper, image_id: int, actor: str, message: str):
+        file.write(f"{image_id:5};{actor};{message}\n")
+    
+
+    with open(filename, 'r') as f:
+        data = json.load(f)
+    
+    categories_map = {category['id']: category['name'] for category in data['categories']}
+
+    annotation_map = defaultdict(lambda: {})
+
+    for annotation in data['annotations']:
+        annotation_map[annotation['image_id']][annotation['attributes']['track_id']] = {'category_id': annotation['category_id'], 'bbox': annotation['bbox']}
+
+    min_image_id = min(annotation_map.keys())
+    max_image_id = max(annotation_map.keys())
+
+    
+    position_map = {}
+    last_seen = {}
+
+    with open(output_filename, 'w') as output_file:
+
+        for image_id in range(min_image_id, max_image_id + 1):
+            for track_id, annotation in annotation_map[image_id].items():
+                x = int(annotation['bbox'][0] + annotation['bbox'][2] / 2)
+                y = int(annotation['bbox'][1] + annotation['bbox'][3] / 2)
+                last_seen[track_id] = image_id
+
+                name = f"{categories_map[annotation['category_id']]}_{track_id}"
+                if track_id in position_map:
+                    prev_x, prev_y, prev_image_id, prev_state = position_map[track_id]
+                    distance = ((x - prev_x)**2 + (y - prev_y)**2)**0.5
+                    if distance > 20:
+                        h, v = directions_of_movement(prev_x, prev_y, x, y)
+                        movement = describe_movement(h, v)
+
+                        state = f"MOVING_{h}{v}"
+                        if prev_state != state:
+                            log(output_file, image_id, name, f"is moving {movement}")
+                        position_map[track_id] = (x,y, image_id, state)
+                    else:
+                        if image_id - prev_image_id > 32 and prev_state[:6] == "MOVING":
+                            # log(image_id, f"{name} stopped moving")
+                            position_map[track_id] = (x,y, image_id, "STILL")
+
+                else:
+                    position_map[track_id] = (x,y, image_id, "STILL")
+                    # TODO: give more information of where it appeared, e.g. "appeared in the top left corner" or if it just popped up in the middle of the screen
+                    log(output_file, image_id, name, "appeared")
+
+            for track_id, image_id_last_seen in last_seen.items():
+                if image_id - image_id_last_seen > 32:
+                    name = f"{categories_map[annotation_map[image_id][track_id]['category_id']]}_{track_id}"
+                    # TODO: give more information of where it dissapeared
+                    log(output_file, image_id, name,"disappeared")
+                    last_seen.pop(track_id)
+        
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Object Tracker')
+
+    parser.add_argument('-a', '--annotations', type=str, required=True, help='Path to the annotations JSON file')
+    parser.add_argument('-d', '--description', type=str, required=True, help='Path to the output description annotations text file')
+    args = parser.parse_args()
+
+    describe_annotations(args.annotations, args.description)

--- a/object_tracker_0/tests/test_inference_metrics.py
+++ b/object_tracker_0/tests/test_inference_metrics.py
@@ -1,0 +1,76 @@
+import pytest
+import numpy as np
+from inference_metrics import compute_iou, compute_confusion_matrix_per_image_one_category, compute_confusion_matrix_per_image, compute_confusion_matrix
+from collections import defaultdict
+import json
+import tempfile
+
+@pytest.fixture
+def mock_data():
+    ground_truth = [
+        {'id': 1, 'image_id': 1, 'category_id': 1, 'bbox': [0, 0, 10, 10]}, 
+        {'id': 2, 'image_id': 1, 'category_id': 2, 'bbox': [10, 10, 10, 10]},
+        {'id': 3, 'image_id': 1, 'category_id': 3, 'bbox': [20, 20, 10, 10]} 
+    ]
+    predictions = [
+        {'id': 1, 'image_id': 1, 'category_id': 1, 'bbox': [1, 1, 9, 10]},
+        {'id': 2, 'image_id': 1, 'category_id': 2, 'bbox': [10, 12, 10, 10]},
+        {'id': 3, 'image_id': 1, 'category_id': 1, 'bbox': [20, 20, 10, 10]}
+    ]
+    return ground_truth, predictions
+
+def test_compute_iou():
+    box1 = [0, 0, 10, 10]
+    box2 = [5, 5, 10, 10]
+    iou = compute_iou(box1, box2)
+    expected_iou = 25 / 175  # Intersection area / Union area
+    assert np.isclose(iou, expected_iou)
+
+    # No intersection
+    box2 = [20, 20, 10, 10]
+    iou = compute_iou(box1, box2)
+    expected_iou = 0  # Intersection area / Union area
+    assert np.isclose(iou, expected_iou)
+
+    box2 = [1, 0, 10, 10]
+    iou = compute_iou(box1, box2)
+    expected_iou = 90 / 110  # Intersection area / Union area
+    assert np.isclose(iou, expected_iou)
+   
+    box2 = [9, 9, 10, 10]
+    iou = compute_iou(box1, box2)
+    expected_iou = 1 / 199  # Intersection area / Union area
+    assert np.isclose(iou, expected_iou)
+
+def test_compute_confusion_matrix_per_image_one_category(mock_data):
+    ground_truth, predictions = mock_data
+
+    expected_cms = [
+        np.array([[1, 1], [0, 0]], np.int32),
+        np.array([[1, 0], [0, 0]], np.int32),
+        np.array([[0, 0], [1, 0]], np.int32)
+    ]
+    for category_id in [1,2,3]:
+        gt = [gt for gt in ground_truth if gt['category_id'] == category_id]
+        pred = [pred for pred in predictions if pred['category_id'] == category_id]
+        cm = compute_confusion_matrix_per_image_one_category(gt, pred, 0.5)
+
+        expected_cm = expected_cms.pop(0)
+        np.testing.assert_array_equal(cm, expected_cm)
+
+def test_compute_confusion_matrix_per_image(mock_data):
+    ground_truth, predictions = mock_data
+    cm = compute_confusion_matrix_per_image(ground_truth, predictions, 0.5)
+    expected_cm = np.array([[2, 1], [1, 0]], np.int32) 
+    np.testing.assert_array_equal(cm, expected_cm)
+
+def test_compute_confusion_matrix(mock_data):
+    ground_truth, predictions = mock_data
+    with tempfile.NamedTemporaryFile('w', delete=False) as gt_file, tempfile.NamedTemporaryFile('w', delete=False) as pred_file:
+        json.dump({'images': [{'id': 1}], 'annotations': ground_truth}, gt_file)
+        json.dump({'images': [{'id': 1}], 'annotations': predictions}, pred_file)
+        gt_file.flush()
+        pred_file.flush()
+        cm = compute_confusion_matrix(gt_file.name, pred_file.name, 0.5)
+        expected_cm = np.array([[2, 1], [1, 0]], np.int32) 
+        np.testing.assert_array_equal(cm, expected_cm)


### PR DESCRIPTION
Provide a new script that given an annotation file outputs a text describing the actions (currently just appear, dissapear and movements).
It also updates the visualize script to show the text, so we can easily see how it matches the video.

I tried it with:
```
python src/visualize.py -v ../datasets/rabbits_2024_08_12_25_10min_div2/video/video.mp4 -a ../datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json -d ../datasets/rabbits_2024_08_12_25_10min_div2/annotations/annotation_description.txt
```

Here's an example of how the visualization looks:
<img width="1156" alt="image" src="https://github.com/user-attachments/assets/abfd1eb8-9379-4c3f-b9fe-8b2dc4cbaa95">
