### PR TITLE
Cleanup inference script

### DIFF
--- a/deep_water_level/src/data.py
+++ b/deep_water_level/src/data.py
@@ -73,7 +73,7 @@ class WaterDataset(Dataset):
         data = [parse_line(line) for line in lines]
 
         # Remove any data points with None values
-        data = [d for d in data if all(d[1])]
+        data = [d for d in data if (None not in d[1])]
 
         return data
 
@@ -131,10 +131,10 @@ def get_data_loaders(
     # Create PyTorch DataLoaders for train and test splits
     return (
         torch.utils.data.DataLoader(
-            train_dataset, batch_size=batch_size, shuffle=True, normalize_output=normalize_output
+            train_dataset, batch_size=batch_size, shuffle=True,
         ),
         torch.utils.data.DataLoader(
-            test_dataset, batch_size=batch_size, shuffle=False, normalize_output=normalize_output
+            test_dataset, batch_size=batch_size, shuffle=False,
         ),
     )
 


### PR DESCRIPTION
Our inference script has gotten a bit fragile and I keep running into crashes or odd results depending on the arguments I pass it. This PR cleans up a few things:

1. Use the dataset class directly instead of get_data_loader to avoid batching (which is not needed for inference).
2. Store inference results directly in the pandas dataframe instead of having extra lists.
3. Handle multiple outputs smoothly for both inference and plotting so that we don't need to special case when use_water_line is True.

@adamantivm could you confirm that my assumption in point 1 is correct before merging? (that there isn't any point in using get_data_loader and having batching when doing inference). Until now we've two nested loops in the run_dataset_inference function in infer.py and I always get confused about why...... it seems that was because we were iterating over batches, then iterating over the images in each batch. After this PR there are no batches in the inference script.
@alejandromarcu with this PR you should be able to use the plotting when using the water line; one column of plots will be generated for each output of the model. Here's an example with use_water_line=True (ignore the actual values, i made a csv with all zeros for the waterline to test)

![Figure_1](https://github.com/user-attachments/assets/07803053-6d76-4680-9628-6f5d555e8e3a)
