### PR TITLE
Change loss calculation for training

### DIFF
--- a/deep_water_level/src/deep_water_level/train.py
+++ b/deep_water_level/src/deep_water_level/train.py
@@ -143,6 +143,7 @@ def do_training(
     for epoch in range(n_epochs):
         # Train for the epoch
         model.train()
+        train_loss = 0
         for i, (inputs, labels, filenames) in enumerate(train_data):
             optimizer.zero_grad()
 
@@ -153,8 +154,9 @@ def do_training(
 
             loss.backward()
             optimizer.step()
+            train_loss += loss.item()
 
-        train_loss = loss.item()
+        train_loss /= len(train_data)
 
         # Test for this epoch
         model.eval()


### PR DESCRIPTION
The loss for test is calculated by averaging per batch, but for training, it was just taking the last loss of the batch.  Now the graph looks smoother, and I think maybe that can be the cause that sometimes the test loss is less than the training loss