### PR TITLE
Add another set of annotations to the visualization

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,9 +44,9 @@
             "console": "integratedTerminal",
             "args": [
                 "-v",
-                "${workspaceFolder}/datasets/datasets/rabbits_2024_08_12_25_10min_div2/video.mp4",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/video/video.mp4",
                 "-a",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/test_v1.json",
                 "-w",
                 "/tmp/15sec"
             ],
@@ -60,11 +60,9 @@
             "console": "integratedTerminal",
             "args": [
                 "-v",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/video/video.mp4",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_15sec/video/rabbits_2024_08_12_15sec.mp4",
                 "-a",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/labeling.json",
-                "-g",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_15sec/annotations/test_v1.json"
             ],
             "cwd": "${workspaceFolder}/object_tracker_0"
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,9 +44,9 @@
             "console": "integratedTerminal",
             "args": [
                 "-v",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/video/video.mp4",
+                "${workspaceFolder}/datasets/datasets/rabbits_2024_08_12_25_10min_div2/video.mp4",
                 "-a",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/test_v1.json",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json",
                 "-w",
                 "/tmp/15sec"
             ],
@@ -60,9 +60,11 @@
             "console": "integratedTerminal",
             "args": [
                 "-v",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_15sec/video/rabbits_2024_08_12_15sec.mp4",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/video/video.mp4",
                 "-a",
-                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_15sec/annotations/test_v1.json"
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/labeling.json",
+                "-g",
+                "${workspaceFolder}/datasets/rabbits_2024_08_12_25_10min_div2/annotations/manual_labeling.json",
             ],
             "cwd": "${workspaceFolder}/object_tracker_0"
         },


### PR DESCRIPTION
With this we can make the visualization show both the results of inference and the ground truth, so that we can compare.
I was able to see that the last 2 minutes or so of ground truth are incorrect, I think we didn't label them yet, Julian will teach me

E.g.

<img width="797" alt="image" src="https://github.com/user-attachments/assets/6e78f643-1f65-47e9-ad68-dd232c8a16bc">
