### PR TITLE
Basic model training

### DIFF
--- a/deep_water_level/src/data.py
+++ b/deep_water_level/src/data.py
@@ -23,7 +23,9 @@ class WaterDataset(Dataset):
                 image_file = images[image_id]['file_name']
                 image_path = os.path.join(self.images_dir, image_file)
                 depth = annotation.get('attributes', {})['depth']
-                data.append((image_path, depth))
+                # NOTE: The second item [depth] is the lable. It's an array because it could
+                # include many labels
+                data.append((image_path, [depth]))
         return data
 
     def __len__(self):

--- a/deep_water_level/src/data.py
+++ b/deep_water_level/src/data.py
@@ -4,6 +4,7 @@ from PIL import Image
 from torchvision import transforms
 import torch
 from torch.utils.data import Dataset
+from typing import Tuple
 
 class WaterDataset(Dataset):
     def __init__(self, annotations_file, images_dir, transform=None):
@@ -39,12 +40,23 @@ class WaterDataset(Dataset):
         depth = torch.tensor(depth, dtype=torch.float32)
         return image, depth
 
-def get_data_loader(annotations_file: str, images_dir: str, batch_size: int = 32):
+def get_data_loaders(
+    annotations_file: str,
+    images_dir: str,
+    batch_size: int = 32,
+    train_test_split: Tuple[int, int] = [0.8, 0.2],
+):
     # Define a transform to apply to the data
     transform = transforms.Compose([transforms.ToTensor()])
 
     # Load dataset from directory
     dataset = WaterDataset(annotations_file, images_dir, transform=transform)
 
-    # Create a PyTorch DataLoader
-    return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    # Split dataset into train and test sets
+    train_dataset, test_dataset = torch.utils.data.random_split(dataset, train_test_split)
+
+    # Create PyTorch DataLoaders for train and test splits
+    return (
+        torch.utils.data.DataLoader(train_dataset, batch_size=batch_size, shuffle=True),
+        torch.utils.data.DataLoader(test_dataset, batch_size=batch_size, shuffle=False),
+    )

--- a/deep_water_level/src/data.py
+++ b/deep_water_level/src/data.py
@@ -1,0 +1,48 @@
+import os
+import json
+from PIL import Image
+from torchvision import transforms
+import torch
+from torch.utils.data import Dataset
+
+class WaterDataset(Dataset):
+    def __init__(self, annotations_file, images_dir, transform=None):
+        self.annotations_file = annotations_file
+        self.images_dir = images_dir
+        self.transform = transform
+        self.data = self.load_annotations()
+
+    def load_annotations(self):
+        with open(self.annotations_file, 'r') as f:
+            annotations = json.load(f)
+        data = []
+        images = annotations.get('images', [])
+        for annotation in annotations['annotations']:
+            image_id = annotation['image_id']
+            if image_id < len(images):
+                image_file = images[image_id]['file_name']
+                image_path = os.path.join(self.images_dir, image_file)
+                depth = annotation.get('attributes', {})['depth']
+                data.append((image_path, depth))
+        return data
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, index):
+        image_path, depth = self.data[index]
+        image = Image.open(image_path)
+        if self.transform:
+            image = self.transform(image)
+        depth = torch.tensor(depth, dtype=torch.float32)
+        return image, depth
+
+def get_data_loader(annotations_file: str, images_dir: str, batch_size: int = 32):
+    # Define a transform to apply to the data
+    transform = transforms.Compose([transforms.ToTensor()])
+
+    # Load dataset from directory
+    dataset = WaterDataset(annotations_file, images_dir, transform=transform)
+
+    # Create a PyTorch DataLoader
+    return torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)

--- a/deep_water_level/src/model.py
+++ b/deep_water_level/src/model.py
@@ -1,0 +1,34 @@
+from typing import Tuple
+import torch.nn as nn
+
+class BasicCnnRegression(nn.Module):
+    """
+    Basic model which includes two CNN layers and a single linear layer.
+    """
+    def __init__(self, image_size: Tuple[int, int, int] = (3, 810, 510)):
+        super().__init__()
+
+        self.image_size = image_size
+        self.linear_line_size = (image_size[1] // 4 ) * (image_size[2] // 4) * 12
+
+        self.conv1 = nn.Conv2d(in_channels=image_size[0], out_channels=6, kernel_size=4, stride=1, padding=1)
+        self.pool1 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.conv2 = nn.Conv2d(in_channels=6, out_channels=12, kernel_size=4, stride=1, padding=1)
+        self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.flatten = nn.Flatten()
+        self.fcn1 = nn.Linear(in_features=self.linear_line_size, out_features=120)
+        self.fcn2 = nn.Linear(in_features=120, out_features=1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = nn.functional.relu(x)
+        x = self.pool1(x)
+        x = self.conv2(x)
+        x = nn.functional.relu(x)
+        x = self.pool2(x)
+        x = self.flatten(x)
+        x = self.fcn1(x)
+        x = nn.functional.relu(x)
+        x = self.fcn2(x)
+        return x
+

--- a/deep_water_level/src/model.py
+++ b/deep_water_level/src/model.py
@@ -9,22 +9,27 @@ class BasicCnnRegression(nn.Module):
         super().__init__()
 
         self.image_size = image_size
-        self.linear_line_size = (image_size[1] // 4 ) * (image_size[2] // 4) * 12
+        # Calculate the target parameter size after the convolutions and poolings
+        self.linear_line_size = (image_size[1] // 4 // 4) * (image_size[2] // 4 // 4) * 12
 
-        self.conv1 = nn.Conv2d(in_channels=image_size[0], out_channels=6, kernel_size=4, stride=1, padding=1)
+        self.conv1 = nn.Conv2d(in_channels=image_size[0], out_channels=6, kernel_size=4, stride=2, padding=1)
         self.pool1 = nn.MaxPool2d(kernel_size=2, stride=2)
-        self.conv2 = nn.Conv2d(in_channels=6, out_channels=12, kernel_size=4, stride=1, padding=1)
+        self.conv2 = nn.Conv2d(in_channels=6, out_channels=12, kernel_size=4, stride=2, padding=1)
         self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2)
         self.flatten = nn.Flatten()
         self.fcn1 = nn.Linear(in_features=self.linear_line_size, out_features=120)
         self.fcn2 = nn.Linear(in_features=120, out_features=1)
 
     def forward(self, x):
+        # print(f'start {x.size()}')
         x = self.conv1(x)
+        # print(f'conv1 {x.size()}')
         x = nn.functional.relu(x)
         x = self.pool1(x)
+        # print(f'pool1 {x.size()}')
         x = self.conv2(x)
         x = nn.functional.relu(x)
+        # print(f'conv2 {x.size()}')
         x = self.pool2(x)
         x = self.flatten(x)
         x = self.fcn1(x)

--- a/deep_water_level/src/train.py
+++ b/deep_water_level/src/train.py
@@ -1,1 +1,65 @@
-# Here will go the code for training the model
+# Script that trains a network model for deep water level detection
+# TODO:
+# - Create the network model using CNN
+# - Load the data
+# - Train the model
+# - Set-up
+import argparse
+import torch
+import torch.nn as nn
+from model import BasicCnnRegression
+from data import get_data_loader
+
+def create_model():
+    # Create the model
+    model = BasicCnnRegression()
+    return model
+
+def load_data():
+    # TODO(adamantivm) Normalization? Resizing?
+    data = None
+    return data
+
+def do_training(annotations_file: str, images_dir: str):
+    # Set-up environment
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    # torch.set_default_device(device)
+    print(f"Using device: {device}")
+
+    # TODO(adamantivm) Load the data
+    data_loader = get_data_loader(annotations_file, images_dir)
+
+    # Train the model
+    model = create_model()
+    model.to(device)
+    print(f"Model summary: {model}")
+
+    learning_rate = 0.001
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    n_epochs = 10
+
+    for epoch in range(n_epochs):
+        for i, (inputs, labels) in enumerate(data_loader):
+            optimizer.zero_grad()
+
+            inputs = inputs.to(device)
+            labels = labels.to(device)
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+
+            loss.backward()
+            optimizer.step()
+
+            if (i + 1) % 10 == 0:
+                print(f'Epoch [{epoch + 1}/{n_epochs}], Step [{i + 1}/{len(data_loader)}], Loss: {loss.item():.4f}')
+
+    return model
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Train a model on the Deep Water Level dataset')
+    parser.add_argument('--annotations_file', type=str, default='datasets/water_2024_10_19_set1/annotations/manual_annotations.json', help='Path to a JSON file containing annotations')
+    parser.add_argument('--images_dir', type=str, default='datasets/water_2024_10_19_set1/images', help='Path to a directory containing images')
+    args = parser.parse_args()
+
+    model = do_training(args.annotations_file, args.images_dir)

--- a/deep_water_level/src/train.py
+++ b/deep_water_level/src/train.py
@@ -51,8 +51,7 @@ def do_training(annotations_file: str, images_dir: str):
             loss.backward()
             optimizer.step()
 
-            if (i + 1) % 10 == 0:
-                print(f'Epoch [{epoch + 1}/{n_epochs}], Step [{i + 1}/{len(data_loader)}], Loss: {loss.item():.4f}')
+            print(f'Epoch [{epoch + 1}/{n_epochs}], Step [{i + 1}/{len(data_loader)}], Loss: {loss.item():.4f}')
 
     return model
 


### PR DESCRIPTION
First basic version of the code that can run a training.

UPDATED: now includes MLFlow trackinig and train / test split evaluation during training.

Sample output:
```
(.venv) ➜  deep_rabbit_hole git:(feature/training) ✗ /home/julian/aaae/deep-rabbit-hole/code/deep_rabbit_hole/.venv/bin/python /home/julian/aaae/deep-rabbit-hole/code/de
ep_rabbit_hole/deep_water_level/src/train.py
Using device: cuda
Model summary: BasicCnnRegression(
  (conv1): Conv2d(3, 6, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1))
  (pool1): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (conv2): Conv2d(6, 12, kernel_size=(4, 4), stride=(2, 2), padding=(1, 1))
  (pool2): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
  (flatten): Flatten(start_dim=1, end_dim=-1)
  (fcn1): Linear(in_features=18600, out_features=120, bias=True)
  (fcn2): Linear(in_features=120, out_features=1, bias=True)
)
Epoch [1/10], Step [1/8], Loss: 34.6578
Epoch [1/10], Step [2/8], Loss: 10.3569
Epoch [1/10], Step [3/8], Loss: 2.2658
Epoch [1/10], Step [4/8], Loss: 8.6796
Epoch [1/10], Step [5/8], Loss: 5.4123
Epoch [1/10], Step [6/8], Loss: 2.4099
Epoch [1/10], Step [7/8], Loss: 2.2761
Epoch [1/10], Step [8/8], Loss: 1.7563
Epoch [2/10], Step [1/8], Loss: 3.1149
Epoch [2/10], Step [2/8], Loss: 3.4474
Epoch [2/10], Step [3/8], Loss: 2.1753
Epoch [2/10], Step [4/8], Loss: 2.1719
Epoch [2/10], Step [5/8], Loss: 1.3235
Epoch [2/10], Step [6/8], Loss: 2.2886
Epoch [2/10], Step [7/8], Loss: 3.1412
Epoch [2/10], Step [8/8], Loss: 1.7376
Epoch [3/10], Step [1/8], Loss: 1.8446
Epoch [3/10], Step [2/8], Loss: 0.9846
Epoch [3/10], Step [3/8], Loss: 1.0271
Epoch [3/10], Step [4/8], Loss: 0.9941
Epoch [3/10], Step [5/8], Loss: 1.1191
Epoch [3/10], Step [6/8], Loss: 1.4127
Epoch [3/10], Step [7/8], Loss: 0.7301
Epoch [3/10], Step [8/8], Loss: 0.6921
Epoch [4/10], Step [1/8], Loss: 0.6299
Epoch [4/10], Step [2/8], Loss: 0.8285
Epoch [4/10], Step [3/8], Loss: 0.6307
Epoch [4/10], Step [4/8], Loss: 0.7932
Epoch [4/10], Step [5/8], Loss: 0.6882
Epoch [4/10], Step [6/8], Loss: 0.5767
Epoch [4/10], Step [7/8], Loss: 0.5998
Epoch [4/10], Step [8/8], Loss: 0.4568
Epoch [5/10], Step [1/8], Loss: 0.5452
Epoch [5/10], Step [2/8], Loss: 0.3014
Epoch [5/10], Step [3/8], Loss: 0.6526
Epoch [5/10], Step [4/8], Loss: 0.5582
Epoch [5/10], Step [5/8], Loss: 0.3723
Epoch [5/10], Step [6/8], Loss: 0.5914
Epoch [5/10], Step [7/8], Loss: 0.7256
Epoch [5/10], Step [8/8], Loss: 0.4212
Epoch [6/10], Step [1/8], Loss: 0.4693
Epoch [6/10], Step [2/8], Loss: 0.4766
Epoch [6/10], Step [3/8], Loss: 0.3153
Epoch [6/10], Step [4/8], Loss: 0.5459
Epoch [6/10], Step [5/8], Loss: 0.6429
Epoch [6/10], Step [6/8], Loss: 0.5045
Epoch [6/10], Step [7/8], Loss: 0.5712
Epoch [6/10], Step [8/8], Loss: 0.5223
Epoch [7/10], Step [1/8], Loss: 0.4894
Epoch [7/10], Step [2/8], Loss: 0.4136
Epoch [7/10], Step [3/8], Loss: 0.4050
Epoch [7/10], Step [4/8], Loss: 0.7742
Epoch [7/10], Step [5/8], Loss: 0.3728
Epoch [7/10], Step [6/8], Loss: 0.3831
Epoch [7/10], Step [7/8], Loss: 0.2947
Epoch [7/10], Step [8/8], Loss: 0.2671
Epoch [8/10], Step [1/8], Loss: 0.3025
Epoch [8/10], Step [2/8], Loss: 0.4485
Epoch [8/10], Step [3/8], Loss: 0.2987
Epoch [8/10], Step [4/8], Loss: 0.2994
Epoch [8/10], Step [5/8], Loss: 0.4446
Epoch [8/10], Step [6/8], Loss: 0.4047
Epoch [8/10], Step [7/8], Loss: 0.3865
Epoch [8/10], Step [8/8], Loss: 0.2461
Epoch [9/10], Step [1/8], Loss: 0.3093
Epoch [9/10], Step [2/8], Loss: 0.3206
Epoch [9/10], Step [3/8], Loss: 0.2958
Epoch [9/10], Step [4/8], Loss: 0.4620
Epoch [9/10], Step [5/8], Loss: 0.2858
Epoch [9/10], Step [6/8], Loss: 0.2861
Epoch [9/10], Step [7/8], Loss: 0.2493
Epoch [9/10], Step [8/8], Loss: 0.2580
Epoch [10/10], Step [1/8], Loss: 0.2820
Epoch [10/10], Step [2/8], Loss: 0.3047
Epoch [10/10], Step [3/8], Loss: 0.3580
Epoch [10/10], Step [4/8], Loss: 0.2800
Epoch [10/10], Step [5/8], Loss: 0.2732
Epoch [10/10], Step [6/8], Loss: 0.3212
Epoch [10/10], Step [7/8], Loss: 0.1958
Epoch [10/10], Step [8/8], Loss: 0.2021
```