### PR TITLE
Update MLFlow URL

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@
 PYTHONPATH=./annotation_utils/src:./object_tracker_0/src:./camera_control/src:./external/GroundingDINO:./external/segment-anything-2:${PYTHONPATH}:./deep_water_level/src
 CUDA_HOME=/usr/local/cuda
 MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING=true
-MLFLOW_TRACKING_URI=https://soft-pond-5082.ploomberapp.io
+MLFLOW_TRACKING_URI=https://cool-surf-9586.ploomber.app
 MLFLOW_TRACKING_USERNAME=admin
 MLFLOW_TRACKING_PASSWORD=W3AreLazy!

--- a/mlflow/update_password.py
+++ b/mlflow/update_password.py
@@ -1,9 +1,9 @@
 #!/bin/env python3
 # Simple python script to update the default MLFlow admin password
+import os
 import requests
-from getpass import getpass
 
-host = "https://soft-pond-5082.ploomberapp.io"
+host = os.environ["MLFLOW_TRACKING_URI"]
 password_new = "W3AreLazy!"
 
 response = requests.patch(


### PR DESCRIPTION
The URL was re-generated since the app was deleted due to inactivity.

Why the inactivity? Because apparently they changed their applications' URL (form plumberapp.io to plumber.app) and the Cloud Scheduler script which kept it alive started failing.