### PR TITLE
Use ruff for python formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,7 @@
 {
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "charliermarsh.ruff",
     },
-    "black-formatter.args": [
-        "[\"--line-length\", \"119\"]"
-    ],
     "python.testing.unittestArgs": [
         "-v",
         "-s",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[tool.ruff.lint]
+select = ["ALL"]
+
+[tool.ruff]
+line-length = 120


### PR DESCRIPTION
We were using the black formatter, but it was configured incorrectly and so it wasn't actually running. Now we're using ruff, since it also provides an import formatter. You'll need to install the ruff extension for vscode (you should be prompted to do so) To format code, press ctrl-shift-I. To organize imports, press alt-shift-O.