### PR TITLE
Adding trainable agent, ruff config, fix renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ cython_debug/
 mlartifacts
 mlruns
 game_recording.yaml
+.vscode/launch.json

--- a/deep_quoridor/src/agents/__init__.py
+++ b/deep_quoridor/src/agents/__init__.py
@@ -1,64 +1,27 @@
-class Agent:
-    """
-    Base class for all agents.
-    Given a game state, the agent should return an action.
-    """
-
-    def name(self) -> str:
-        raise NotImplementedError("You must implement the name method")
-
-    def get_action(self, game) -> int:
-        raise NotImplementedError("You must implement the get_action method")
-
-    def reset(self):
-        """This method is called before starting a new game for the agent
-        to have a chance to reset its state before starting.
-        """
-        pass
-
-
-class AgentRegistry:
-    agents = {}
-
-    @staticmethod
-    def create(friendly_name: str, **kwargs) -> Agent:
-        return AgentRegistry.agents[friendly_name](**kwargs)
-
-    @staticmethod
-    def names():
-        return list(AgentRegistry.agents.keys())
-
-    @staticmethod
-    def register(name: str, agent_class):
-        AgentRegistry.agents[name] = agent_class
-
-
-class SelfRegisteringAgent(Agent):
-    """
-    Base class for all agents.
-    Given a game state, the agent should return an action.
-    """
-
-    def __init_subclass__(cls, **kwargs):
-        AgentRegistry.register(SelfRegisteringAgent._friendly_name(cls.__name__), cls)
-
-    def name(self):
-        return SelfRegisteringAgent._friendly_name(self.__class__.__name__)
-
-    @staticmethod
-    def _friendly_name(class_name: str):
-        return class_name.replace("Agent", "").lower()
-
-
 __all__ = [
-    "RandomAgent",
-    "SimpleAgent",
     "Agent",
+    "AgentRegistry",
+    "DExpAgent",
     "FlatDQNAgent",
     "Pretrained01FlatDQNAgent",
+    "RandomAgent",
+    "ReplayAgent",
+    "ReplayBuffer",
+    "SelfRegisteringAgent",
+    "SimpleAgent",
+    "AbstractTrainableAgent",
 ]
 
 
-from agents.random import RandomAgent  # noqa: E402, F401
-from agents.simple import SimpleAgent  # noqa: E402, F401
+from agents.core import (  # noqa: E402, F401  # noqa: E402, F401
+    AbstractTrainableAgent,
+    Agent,
+    AgentRegistry,
+    ReplayBuffer,
+    SelfRegisteringAgent,
+)
+from agents.dexp import DExpAgent  # noqa: E402
 from agents.flat_dqn import FlatDQNAgent, Pretrained01FlatDQNAgent  # noqa: E402
+from agents.random import RandomAgent  # noqa: E402, F401
+from agents.replay import ReplayAgent  # noqa: E402, F401
+from agents.simple import SimpleAgent  # noqa: E402, F401

--- a/deep_quoridor/src/agents/core/__init__.py
+++ b/deep_quoridor/src/agents/core/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ["Agent", "AgentRegistry", "ReplayBuffer", "SelfRegisteringAgent", "AbstractTrainableAgent"]
+
+
+from agents.core.agent import Agent, AgentRegistry, SelfRegisteringAgent
+from agents.core.replay_buffer import ReplayBuffer
+from agents.core.trainable_agent import AbstractTrainableAgent

--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -1,0 +1,50 @@
+class Agent:
+    """
+    Base class for all agents.
+    Given a game state, the agent should return an action.
+    """
+
+    def name(self) -> str:
+        raise NotImplementedError("You must implement the name method")
+
+    def get_action(self, game) -> int:
+        raise NotImplementedError("You must implement the get_action method")
+
+    def reset(self):
+        """This method is called before starting a new game for the agent
+        to have a chance to reset its state before starting.
+        """
+        pass
+
+
+class AgentRegistry:
+    agents = {}
+
+    @staticmethod
+    def create(friendly_name: str, **kwargs) -> Agent:
+        return AgentRegistry.agents[friendly_name](**kwargs)
+
+    @staticmethod
+    def names():
+        return list(AgentRegistry.agents.keys())
+
+    @staticmethod
+    def register(name: str, agent_class):
+        AgentRegistry.agents[name] = agent_class
+
+
+class SelfRegisteringAgent(Agent):
+    """
+    Base class for all agents.
+    Given a game state, the agent should return an action.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        AgentRegistry.register(SelfRegisteringAgent._friendly_name(cls.__name__), cls)
+
+    def name(self):
+        return SelfRegisteringAgent._friendly_name(self.__class__.__name__)
+
+    @staticmethod
+    def _friendly_name(class_name: str):
+        return class_name.replace("Agent", "").lower()

--- a/deep_quoridor/src/agents/core/replay_buffer.py
+++ b/deep_quoridor/src/agents/core/replay_buffer.py
@@ -1,0 +1,18 @@
+import random
+from collections import deque
+
+
+class ReplayBuffer:
+    """Experience replay buffer to store and sample transitions."""
+
+    def __init__(self, capacity):
+        self.buffer = deque(maxlen=capacity)
+
+    def add(self, state, action, reward, next_state, done):
+        self.buffer.append((state, action, reward, next_state, done))
+
+    def sample(self, batch_size):
+        return random.sample(self.buffer, batch_size)
+
+    def __len__(self):
+        return len(self.buffer)

--- a/deep_quoridor/src/agents/core/replay_buffer.py
+++ b/deep_quoridor/src/agents/core/replay_buffer.py
@@ -9,10 +9,13 @@ class ReplayBuffer:
         self.buffer = deque(maxlen=capacity)
 
     def add(self, state, action, reward, next_state, done):
-        self.buffer.append((state, action, reward, next_state, done))
+        self.buffer.append([state, action, reward, next_state, done])
 
     def sample(self, batch_size):
         return random.sample(self.buffer, batch_size)
+
+    def get_last(self):
+        return self.buffer[-1]
 
     def __len__(self):
         return len(self.buffer)

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -1,0 +1,161 @@
+import random
+from collections import deque
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from agents.core import SelfRegisteringAgent
+from agents.core.replay_buffer import ReplayBuffer
+
+
+class AbstractTrainableAgent(SelfRegisteringAgent):
+    """Base class for trainable agents using neural networks."""
+
+    def __init__(self, board_size, epsilon=1.0, epsilon_min=0.01, epsilon_decay=0.995, gamma=0.99):
+        super().__init__()
+        self.board_size = board_size
+        self.epsilon = epsilon
+        self.epsilon_min = epsilon_min
+        self.epsilon_decay = epsilon_decay
+        self.gamma = gamma
+
+        self.action_size = self._calculate_action_size()
+
+        # Setup device
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        # Initialize networks
+        self.online_network = self._create_network()
+        self.target_network = self._create_network()
+        self.online_network.to(self.device)
+        self.target_network.to(self.device)
+
+        self.update_target_network()
+
+        # Setup training components
+        self.optimizer = self._create_optimizer()
+        self.criterion = self._create_criterion()
+        self.replay_buffer = ReplayBuffer(capacity=10000)
+
+    def _calculate_action_size(self):
+        """Calculate the size of the action space."""
+        raise NotImplementedError("Subclasses must implement _calculate_action_size")
+
+    def _create_network(self):
+        """Create the neural network model."""
+        raise NotImplementedError("Subclasses must implement _create_network")
+
+    def _create_optimizer(self):
+        """Create the optimizer for training."""
+        return optim.Adam(self.online_network.parameters(), lr=0.001)
+
+    def _create_criterion(self):
+        """Create the loss criterion."""
+        return nn.MSELoss().to(self.device)
+
+    def observation_to_tensor(self, observation):
+        """Convert observation to tensor format."""
+        raise NotImplementedError("Subclasses must implement observation_to_tensor")
+
+    def update_target_network(self):
+        """Copy parameters from online network to target network."""
+        self.target_network.load_state_dict(self.online_network.state_dict())
+
+    def get_action(self, game):
+        """Select an action using epsilon-greedy policy."""
+        observation, _, termination, truncation, _ = game.last()
+        if termination or truncation:
+            return None
+
+        mask = observation["action_mask"]
+
+        if random.random() < self.epsilon:
+            valid_actions = self._get_valid_actions(mask)
+            return self._select_random_action(valid_actions)
+
+        return self._get_best_action(observation, mask)
+
+    def _get_valid_actions(self, mask):
+        """Get valid actions from the action mask."""
+        return np.where(mask == 1)[0]
+
+    def _select_random_action(self, valid_actions):
+        """Select a random action from valid actions."""
+        return np.random.choice(valid_actions)
+
+    def _get_best_action(self, observation, mask):
+        """Get the best action based on Q-values."""
+        state = self.observation_to_tensor(observation)
+        with torch.no_grad():
+            q_values = self.online_network(state)
+
+        mask_tensor = torch.tensor(mask, dtype=torch.float32, device=self.device)
+        q_values = q_values * mask_tensor - 1e9 * (1 - mask_tensor)
+
+        return torch.argmax(q_values).item()
+
+    def train(self, batch_size):
+        """Train the network on a batch of samples."""
+        if len(self.replay_buffer) < batch_size:
+            return
+
+        batch = self.replay_buffer.sample(batch_size)
+        loss = self._train_on_batch(batch)
+        self._update_epsilon()
+
+        return loss
+
+    def _train_on_batch(self, batch):
+        """Train the network on a single batch."""
+        states, actions, rewards, next_states, dones = self._prepare_batch(batch)
+
+        current_q_values = self._compute_current_q_values(states, actions)
+        target_q_values = self._compute_target_q_values(rewards, next_states, dones)
+
+        loss = self._update_network(current_q_values, target_q_values)
+        return loss
+
+    def _prepare_batch(self, batch):
+        """Prepare batch data for training."""
+        states, actions, rewards, next_states, dones = zip(*batch)
+
+        states = torch.stack([torch.FloatTensor(s).to(self.device) for s in states])
+        actions = torch.LongTensor(actions).to(self.device).unsqueeze(1)
+        rewards = torch.FloatTensor(rewards).to(self.device)
+        next_states = torch.stack([torch.FloatTensor(s).to(self.device) for s in next_states])
+        dones = torch.FloatTensor(dones).to(self.device)
+
+        return states, actions, rewards, next_states, dones
+
+    def _compute_current_q_values(self, states, actions):
+        """Compute current Q-values."""
+        return self.online_network(states).gather(1, actions).squeeze()
+
+    def _compute_target_q_values(self, rewards, next_states, dones):
+        """Compute target Q-values."""
+        with torch.no_grad():
+            next_q_values = self.target_network(next_states).max(1)[0]
+            return rewards + (1 - dones) * self.gamma * next_q_values
+
+    def _update_network(self, current_q_values, target_q_values):
+        """Update the network using computed Q-values."""
+        loss = self.criterion(current_q_values, target_q_values)
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        return loss.item()
+
+    def _update_epsilon(self):
+        """Update epsilon value for exploration."""
+        self.epsilon = max(self.epsilon_min, self.epsilon * self.epsilon_decay)
+
+    def save_model(self, path):
+        """Save the model to disk."""
+        torch.save(self.online_network.state_dict(), path)
+
+    def load_model(self, path):
+        """Load the model from disk."""
+        self.online_network.load_state_dict(torch.load(path))
+        self.update_target_network()

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -1,5 +1,4 @@
 import random
-from collections import deque
 
 import numpy as np
 import torch

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -8,14 +8,14 @@ import torch.nn as nn
 from agents.core import AbstractTrainableAgent
 
 
-class DQNNetwork(nn.Module):
+class DExpNetwork(nn.Module):
     """
     Neural network model for Deep Q-learning.
     Takes observation from the Quoridor game and outputs Q-values for each action.
     """
 
     def __init__(self, board_size, action_size):
-        super(DQNNetwork, self).__init__()
+        super(DExpNetwork, self).__init__()
 
         # Calculate input dimensions based on observation space
         # Board is board_size x board_size with 2 channels (player position and opponent position)
@@ -28,15 +28,24 @@ class DQNNetwork(nn.Module):
 
         # Define network architecture
         self.model = nn.Sequential(
-            nn.Linear(flat_input_size, 256), nn.ReLU(), nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size)
+            nn.Linear(flat_input_size, 512),
+            nn.ReLU(),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Linear(512, 256),
+            nn.ReLU(),
+            nn.Linear(256, action_size),
         )
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = nn.DataParallel(self.model)
+        self.model.to(device)
 
     def forward(self, x):
         return self.model(x)
 
 
-class FlatDQNAgent(AbstractTrainableAgent):
-    """Agent that uses Deep Q-Network with flat state representation."""
+class DExpAgent(AbstractTrainableAgent):
+    """Diego experimental Agent using DRL."""
 
     def _calculate_action_size(self):
         """Calculate the size of the action space."""
@@ -44,28 +53,29 @@ class FlatDQNAgent(AbstractTrainableAgent):
 
     def _create_network(self):
         """Create the neural network model."""
-        return DQNNetwork(self.board_size, self.action_size)
+        return DExpNetwork(self.board_size, self.action_size)
 
     def observation_to_tensor(self, observation):
         """Convert the observation dict to a flat tensor."""
         obs = observation["observation"]
+
         board = obs["board"].flatten()
         walls = obs["walls"].flatten()
         my_walls = np.array([obs["my_walls_remaining"]])
         opponent_walls = np.array([obs["opponent_walls_remaining"]])
 
         flat_obs = np.concatenate([board, walls, my_walls, opponent_walls])
-        return torch.FloatTensor(flat_obs, device=self.device)
+        return torch.FloatTensor(flat_obs).to(self.device)
 
 
-class Pretrained01FlatDQNAgent(FlatDQNAgent):
+class DExpPretainedAgent(DExpAgent):
     """
     A FlatDQNAgent that is initialized with the pre-trained model from main.py.
     """
 
     def __init__(self, board_size, **kwargs):
         super().__init__(board_size, epsilon=0.0)
-        model_path = Path(__file__).resolve().parents[3] / "models" / "flatdqn_final.pt"
+        model_path = Path(__file__).resolve().parents[3] / "models" / "dexp_final.pt"
         if os.path.exists(model_path):
             print(f"Loading pre-trained model from {model_path}")
             self.load_model(model_path)

--- a/deep_quoridor/src/agents/flat_dqn.py
+++ b/deep_quoridor/src/agents/flat_dqn.py
@@ -55,7 +55,7 @@ class FlatDQNAgent(AbstractTrainableAgent):
         opponent_walls = np.array([obs["opponent_walls_remaining"]])
 
         flat_obs = np.concatenate([board, walls, my_walls, opponent_walls])
-        return torch.FloatTensor(flat_obs, device=self.device)
+        return torch.FloatTensor(flat_obs).to(self.device)
 
 
 class Pretrained01FlatDQNAgent(FlatDQNAgent):

--- a/deep_quoridor/src/agents/random.py
+++ b/deep_quoridor/src/agents/random.py
@@ -1,4 +1,4 @@
-from agents import SelfRegisteringAgent
+from agents.core import SelfRegisteringAgent
 
 
 class RandomAgent(SelfRegisteringAgent):

--- a/deep_quoridor/src/agents/replay.py
+++ b/deep_quoridor/src/agents/replay.py
@@ -1,4 +1,4 @@
-from agents import Agent
+from agents.core import Agent
 
 
 class ReplayAgent(Agent):

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -1,4 +1,4 @@
-from agents import SelfRegisteringAgent
+from agents.core import SelfRegisteringAgent
 
 
 def sample_random_action_sequence(game, max_path_length):
@@ -42,9 +42,7 @@ class SimpleAgent(SelfRegisteringAgent):
 
         possible_action_sequences = []
         for _ in range(self.num_sequences):
-            action_sequence, total_reward = sample_random_action_sequence(
-                game.copy(), self.sequence_length
-            )
+            action_sequence, total_reward = sample_random_action_sequence(game.copy(), self.sequence_length)
             possible_action_sequences.append((action_sequence, total_reward))
 
         # Choose the action sequence with the highest reward.

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -1,10 +1,11 @@
-from typing import Optional
-from quoridor_env import env
-from agents import Agent
-from agents import AgentRegistry
-from agents.replay import ReplayAgent
-from dataclasses import dataclass
+import select
+import sys
 import time
+from dataclasses import dataclass
+from typing import Optional
+
+from agents import Agent, AgentRegistry, ReplayAgent
+from quoridor_env import env
 
 
 @dataclass

--- a/deep_quoridor/src/arena_yaml_recorder.py
+++ b/deep_quoridor/src/arena_yaml_recorder.py
@@ -1,5 +1,5 @@
-from arena import ArenaPlugin, Agent, GameResult
 import yaml
+from arena import Agent, ArenaPlugin, GameResult
 
 
 class ArenaYAMLRecorder(ArenaPlugin):
@@ -42,6 +42,3 @@ class ArenaYAMLRecorder(ArenaPlugin):
     def load_recorded_arena_data(filename: str) -> dict:
         with open(filename, "r") as file:
             return yaml.load(file, Loader=yaml.FullLoader)
-
-
-

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -1,7 +1,8 @@
 import argparse
-from arena_yaml_recorder import ArenaYAMLRecorder
-from arena import Arena
+
 from agents import AgentRegistry
+from arena import Arena
+from arena_yaml_recorder import ArenaYAMLRecorder
 from renderers import Renderer
 
 if __name__ == "__main__":

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -27,11 +27,12 @@ Every time we represent a coordinate as a tuple, it is in the form (row, col)
 
 import copy
 import functools
-from typing import Tuple, Optional
+from typing import Optional, Tuple
+
+import numpy as np
+from gymnasium import spaces
 from pettingzoo import AECEnv
 from pettingzoo.utils import wrappers
-from gymnasium import spaces
-import numpy as np
 
 
 class QuoridorEnv(AECEnv):

--- a/deep_quoridor/src/renderers/arena_results.py
+++ b/deep_quoridor/src/renderers/arena_results.py
@@ -1,7 +1,8 @@
-from renderers import Renderer
-from prettytable import PrettyTable
 import numpy as np
 from arena import GameResult
+from prettytable import PrettyTable
+
+from renderers import Renderer
 
 
 class ArenaResultsRenderer(Renderer):

--- a/deep_quoridor/src/renderers/curses_board.py
+++ b/deep_quoridor/src/renderers/curses_board.py
@@ -1,7 +1,9 @@
-from renderers import Renderer
-from arena import GameResult
-from agents import Agent
 import curses
+
+from agents import Agent
+from arena import GameResult
+
+from renderers import Renderer
 
 
 class CursesBoardRenderer(Renderer):
@@ -27,6 +29,6 @@ class CursesBoardRenderer(Renderer):
         board = game.render()
         self.stdscr.erase()
         self.stdscr.addstr(0, 0, f"Game: {self.match} - Step {step + 1}: {agent} takes action {action}")
-        self.stdscr.addstr(2, 2, board)
+        self.stdscr.addstr(2, 0, board)
         self.stdscr.refresh()
         curses.napms(self.napms)

--- a/deep_quoridor/src/renderers/match_results.py
+++ b/deep_quoridor/src/renderers/match_results.py
@@ -1,6 +1,7 @@
-from renderers import Renderer
-from arena import GameResult
 from agents import Agent
+from arena import GameResult
+
+from renderers import Renderer
 
 
 class MatchResultsRenderer(Renderer):

--- a/deep_quoridor/src/renderers/progress_bar.py
+++ b/deep_quoridor/src/renderers/progress_bar.py
@@ -1,5 +1,6 @@
-from renderers import Renderer
 from arena import GameResult
+
+from renderers import Renderer
 
 
 class ProgressBarRenderer(Renderer):

--- a/deep_quoridor/src/replay_tool.py
+++ b/deep_quoridor/src/replay_tool.py
@@ -1,10 +1,9 @@
 import argparse
 import time
-from arena_yaml_recorder import ArenaYAMLRecorder
-from arena import Arena
-from arena import ArenaPlugin
-from renderers import Renderer
 
+from arena import Arena, ArenaPlugin
+from arena_yaml_recorder import ArenaYAMLRecorder
+from renderers import Renderer
 
 """Deep Quoridor Game Replay Tool
 

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -84,7 +84,7 @@ def train_dqn(
                     and len(agent.replay_buffer) > 0
                 ):
                     last = agent.replay_buffer.get_last()
-                    last[2] = -1000
+                    last[2] = game.rewards[player_id]
                     last[4] = 1.0
                 break
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -39,9 +39,9 @@ target-version = "py311"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "W291", "W292", "W293"]
+select = ["E4", "E7", "E9", "F", "W291", "W292", "W293", "I"]
 ignore = []
-extend-select = ["I"]
+
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,78 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
 line-length = 120
+indent-width = 4
+
+# Assume Python 3.11
+target-version = "py311"
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "W291", "W292", "W293"]
+ignore = []
+extend-select = ["I"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
- Extracted common DQN code into a base class that can be easily inherited and overridden, base class includes hook methods for different aspects of the construction, observation, etc. (CodePilot refactoring)
- Made training to run unaware of what agents are running, meaning multiple trainable agents could run together (there are some additional changes that could be done for making it more generic, for now it is still for us to change code and play with it).
- Including a DExpAgent (Diego Experimental Agent). Not sure how you guys want to do this, but I find it handy to keep a class, I will be playing with, around. Easier to handle commits, changes, versions. Happy to remove if you guys prefer to keep this kind of code out.
- - For DExpAgent I added more layers to the NN, to see whether there was an improvement (Not really without changing other considerations). Also I plan to change representation.
- Fix Curses renderer that had an alignment issue
- Include new Ruff config enabling standard formatting,  import ordering.
- - Reordered imports to avoid warnings.

Sorry about the big PR with multiple unrelated changes. 

