### PR TITLE
Quick hack to make it work for long videos

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # So that extensions in VSCode can find our modules.
-PYTHONPATH=./object_tracker_0/src:./camera_control/src:./external/GroundingDINO:${PYTHONPATH}
+PYTHONPATH=./object_tracker_0/src:./camera_control/src:./external/GroundingDINO:./external/segment-anything-2:${PYTHONPATH}
 CUDA_HOME=/usr/local/cuda

--- a/external/segment-anything-2/sam2/utils/misc.py
+++ b/external/segment-anything-2/sam2/utils/misc.py
@@ -141,8 +141,14 @@ class AsyncVideoFrameLoader:
             except Exception as e:
                 self.exception = e
 
-        self.thread = Thread(target=_load_frames, daemon=True)
-        self.thread.start()
+        # === Lazy Learning Lair ===
+        # Don't load all the frames!
+        # This quick hack to process long videos was kindly stolen from: https://github.com/facebookresearch/segment-anything-2/issues/288
+        # While we impatiently wait for SAM to support long videos nativelly and without doing dumb stuff.
+        # E.g., hopefully in the future something like this will be available: https://github.com/facebookresearch/segment-anything-2/pull/46/files
+
+        # self.thread = Thread(target=_load_frames, daemon=True)
+        # self.thread.start()
 
     def __getitem__(self, index):
         if self.exception is not None:
@@ -162,7 +168,10 @@ class AsyncVideoFrameLoader:
         img /= self.img_std
         if not self.offload_video_to_cpu:
             img = img.to(self.compute_device, non_blocking=True)
-        self.images[index] = img
+
+        # === Lazy Learning Lair ===
+        # Don't cache the loaded image, otherwise we run out of memory for large videos! Same Hack than above.
+        # self.images[index] = img
         return img
 
     def __len__(self):

--- a/object_tracker_0/src/utils.py
+++ b/object_tracker_0/src/utils.py
@@ -21,6 +21,9 @@ def load_model(filepath):
     model.load_state_dict(torch.load(filepath))
     return model
 
+def my_device():
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
 class Timer:
     def __init__(self):
         self.total_time = 0


### PR DESCRIPTION
Since it loads all the frames of the video in memory, a long enough video will exhaust all the memory 🤦 
I followed this very easy hack to fix it: https://github.com/facebookresearch/segment-anything-2/issues/288
It uses the lazy loader, and it changes it to actually be lazy.
It's not ideal to directly change the code in external, since we would need to re-do the changes when we upgrade the version, but my hope is that this will be fixed before we need to upgrade, and worst case we can re-do it or figure out something else.
Another option to not directly change the code would be to partition the video and just work with batches, but I don't think it's worth doing for now if we can just fix it with this hack.

There's also people working on directly supporting video, so eventually one day we'll be able to use it: https://github.com/facebookresearch/segment-anything-2/pull/46/files
