### PR TITLE
Option to show training data on inference scatter plot

### DIFF
--- a/deep_water_level/requirements.txt
+++ b/deep_water_level/requirements.txt
@@ -1,6 +1,7 @@
 gradio
 matplotlib
 mlflow
+mplcursors
 opencv-python
 psutil # for mlflow
 pynvml # for mlflow


### PR DESCRIPTION
If the results on the training data looks much better than the test data, then we know we're over fitting. I also added tool tips to show the filename for each point on the scatter plot so that we can track down outliers more easily. To include the inference results on the training dataset, you pass in the `-train_dataset_dir` to `infer.py`:
```
infer.py  --train_dataset_dir=datasets/water_train_set4
```
See the changes in the bottom plot:
![Figure_1](https://github.com/user-attachments/assets/44f01ab8-d802-4d2e-8b82-8ae6a1d38e3e)
