### PR TITLE
Refactor how we choose the model

### DIFF
--- a/deep_water_level/src/deep_water_level/model.py
+++ b/deep_water_level/src/deep_water_level/model.py
@@ -1,7 +1,9 @@
-from typing import Tuple
+from typing import Tuple, Literal
 
 import torch
 import torch.nn as nn
+
+ModelNames = Literal["BasicCnnRegression", "BasicCnnRegressionWaterLine", "ResNet50Pretrained"]
 
 
 class BasicCnnRegression(nn.Module):

--- a/deep_water_level/src/deep_water_level/visualize_cnn.py
+++ b/deep_water_level/src/deep_water_level/visualize_cnn.py
@@ -9,7 +9,6 @@ from torchvision import transforms, utils
 from torchvision.transforms import v2
 
 from deep_water_level.infer import load_model
-from deep_water_level.model import BasicCnnRegression
 
 
 def get_conv_layers(model):
@@ -98,7 +97,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    model, _ = load_model(args.model_path)
+    model, _, _ = load_model(args.model_path, "BasicCnnRegression")
     conv_layers = get_conv_layers(model)
 
     for layer in conv_layers:

--- a/experiments/2024_12_09_jon_larger_model.py
+++ b/experiments/2024_12_09_jon_larger_model.py
@@ -9,9 +9,9 @@ annotations_file = Path("filtered.csv")
 train_dataset_path = Path("datasets/water_train_set4")
 test_dataset_path = Path("datasets/water_test_set5")
 crop_box = [130, 275, 140, 140]
-train_water_line = False
 model_filename = Path("model.pth")
 parent_output_dir = Path("../dwl_output")
+model_name = "BasicCnnRegression"
 
 output_dir = parent_output_dir / f"large_conv"
 output_model_path = output_dir / model_filename
@@ -28,6 +28,7 @@ do_training(
     normalize_output=False,
     crop_box=None,
     # Model parameters
+    model_name=model_name,
     dropout_p=None,
     n_conv_layers=2,
     channel_multiplier=2.0,
@@ -38,27 +39,26 @@ do_training(
     max_pool_stride=1,
     # Configuration parameters
     log_transformed_images=False,
-    train_water_line=False,
     output_model_path=output_model_path,
 )
 
 # Load the model and run inference using it
-model, model_args, preprocessing_args = load_model(output_model_path, train_water_line)
+model, model_args, preprocessing_args = load_model(output_model_path, model_name)
 
 train_df = run_dataset_inference(
     model,
+    model_name,
     train_dataset_path,
     annotations_file,
     **preprocessing_args,
-    use_water_line=train_water_line,
 )
 
 test_df = run_dataset_inference(
     model,
+    model_name,
     test_dataset_path,
     annotations_file,
     **preprocessing_args,
-    use_water_line=train_water_line,
 )
 
 plot_inference_results(test_df, train_df)

--- a/experiments/2024_12_17_julian_amped_augmentation.py
+++ b/experiments/2024_12_17_julian_amped_augmentation.py
@@ -11,9 +11,9 @@ annotations_file = Path("filtered.csv")
 train_dataset_path = Path("datasets/water_train_set4")
 test_dataset_path = Path("datasets/water_test_set5")
 crop_box = [130, 275, 140, 140]
-train_water_line = False
 model_filename = Path("model.pth")
 parent_output_dir = Path("../dwl_output")
+model_name = "BasicCnnRegression"
 
 output_dir = parent_output_dir / f"large_conv"
 output_model_path = output_dir / model_filename
@@ -35,6 +35,7 @@ args = {
     "crop_box_jitter": [5, 20],
     "color_jitter": 0.5,
     # Model parameters
+    "model_name": model_name,
     "dropout_p": 0.1,
     "n_conv_layers": 2,
     "channel_multiplier": 4.0,
@@ -46,7 +47,6 @@ args = {
     # Configuration parameters
     "log_transformed_images": False,
     "output_model_path": output_model_path,
-    "train_water_line": train_water_line,
 }
 
 start_experiment("Deep Water Level Training")
@@ -56,22 +56,22 @@ with mlflow.start_run():
     do_training(**args)
 
     # Load the model and run inference using it
-    model, model_args, preprocessing_args = load_model(output_model_path, train_water_line)
+    model, model_args, preprocessing_args = load_model(output_model_path, model_name)
 
     train_df = run_dataset_inference(
         model,
+        model_name,
         train_dataset_path,
         annotations_file,
         **preprocessing_args,
-        use_water_line=train_water_line,
     )
 
     test_df = run_dataset_inference(
         model,
+        model_name,
         test_dataset_path,
         annotations_file,
         **preprocessing_args,
-        use_water_line=train_water_line,
     )
 
     plot_inference_results(test_df, train_df, plot_filename="inference_results.png")

--- a/experiments/2025_01_10_julian_pretrained_resnet_places365.py
+++ b/experiments/2025_01_10_julian_pretrained_resnet_places365.py
@@ -12,9 +12,9 @@ annotations_file = Path("filtered.csv")
 train_dataset_path = Path("datasets/water_train_set4")
 test_dataset_path = Path("datasets/water_test_set5")
 crop_box = [88, 234, 224, 224]  # Cropping image to Resnet 50 input size. TODO: Verify
-train_water_line = False
 model_filename = Path("model.pth")
 parent_output_dir = Path("../dwl_output")
+model_name = "ResNet50Pretrained"
 
 output_dir = parent_output_dir / "pretrained_resnet_places365"
 output_model_path = output_dir / model_filename
@@ -37,7 +37,7 @@ args = {
     "crop_box_jitter": [10, 30],
     "color_jitter": 0.3,
     # Model parameters
-    "use_pretrained": True,
+    "model_name": model_name,
     "dropout_p": 0.1,
     "n_conv_layers": 2,
     "channel_multiplier": 4.0,
@@ -49,7 +49,6 @@ args = {
     # Configuration parameters
     "log_transformed_images": False,
     "output_model_path": output_model_path,
-    "train_water_line": train_water_line,
 }
 
 start_experiment("Deep Water Level Training - Pretrained")
@@ -60,22 +59,22 @@ with mlflow.start_run():
     do_training(**args)
 
     # Load the model and run inference using it
-    model, model_args, preprocessing_args = load_model(output_model_path, train_water_line, use_pretrained=True)
+    model, model_args, preprocessing_args = load_model(output_model_path, model_name)
 
     train_df = run_dataset_inference(
         model,
+        model_name,
         train_dataset_path,
         annotations_file,
         **preprocessing_args,
-        use_water_line=train_water_line,
     )
 
     test_df = run_dataset_inference(
         model,
+        model_name,
         test_dataset_path,
         annotations_file,
         **preprocessing_args,
-        use_water_line=train_water_line,
     )
 
     plot_inference_results(test_df, train_df, plot_filename="inference_results.png")


### PR DESCRIPTION
Initially we had just one model (BasicCnnRegression), then I added BasicCnnRegressionWaterLine and started a bad pattern by adding the parameter use_water_line to chose between the 2 of them. Julian added another model and used the parameter use_pretrained.  Now I want to use a new model for segmentation, and adding a new parameter would be a mess and is getting harder to follow. Instead, I prefer to pass a model name that can be expanded to include new models and there's no need to be passing new parameters everywhere.