### PR TITLE
Fix the results table

### DIFF
--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -48,3 +48,8 @@ class SimpleAgent(Agent):
         # Choose the action sequence with the highest reward.
         best_sequence, _ = max(possible_action_sequences, key=lambda x: x[1])
         return best_sequence[0]
+
+
+class SimplePlus(SimpleAgent):
+    def __init__(self, sequence_length=20, num_sequences=20):
+        super().__init__()

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -48,8 +48,3 @@ class SimpleAgent(Agent):
         # Choose the action sequence with the highest reward.
         best_sequence, _ = max(possible_action_sequences, key=lambda x: x[1])
         return best_sequence[0]
-
-
-class SimplePlus(SimpleAgent):
-    def __init__(self, sequence_length=20, num_sequences=20):
-        super().__init__()


### PR DESCRIPTION
I realized that my previous PR displayed a table that had a problem.  The rows where when the P1 won, and I thought the columns would be when P2 won, but it doesn't work that way. I had asked chatGPT but I didn't clarify that we care about who is P1 vs P2.  Now that I clarified it suggested something like this, where you can see how well an agent did as P1 and as P2.

```
+---------------+--------+--------+------------+-------+
|     Player    | random | simple | simpleplus | Total |
+---------------+--------+--------+------------+-------+
|   P1 random   |   -    |  20%   |    60%     |  40%  |
|   P2 random   |   -    |  20%   |    20%     |  20%  |
|   P1 simple   |  80%   |   -    |    80%     |  80%  |
|   P2 simple   |  80%   |   -    |    20%     |  50%  |
| P1 simpleplus |  80%   |  80%   |     -      |  80%  |
| P2 simpleplus |  40%   |  20%   |     -      |  30%  |
+---------------+--------+--------+------------+-------+
```
