### PR TITLE
Fix format of ruff config file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,6 @@
         "ms-python.black-formatter",
         "github.copilot",
         "github.copilot-chat"
-    ]
+    ],
+    "ruff.trace.server": "messages"
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,1 @@
-[tool.ruff.lint]
-select = ["ALL"]
-
-[tool.ruff]
 line-length = 120


### PR DESCRIPTION
Also increased verbosity of logging for ruff vscode extension to make debugging easier in the future, and turned off ruff linting for now since it otherwise hates _all_ of our code.