### PR TITLE
Inference: fix box addition

### DIFF
--- a/object_tracker_0/src/inference.py
+++ b/object_tracker_0/src/inference.py
@@ -268,12 +268,15 @@ def perform_object_tracking(video_path, annotation_path, working_dir, frame_batc
         new_bboxes = list(filter(lambda newbbox: not any(is_similar(newbbox, oldbbox) for oldbbox in last_track_bboxes.values()), obj_detect_bboxes))
         # If any new rabbits were found, reset the tracker state and restart tracking from here with the new boxes
         if len(new_bboxes) > 0:
-            print(f"Found new rabbits: {new_bboxes}")
+            print(f"Found {len(new_bboxes)} new rabbits (total: {len(new_bboxes) + len(current_bboxes)}): {new_bboxes}")
             for new_bbox in new_bboxes:
                 current_bboxes[track_id] = new_bbox
                 track_id += 1
 
             obj_track_predictor.reset_state(obj_track_state)
+        else:
+            # No new rabbits, so we don't reset the state, so no need to pass again the boxes
+            current_bboxes = {}
 
 
         # Track the bbox rabbits until the next batch


### PR DESCRIPTION
I realized that if there are no new rabbits we are still re-adding the boxes (without resetting).   SAM2 would take it as refinements, and this probably was causing the OOM.
I just was able to run the 10 min inference in the cloud without OOM!
It run in `Timings => Detection: Total: 945.98s (16000 x 0.06s), Inference: Total: 875.83s (10330 x 0.08s)`.

Metrics:
```
Confusion matrix:
[[ 7954 11406]
 [ 7495     0]]
Precision: 0.41
Recall   : 0.51
F1       : 0.46
```