### PR TITLE
Install google cloud python package

### DIFF
--- a/object_tracker_0/requirements.txt
+++ b/object_tracker_0/requirements.txt
@@ -10,6 +10,7 @@ mlflow
 psutil # So that mlflow can log system metrics
 pynvml # So that mlflow can log GPU metrics
 ffmpeg-python  # To extract video recording time from mp4 file
+google-cloud-storage # For logging mlflow artifacts on GCS
 
 # install this one manually
 # -e ../external/segment-anything-2

--- a/scripts/local_setup
+++ b/scripts/local_setup
@@ -9,4 +9,4 @@ pip install -e external/segment-anything-2/
 
 # Log-in to Google Cloud using user's credentials
 # TODO(adamantivm) Replace with file-based credential access
-gcloud auth application-default-login
+gcloud auth application-default login


### PR DESCRIPTION
And fix typo in cloud login command.

Without these changes, the inference script dies at the end because mlflow can't upload the artifacts, and the GCS login in the cloud script fails with
```
ERROR: (gcloud.auth) Invalid choice: 'application-default-login'.
Maybe you meant:
  gcloud auth application-default login
  gcloud auth login
  gcloud auth application-default print-access-token
  gcloud auth application-default revoke
  gcloud auth application-default set-quota-project

To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS

```