### PR TITLE
Add class to control camera PTZ using Onvif

### DIFF
--- a/camera_control/README.md
+++ b/camera_control/README.md
@@ -20,7 +20,12 @@ If you want to capture live images from a camera using gstreamer, you must speci
 `~/.config` with the following content:
 ```yaml
 {
-  camera_uri: "rtsp://<username>:<password>@<camera_ip_address>:<camera_rtsp_ port>/<path_to_stream>
+  camera_address: ...,
+  camera_rtsp_port: ...,
+  camera_rtsp_path: ...,
+  camera_onvif_port: ...,
+  camera_username: ...,
+  camera_password: ...,
 }
 ```
 

--- a/camera_control/requirements.txt
+++ b/camera_control/requirements.txt
@@ -1,6 +1,6 @@
 imutils
 numpy
+onvif_zeep
 opencv-python
 PySide6
 pyyaml
-

--- a/camera_control/src/camera_control/onvif_camera_control.py
+++ b/camera_control/src/camera_control/onvif_camera_control.py
@@ -1,0 +1,104 @@
+from onvif import ONVIFCamera
+from pathlib import Path
+import sys
+import time
+import yaml
+
+class OnvifCameraControl:
+    def __init__(self, host, port, user, password):
+        """
+        Simple interface for controlling a camera using the ONVIF protocol.
+        """
+        self.camera = ONVIFCamera(host, port, user, password)
+        self.media_service = self.camera.create_media_service()
+        self.ptz_service = self.camera.create_ptz_service()
+        self.media_profile = self.media_service.GetProfiles()[0]
+        self.ptz_configuration = self.ptz_service.GetConfigurationOptions({'ConfigurationToken': self.media_profile.PTZConfiguration.token})
+
+    def stop(self):
+        """
+        Works with Jennov PS6007.
+        """
+        self.ptz_service.Stop({'ProfileToken': self.media_profile.token})
+
+    def continuous_move(self, x, y, z):
+        """
+        Works for pan and tilt but not zoom with Jennov PS6007.
+        """
+        request = self.ptz_service.create_type('ContinuousMove')
+        request.ProfileToken = self.media_profile.token
+        request.Velocity = {
+            'PanTilt': {'x': x, 'y': y},
+            'Zoom': {'x': z}
+        }
+        self.ptz_service.ContinuousMove(request)
+
+
+    def relative_move(self, pan, tilt, zoom):
+        """
+        Seems to be the same as a "ContinuousMove" for pan and tilt on Jennov PS6007.
+        """
+        request = self.ptz_service.create_type('RelativeMove')
+        request.ProfileToken = self.media_profile.token
+        request.Translation = {
+            'PanTilt': {'x': pan, 'y': tilt},
+            'Zoom': {'x': zoom}
+        }
+        self.ptz_service.RelativeMove(request)
+
+    def goto_preset(self, preset_token):
+        """
+        Works with Jennov PS6007
+        """
+        request = self.ptz_service.create_type('GotoPreset')
+        request.ProfileToken = self.media_profile.token
+        request.PresetToken = preset_token
+        self.ptz_service.GotoPreset(request)
+
+    def is_movement_finished(self):
+        """
+        Doesn't seem to work with Jennov PS6007, at least when moving to presets.
+        """
+        request = self.ptz_service.create_type('GetStatus')
+        request.ProfileToken = self.media_profile.token
+        status = self.ptz_service.GetStatus(request)
+        return status.MoveStatus == 'IDLE'
+
+if __name__ == "__main__":
+    # Load camera configuration from a YAML file.
+    config_file_path = Path.home() / ".config/camera_control.yml"
+    try:
+        with open(config_file_path) as yaml_file:
+            camera_config = yaml.load(yaml_file, Loader=yaml.FullLoader)
+    except FileNotFoundError:
+        print(f"No config file found at {config_file_path}.")
+        sys.exit(-1)
+
+    cam = OnvifCameraControl(
+        camera_config["camera_address"],
+        camera_config["camera_onvif_port"],
+        camera_config["camera_username"],
+        camera_config["camera_password"])
+
+
+    for ii in range(3):
+        print("Moving to preset 1")
+        cam.goto_preset("1")
+        time.sleep(10.0)
+
+
+        print("Moving right and down")
+        cam.continuous_move(1, 1, 0)
+        time.sleep(3.0)
+
+        cam.stop()
+        time.sleep(2.0)
+
+
+        print("Zooming in")
+        cam.relative_move(0, 0, 1)
+        time.sleep(5.0)
+
+        print('Stopping')
+        cam.stop()
+        time.sleep(2.0)


### PR DESCRIPTION
Doesn't do anything yet through the GUI, but running `camera_control/src/camera_control/onvif_camera_control.py` as a script moves the camera.

Some annoying things about this camera:
- doesn't support AbsoluteMove commands, but happily acts as though it does
- doesn't report its current position, even though it must know it, or else the presets wouldn't work
- ContinuousMove works for pan and tilt axes, but not zoom
- RelativeMove works for zoom but acts as a ContinuousMove for pan and tilt

Note: the format of the camera_control YAML config file has changed - I had to the camera parameters up so that I could use them for both RTSP and Onvif.