### PR TITLE
Option to crop images for water level training

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,20 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Train water level model",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "deep_water_level/src/train.py",
+            "console": "integratedTerminal",
+            "args": [
+                "--train_dataset_dir", "datasets/water_2024_10_19_set1",
+                "--test_dataset_dir", "datasets/water_test_set3",
+                "--annotations_file", "manual_annotations.json",
+                "--crop_box", "130", "275", "140", "140",
+                "--log_transformed_images", "True",
+            ]
+        },
+        {
             "name": "Merge Coco Annotations",
             "type": "debugpy",
             "request": "launch",

--- a/deep_water_level/src/data.py
+++ b/deep_water_level/src/data.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import json
 import mlflow
@@ -60,8 +61,13 @@ def get_data_loaders(
     annotations_file: str,
     batch_size: int = 32,
     train_test_split: Tuple[int, int] = [0.8, 0.2],
+    crop_box = None, # [top, left, height, width]
 ):
     transforms = get_transforms() 
+    if crop_box is not None:
+        top, left, height, width = crop_box
+        crop_function = functools.partial(v2.functional.crop, top=top, left=left, height=height, width=width)
+        transforms = v2.Compose([transforms, crop_function])
 
     # Load dataset from directory
     dataset = WaterDataset(annotations_file, images_dir, transforms=transforms)
@@ -87,8 +93,13 @@ def get_data_loader(
     annotations_file: str,
     batch_size: int = 32,
     shuffle: bool = True,
+    crop_box = None, # [top, left, height, width]
 ):
     transforms = get_transforms() 
+    if crop_box is not None:
+        top, left, height, width = crop_box
+        crop_function = functools.partial(v2.functional.crop, top=top, left=left, height=height, width=width)
+        transforms = v2.Compose([transforms, crop_function])
 
     # Load dataset from directory
     dataset = WaterDataset(annotations_file, images_dir, transforms=transforms)

--- a/deep_water_level/src/train.py
+++ b/deep_water_level/src/train.py
@@ -1,15 +1,18 @@
 # Script that trains a network model for deep water level detection
 import argparse
 import mlflow
+import numpy as np
+from pathlib import Path
 import torch
 import torch.nn as nn
+import torchvision
 from model import BasicCnnRegression
 from data import get_data_loader, get_data_loaders
 from utils import start_experiment
 
-def create_model():
+def create_model(image_size):
     # Create the model
-    model = BasicCnnRegression()
+    model = BasicCnnRegression(image_size)
     return model
 
 def load_data():
@@ -23,6 +26,8 @@ def do_training(
         annotations_file: str,
         n_epochs: int,
         learning_rate: float,
+        crop_box: list,
+        log_transformed_images,
         ):
     # Set-up environment
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -32,13 +37,42 @@ def do_training(
     # Load the data
     if train_dataset_dir is None or test_dataset_dir == train_dataset_dir:
         # Split the train dataset in test and train datasets
-        (train_data, test_data) = get_data_loaders(train_dataset_dir + '/images', train_dataset_dir + '/annotations/' + annotations_file)
+        (train_data, test_data) = get_data_loaders(
+            train_dataset_dir + '/images',
+            train_dataset_dir + '/annotations/' + annotations_file,
+            crop_box=crop_box,
+        )
+
     else:
-        train_data = get_data_loader(train_dataset_dir + '/images', train_dataset_dir + '/annotations/' + annotations_file)
-        test_data = get_data_loader(test_dataset_dir + '/images', test_dataset_dir + '/annotations/' + annotations_file, shuffle=False)
+        train_data = get_data_loader(
+            train_dataset_dir + '/images',
+            train_dataset_dir + '/annotations/' + annotations_file,
+            crop_box=crop_box,
+        )
+        test_data = get_data_loader(
+            test_dataset_dir + '/images',
+            test_dataset_dir + '/annotations/' + annotations_file,
+            shuffle=False,
+            crop_box=crop_box,
+        )
+
+    if log_transformed_images:
+        log_dir = Path('/tmp/deep_water_level')
+        log_dir.mkdir(parents=True, exist_ok=True)
+        for image_i in range(len(train_data.dataset)):
+            image_filename = log_dir / f"train_data_{image_i}.png"
+            image = train_data.dataset[image_i][0]
+            torchvision.utils.save_image(image, image_filename)
+        for image_i in range(len(test_data.dataset)):
+            image_filename = log_dir / f"test_data_{image_i}.png"
+            image = test_data.dataset[image_i][0]
+            torchvision.utils.save_image(image, image_filename)
+
+    # Grab the first training image to find the resolution, which determines the size of the model
+    first_image = train_data.dataset[0][0]
 
     # Train the model
-    model = create_model()
+    model = create_model(first_image.shape)
     model.to(device)
     print(f"Model summary: {model}")
 
@@ -93,6 +127,8 @@ if __name__ == '__main__':
     parser.add_argument('--annotations_file', type=str, default='manual_annotations.json', help='File name of the JSON file containing annotations within a dataset')
     parser.add_argument('--n_epochs', type=int, default=40, help='Number of epochs to train the model')
     parser.add_argument('--learning_rate', type=float, default=0.001, help='Learning rate for training the model')
+    parser.add_argument('--crop_box', nargs=4, type=int, default=None, help='Box with which to crop images, of form: top left height width')
+    parser.add_argument('--log_transformed_images', type=bool, default=False, help='Log transformed images using mlflow')
     args = parser.parse_args()
 
     start_experiment("Deep Water Level Training")


### PR DESCRIPTION
Also added an option to save transformed images to disk, to make it easier to debug the cropping. I tried logging the images to mlflow, but that was way too slow, even for small cropped images.

I didn't see much improvement in test performance from just the cropping, but maybe it will work when combined with other data augmentation methods.