### PR TITLE
Generate dataset with mirrored images 

### DIFF
--- a/deep_water_level/requirements.txt
+++ b/deep_water_level/requirements.txt
@@ -1,5 +1,7 @@
+gradio
 matplotlib
 mlflow
+opencv-python
 psutil # for mlflow
 pynvml # for mlflow
 pytz


### PR DESCRIPTION
These simulate the effect of objects outside of the pool being reflected in the water. The results are .... not great, but not terrible.  In this dataset, A blue box is drawn near the top of the images, then reflected around the water line to draw another box near the bottom of the image. I wanted to see whether the CNN could learn the water line based only on the reflection, so I added some randomness to the position of the top box. In real life, the position of some objects (like the shed) don't really change between images. But other things (like pool tools and cats) may change position.

Here's an example image:
![img_003](https://github.com/user-attachments/assets/52ea8f33-93f7-4578-9f60-1d754108ebd1)

Here's the scatterplot for inference on the test set:
![mirrored_image_test](https://github.com/user-attachments/assets/07f82474-84b5-4af6-8d4e-7d3138236739)
