### PR TITLE
Optional Incremental rewards

### DIFF
--- a/deep_quoridor/src/main.py
+++ b/deep_quoridor/src/main.py
@@ -17,9 +17,9 @@ class RandomAgent:
         return game.action_space(game.agent_selection).sample(mask)
 
 
-def play(board_size: int | None, max_walls: int | None, render: str):
+def play(board_size: int | None, max_walls: int | None, render: str, step_rewards: bool):
     # Don't pass the None arguments to env so it uses the defaults
-    args = {"board_size": board_size, "max_walls": max_walls}
+    args = {"board_size": board_size, "max_walls": max_walls, "step_rewards": step_rewards}
     args = {k: v for k, v in args.items() if v is not None}
     game = env(**args)
 
@@ -53,6 +53,7 @@ def play(board_size: int | None, max_walls: int | None, render: str):
         action = agents[agent].get_action(game)
         print(f"\nStep {step + 1}: {agent} takes action {action}")
         game.step(action)  # Apply action
+        print(f"Rewards: {game.rewards}")
 
         board = game.render()
 
@@ -79,7 +80,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Deep Quoridor")
     parser.add_argument("-N", "--board_size", type=int, default=None, help="Board Size")
     parser.add_argument("-W", "--max_walls", type=int, default=None, help="Max walls per player")
-    parser.add_argument("-r", "--render", choices=["print", "curses"], default="curses", help="Render mode")
+    parser.add_argument("-r", "--render", choices=["print", "curses"], default="print", help="Render mode")
+    parser.add_argument("--step_rewards", action="store_true", default=False, help="Enable step rewards")
 
     args = parser.parse_args()
-    play(args.board_size, args.max_walls, args.render)
+    play(**vars(args))

--- a/deep_quoridor/src/main.py
+++ b/deep_quoridor/src/main.py
@@ -27,7 +27,7 @@ def play(board_size: int | None, max_walls: int | None, render: str):
 
     agents = {
         "player_0": RandomAgent(),
-        "player_1": RandomAgent(),
+        "player_1": SimpleAgent(),
     }
 
     if render == "print":
@@ -60,7 +60,7 @@ def play(board_size: int | None, max_walls: int | None, render: str):
             stdscr.clear()
             stdscr.addstr(2, 2, board)
             stdscr.refresh()
-            curses.napms(500)
+            curses.napms(100)
 
         if render == "print":
             print(board)

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -473,14 +473,16 @@ class QuoridorEnv(AECEnv):
                 dfs = self._dfs(new_row, new_col, target_row, visited)
                 if dfs != -1:
                     if any_path:
-                        return dfs
+                        return dfs + 1
                     if best == -1 or dfs + 1 < best:
-                        best = dfs
+                        best = dfs + 1
 
         return best
 
     def can_reach(self, row, col, target_row, any_path=True):
         """
+        Returns -1 if the target row can't be reached, or the number of moves it takes to reach
+        the target row if it's reachable.
         If any_path is set to true, the first path to the target row will be returned (faster).
         Otherwise, the shortest path will be returned (potentially slower)
         """

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -103,8 +103,14 @@ class QuoridorEnv(AECEnv):
             self.rewards[agent] = 1
             self.rewards[self.get_opponent(agent)] = -1
         elif self.step_rewards:
-            # TODO: Calculate distance to goal for each agent
-            pass
+            # Assign rewards as the difference in distance to the goal divided by
+            # twice the board size.
+            (row, col) = self.positions[agent]
+            agent_distance = self.can_reach(row, col, self.board_size - 1, False)
+            (row, col) = self.positions[self.get_opponent(agent)]
+            oponent_distance = self.can_reach(row, col, self.board_size - 1, False)
+            self.rewards[agent] = (agent_distance - oponent_distance) / (2 * self.board_size)
+            self.rewards[self.get_opponent(agent)] = (oponent_distance - agent_distance) / (2 * self.board_size)
 
         # TODO: Confirm if this is needed and if it's doing anything
         self._accumulate_rewards()

--- a/deep_quoridor/test/quoridor_env_test.py
+++ b/deep_quoridor/test/quoridor_env_test.py
@@ -117,6 +117,68 @@ class TestQuoridorEnv:
 
         assert set(env_walls) == set(forbidden_walls)
 
+    def _test_can_reach(self, s, moves_p1, moves_p2):
+        env, _, _ = parse_board(s)
+        N = env.board_size
+        (row, col) = env.positions["player_0"]
+        assert moves_p1 == env.can_reach(row, col, N - 1, False)
+        (row, col) = env.positions["player_1"]
+        assert moves_p2 == env.can_reach(row, col, 0, False)
+
+    def test_distance_to_goal(self):
+        self._test_can_reach(
+            """
+            1 . .
+            . . .
+            . . 2
+        """,
+            2,
+            2,
+        )
+
+        self._test_can_reach(
+            """
+            . * .
+            . . .
+            2 . 1
+        """,
+            0,
+            2,
+        )
+
+        self._test_can_reach(
+            """
+            1 . .
+            - -
+            . . .
+            . . 2
+        """,
+            4,
+            2,
+        )
+
+        self._test_can_reach(
+            """
+            1 .|.
+            - -+
+            . .|.
+            . . 2
+        """,
+            -1,
+            2,
+        )
+
+        self._test_can_reach(
+            """
+            1 . .
+            - - 
+            . .|.
+            . .|2
+        """,
+            4,
+            2,
+        )
+
     def test_corner_movements(self):
         self._test_pawn_movements("""
             1 * .

--- a/deep_quoridor/test/quoridor_env_test.py
+++ b/deep_quoridor/test/quoridor_env_test.py
@@ -117,16 +117,16 @@ class TestQuoridorEnv:
 
         assert set(env_walls) == set(forbidden_walls)
 
-    def _test_can_reach(self, s, moves_p1, moves_p2):
+    def _test_distance_to_target(self, s, moves_p1, moves_p2):
         env, _, _ = parse_board(s)
         N = env.board_size
         (row, col) = env.positions["player_0"]
-        assert moves_p1 == env.can_reach(row, col, N - 1, False)
+        assert moves_p1 == env.distance_to_target(row, col, N - 1, False)
         (row, col) = env.positions["player_1"]
-        assert moves_p2 == env.can_reach(row, col, 0, False)
+        assert moves_p2 == env.distance_to_target(row, col, 0, False)
 
     def test_distance_to_goal(self):
-        self._test_can_reach(
+        self._test_distance_to_target(
             """
             1 . .
             . . .
@@ -136,7 +136,7 @@ class TestQuoridorEnv:
             2,
         )
 
-        self._test_can_reach(
+        self._test_distance_to_target(
             """
             . * .
             . . .
@@ -146,7 +146,7 @@ class TestQuoridorEnv:
             2,
         )
 
-        self._test_can_reach(
+        self._test_distance_to_target(
             """
             1 . .
             - -
@@ -157,7 +157,7 @@ class TestQuoridorEnv:
             2,
         )
 
-        self._test_can_reach(
+        self._test_distance_to_target(
             """
             1 .|.
             - -+
@@ -168,7 +168,7 @@ class TestQuoridorEnv:
             2,
         )
 
-        self._test_can_reach(
+        self._test_distance_to_target(
             """
             1 . .
             - - 


### PR DESCRIPTION
Implements an option to enable incremental rewards, to accelerate training albeit suboptimally.

~~I still want to test it a bit more, but~~ it's ready for review.

Thanks for the unit tests and the DFS @alejandromarcu , it came very handy

Some clarifications:
 - I changed the default render mode to print, because ncurses once you run it, it ruins the terminal and it's annoying to get back to it (I use it a lot to re-run on the console)
 - The new DFS param `any_path` is meant so that if the distance is not needed, the amount of comparations remains the same as before when it only returned True / False
 - For the incremental step value, I did some runs and it looked like when a player wins by a large margin, the rewawrd right before winning is still lower than 1 (but getting close to 1)