### PR TITLE
Rough implementation of pan-tilt-zoom to point

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "program": "camera_control/src/camera_control/camera_control_app.py",
             "console": "integratedTerminal",
             "redirectOutput": true,
-            "env": {"GST_DEBUG": "2"},
+            "env": {"GST_DEBUG": "1"},
             "args": [
             ],
         },

--- a/camera_control/src/camera_control/common.py
+++ b/camera_control/src/camera_control/common.py
@@ -12,5 +12,5 @@ def cv_image_to_q_image(cv_image):
     cv_image_rgb = cv2.cvtColor(cv_image, cv2.COLOR_BGR2RGB)
     height, width, channels = cv_image_rgb.shape
     bytes_per_line = channels * width
-    q_image = QImage(cv_image.data, width, height, bytes_per_line, QImage.Format.Format_RGB888)
+    q_image = QImage(cv_image_rgb.data, width, height, bytes_per_line, QImage.Format.Format_RGB888)
     return q_image

--- a/camera_control/src/camera_control/detection_control_widget.py
+++ b/camera_control/src/camera_control/detection_control_widget.py
@@ -30,7 +30,7 @@ class DetectionControlWidget(QWidget):
         self.detection_thread = None
 
         self.main_layout = QVBoxLayout(self)
-        self.frame_number_label = QLabel("Frame: {self.frame_number:9d}", self)
+        self.frame_number_label = QLabel(f"Frame: {self.frame_number:9d}", self)
         self.main_layout.addWidget(self.frame_number_label)
         self.min_area_label = QLabel("Minimum area")
         self.min_area_spinbox = QSpinBox()

--- a/camera_control/src/camera_control/image_widget.py
+++ b/camera_control/src/camera_control/image_widget.py
@@ -1,11 +1,14 @@
-from PySide6.QtWidgets import QLabel
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QPixmap, QPainter
-from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLabel
+
 
 class ImageWidget(QLabel):
     """
     A widget to display an image, resizing it as the window size changes.
     """
+    image_clicked_signal = Signal(int, int)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.raw_pixmap = None
@@ -22,3 +25,13 @@ class ImageWidget(QLabel):
             painter.drawPixmap(self.rect(), self.raw_pixmap)
             painter.end()
         super().paintEvent(event)
+
+    def mousePressEvent(self, event):
+            if self.raw_pixmap is not None and event.button() == Qt.LeftButton:
+                # Calculate the coordinates in the image
+                x_ratio = self.raw_pixmap.width() / self.width()
+                y_ratio = self.raw_pixmap.height() / self.height()
+                x = int(event.pos().x() * x_ratio)
+                y = int(event.pos().y() * y_ratio)
+                self.image_clicked_signal.emit(x, y)
+            super().mousePressEvent(event)

--- a/camera_control/src/camera_control/onvif_camera_controller.py
+++ b/camera_control/src/camera_control/onvif_camera_controller.py
@@ -4,7 +4,7 @@ import sys
 import time
 import yaml
 
-class OnvifCameraControl:
+class OnvifCameraController:
     def __init__(self, host, port, user, password):
         """
         Simple interface for controlling a camera using the ONVIF protocol.
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         print(f"No config file found at {config_file_path}.")
         sys.exit(-1)
 
-    cam = OnvifCameraControl(
+    cam = OnvifCameraController(
         camera_config["camera_address"],
         camera_config["camera_onvif_port"],
         camera_config["camera_username"],


### PR DESCRIPTION
When the user clicks on a point in the live camera image, the camera will pan and tilt to look at that point, and zoom in a bit. It's not very accurate yet. The camera seems to always zoom at the same speed regardless of what it is told, and ignores zero values sent for pan and tilt speeds if the camera is already moving (it just keeps moving).