### PR TITLE
Data Augmentation for masks in segmentation training

### DIFF
--- a/deep_water_level/src/deep_water_level/infer.py
+++ b/deep_water_level/src/deep_water_level/infer.py
@@ -24,7 +24,7 @@ import torch.nn as nn
 import torchvision
 
 from annotation_utils.misc import filename_to_datetime, my_device
-from deep_water_level.data import WaterDataset, get_transforms
+from deep_water_level.data import WaterDataset, ImageTransforms
 from deep_water_level.model import BasicCnnRegression, BasicCnnRegressionWaterLine, ModelNames, DeepLabModel
 
 VERBOSE = False
@@ -63,7 +63,7 @@ def run_inference(model, input, transforms=None):
 
 
 def run_gradio_app(model, crop_box=None):
-    transforms = get_transforms(crop_box)
+    transforms = ImageTransforms(crop_box)
 
     # Define the Gradio app
     demo = gr.Interface(
@@ -95,7 +95,7 @@ def run_dataset_inference(
         else:
             return "[" + ", ".join([f"{x:.4f}" for x in a]) + "]"
 
-    transforms = get_transforms(crop_box=crop_box, equalization=equalization)
+    transforms = ImageTransforms(crop_box=crop_box, equalization=equalization)
     dataset = WaterDataset(
         dataset_dir / "annotations" / annotations_file,
         dataset_dir / "images",

--- a/deep_water_level/src/infer_segmentation.py
+++ b/deep_water_level/src/infer_segmentation.py
@@ -1,48 +1,60 @@
 import argparse
+import random
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import torch
 from PIL import Image
-from torchvision import transforms
-
-from deep_water_level.data import get_transforms
+from deep_water_level.data import ImageTransforms
 from deep_water_level.infer import load_model
 
 
-def visualize_segmentation(image, mask):
+def visualize_segmentations(segmentations):
+    n = len(segmentations)
     plt.figure(figsize=(12, 6))
-    plt.subplot(1, 3, 1)
-    plt.imshow(image)
-    plt.title("Original Image")
-    plt.axis("off")
 
-    plt.subplot(1, 3, 2)
+    for i, (image, mask) in enumerate(segmentations):
+        plt.subplot(3, n, i + 1)
+        plt.imshow(image)
+        plt.axis("off")
 
-    plt.imshow(mask, cmap="jet", alpha=0.7)
-    plt.title("Segmentation Mask")
-    plt.axis("off")
+        plt.subplot(3, n, i + 1 + n)
+        plt.imshow(mask, cmap="jet", alpha=0.7)
+        plt.axis("off")
 
-    combined = image.clone()
-    combined[mask == 1] = torch.tensor([1.0, 0, 0])
+        combined = image.clone()
+        combined[mask == 1] = torch.tensor([1.0, 0, 0])
 
-    plt.subplot(1, 3, 3)
-    plt.imshow(combined)
-    plt.title("Image with Segmentation Mask")
-    plt.axis("off")
+        plt.subplot(3, n, i + 1 + 2 * n)
+        plt.imshow(combined)
+        plt.axis("off")
+
     plt.show()
 
 
-def run_segmentation(model, image_path):
-    image = Image.open(image_path)
-    tf = get_transforms(is_training=False)
-    preprocessed_image = tf(image).unsqueeze(0)
+def run_segmentations(model, image_paths):
+    def crop_box_function():
+        top = random.randint(50, 150)
+        left = random.randint(0, 500)
+        width = random.randint(100, 500)
+        height = random.randint(width - 20, width + 20)  # make them square-ish
+        return [top, left, min(height, 510), min(width, 810)]
 
-    output = model(preprocessed_image)
-    mask = torch.argmax(output, dim=1).squeeze().numpy()
-    displayable_image = transforms.ToTensor()(image).permute(1, 2, 0)
+    result = []
+    for image_path in image_paths:
+        image = Image.open(image_path)
 
-    return displayable_image, mask
+        transformation = ImageTransforms(crop_box=crop_box_function, is_training=False)
+        preprocessed_image = transformation(image)
+        preprocessed_image = preprocessed_image.unsqueeze(0)
+
+        output = model(preprocessed_image)
+        mask = torch.argmax(output, dim=1).squeeze().numpy()
+        # displayable_image = transforms.ToTensor()(image).permute(1, 2, 0)
+
+        result.append((preprocessed_image.squeeze(0).permute(1, 2, 0), mask))
+
+    return result
 
 
 if __name__ == "__main__":
@@ -51,22 +63,35 @@ if __name__ == "__main__":
         "-m",
         "--model_path",
         type=str,
-        default="../dwl_output/deeplabv3/model.pth",
+        default="../dwl_output/deeplabv3/model_deleteme.pth",
         help="Path to the model file",
     )
-
     parser.add_argument(
         "-i",
-        "--image_path",
+        "--image_dir",
         type=str,
-        default="datasets/water_test_set5/images/2024-10-29/0-1730238001.jpg",
-        help="Path to an image file to run segmentation",
+        default="datasets/water_2024_10_19_set1/images/",  # water_2024_11_01_set2
+        help="Path to a directory to find random images to segment",
+    )
+    parser.add_argument(
+        "-n",
+        "--num_images",
+        type=int,
+        default=10,
+        help="Number of images to segment",
     )
 
     args = parser.parse_args()
 
     model, model_name, model_args, preprocessing_args = load_model(Path(args.model_path))
 
-    image, mask = run_segmentation(model, args.image_path)
+    # Get random jpg from directory
+    jpg_files = list(Path(args.image_dir).glob("**/*.jpg"))
+    if not jpg_files:
+        raise ValueError(f"No jpg files found in {args.image_dir}")
 
-    visualize_segmentation(image, mask)
+    random_images = random.choices(jpg_files, k=args.num_images)
+
+    segmentations = run_segmentations(model, random_images)
+
+    visualize_segmentations(segmentations)

--- a/experiments/2025_01_19_cucu_pretrained_deeplabv3.py
+++ b/experiments/2025_01_19_cucu_pretrained_deeplabv3.py
@@ -5,12 +5,23 @@ from pathlib import Path
 from utils import my_device, start_experiment
 
 import mlflow
+import random
 from deep_water_level.train import do_training
+
+
+def crop_box_function():
+    top = random.randint(50, 150)
+    left = random.randint(0, 500)
+    width = random.randint(100, 500)
+    height = random.randint(width - 20, width + 20)  # make them square-ish
+    return [top, left, min(height, 510), min(width, 810)]
+
 
 annotations_file = Path("filtered.json")
 train_dataset_path = Path("datasets/water_2024_10_19_set1")
 test_dataset_path = Path("datasets/water_test_set3")
-# crop_box = [88, 234, 224, 224]
+
+resize = [224, 224]
 model_filename = Path("model.pth")
 parent_output_dir = Path("../dwl_output")
 model_name = "DeepLabV3"
@@ -25,16 +36,16 @@ args = {
     "test_dataset_dir": test_dataset_path,
     "annotations_file": annotations_file,
     # Preprocessing params
-    #   "crop_box": crop_box,
+    "crop_box": crop_box_function,
+    "resize": resize,
     "normalize_output": False,
-    "equalization": True,
+    "equalization": False,
     # Training parameters
-    "batch_size": 2,
-    "n_epochs": 5,
-    "learning_rate": 1e-3,
-    # "random_rotation_degrees": 15,
-    # "crop_box_jitter": [10, 30],
-    "color_jitter": 0.3,
+    "batch_size": 4,
+    "n_epochs": 100,
+    "learning_rate": 1e-4,
+    "random_rotation_degrees": 10.0,
+    "color_jitter": 0.1,
     # Model parameters
     "model_name": model_name,
     # Configuration parameters


### PR DESCRIPTION
The main change is that the transforms can now process an image and a mask at the same time.  The mask goes only through the geometrical transformations, e.g. no color jitter or equalization.  The random parameters are set equally for the image and the mask.  We now allow the crop_box to be a function, so that we can do something more custom, e.g. for this training I allowed the crop box to take random sizes given some constraints.  It also allows to do a resize at the end.

Still, the result is far from great, but we can continue iterating if we want.  E.g. after training for 100 epochs I got:
`Epoch [100/100], Loss: 0.0141, Test loss: 0.5272`


<img width="948" alt="image" src="https://github.com/user-attachments/assets/77e4018d-e7d4-47af-b446-4b8bb9e82774" />
