### PR TITLE
Add readme for running on the cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+## Running on a Cloud GPU
+
+This guide assumes that you have already started a cloud machine using some compute provider,
+e.g. Lambda Labs. It assumes that the remote machine comes with a relatively recent version of
+python, pip, and virtualenv, and has CUDA libraries installed already. All commands below are
+assumed to be run from the root directory of this repo.
+
+To make things easier, store the IP of the cloud machine in an environment variable.
+
+```
+export CLOUD_IP=<ip of cloud machine>
+```
+
+Transfer our code to the remote machine, leaving out directories we don't need.
+
+```
+rsync -av --exclude .venv --exclude .git $PWD ubuntu@$CLOUD_IP:
+```
+
+On the remote machine, create a virtual environment, activate it,  and install the our dependencies.
+This should take a couple minutes.
+
+```
+cd ~/deep_rabbit_hole
+virtualenv .venv
+. .venv/bin/activate
+pip install -r object_tracker_0/requirements.txt
+```
+
+Install segment-anything-2 (into the virtual environment). This will also take a couple of minutes.
+
+```
+pip install -e external/segment-anything-2/
+```
+
+Now you can run our scripts. For example to run inference:
+
+```
+python object_tracker_0/src/inference.py -v datasets/rabbits_2024_08_12_25_15sec/video/rabbits_2024_08_12_15sec.mp4 -a datasets/rabbits_2024_08_12_25_15sec/annotations/test_v1.json -w /tmp/15sec
+```


### PR DESCRIPTION
This is the most barebones possible setup, and fairly manual. The instructions explain how to rsync our code to the cloud machine, install dependencies, and run inference. I tested it on an a100 machine that I spun up on-demand through LambdaLabs

Potential improvements for the future:
1. Use VSCode's remote connection to edit the files and run launch configurations over SSH. To be really useful, we'll want to configure vscode to automatically install some useful extensions (like the python extension) in the server that it runs on the cloud machine
2. Mount the code onto the remote machine using something like sshfs. This would mean changes you make to the code on the remote machine would be reflected locally. In the current setup if you make changes to the code on the remote machine, you need to rsync them back to your local machine afterwards. It might make dataset loading slow though. Would take some experimentation.
3.  Mount our google cloud datasets volume directly into the cloud machine. In the current setup, those get rsync'd across along with our code. That's fine for the ~200MB we have at the moment, but won't scale.
4. Add programmatic provisioning of cloud machines. This could get complicated and cause unexpectedly high bills, so I'm a little wary of it.