### PR TITLE
Unify training logic inside agent 

### DIFF
--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -11,14 +11,24 @@ class Agent:
     def name(self) -> str:
         return Agent._friendly_name(self.__class__.__name__)
 
-    def get_action(self, game) -> int:
-        raise NotImplementedError("You must implement the get_action method")
+    def is_learning_agent(self) -> bool:
+        """Returns True if the agent is a learning agent, False otherwise."""
+        return False
 
-    def reset(self):
-        """This method is called before starting a new game for the agent
-        to have a chance to reset its state before starting.
+    def start_game(self, game):
+        """This method is called when a new game starts.
+        It allows the agent to reset its state if needed.
         """
         pass
+
+    def end_game(self, game):
+        """This method is called when a game ends.
+        It allows the agent to clean up its state if needed.
+        """
+        pass
+
+    def get_action(self, game) -> int:
+        raise NotImplementedError("You must implement the get_action method")
 
 
 class AgentRegistry:

--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -11,11 +11,11 @@ class Agent:
     def name(self) -> str:
         return Agent._friendly_name(self.__class__.__name__)
 
-    def is_learning_agent(self) -> bool:
+    def is_trainable(self) -> bool:
         """Returns True if the agent is a learning agent, False otherwise."""
         return False
 
-    def start_game(self, game):
+    def start_game(self, game, player_id):
         """This method is called when a new game starts.
         It allows the agent to reset its state if needed.
         """

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -51,11 +51,11 @@ class AbstractTrainableAgent(Agent):
         self.criterion = self._create_criterion()
         self.replay_buffer = ReplayBuffer(capacity=10000)
         self.training_mode = False
-        self.match_rewards = []
+        self.episodes_rewards = []
         self.train_call_losses = []
-        self.reset_match_related_info()
+        self.reset_episode_related_info()
 
-    def reset_match_related_info(self):
+    def reset_episode_related_info(self):
         self.current_match_reward = 0
         self.player_id = None
         self.games_count = 0
@@ -64,12 +64,12 @@ class AbstractTrainableAgent(Agent):
         return True
 
     def start_game(self, game, player_id):
-        self.reset_match_related_info()
+        self.reset_episode_related_info()
         self.player_id = player_id
 
     def end_game(self, game):
         """Store episode results and reset tracking"""
-        self.match_rewards.append(self.current_match_reward)
+        self.episodes_rewards.append(self.current_match_reward)
         self.games_count += 1
         if (self.games_count % self.update_target_every) == 0:
             self.update_target_network()

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -56,7 +56,7 @@ class AbstractTrainableAgent(Agent):
         self.reset_episode_related_info()
 
     def reset_episode_related_info(self):
-        self.current_match_reward = 0
+        self.current_episode_reward = 0
         self.player_id = None
         self.games_count = 0
 
@@ -69,7 +69,7 @@ class AbstractTrainableAgent(Agent):
 
     def end_game(self, game):
         """Store episode results and reset tracking"""
-        self.episodes_rewards.append(self.current_match_reward)
+        self.episodes_rewards.append(self.current_episode_reward)
         self.games_count += 1
         if (self.games_count % self.update_target_every) == 0:
             self.update_target_network()
@@ -90,7 +90,7 @@ class AbstractTrainableAgent(Agent):
         state_before_action = self.observation_to_tensor(observation_before_action)
         state_after_action = self.observation_to_tensor(game.observe(self.player_id))
         done = game.is_done()
-        self.current_match_reward += reward
+        self.current_episode_reward += reward
 
         self.replay_buffer.add(
             state_before_action.cpu().numpy(),

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -17,7 +17,7 @@ class Arena:
         renderers: list[ArenaPlugin] = [],
         saver: Optional[ArenaPlugin] = None,
         plugins: list[ArenaPlugin] = [],
-        swap_players: bool = False,
+        swap_players: bool = True,
     ):
         self.board_size = board_size
         self.max_walls = max_walls
@@ -91,7 +91,9 @@ class Arena:
         for i in range(len(players)):
             for j in range(i + 1, len(players)):
                 for t in range(times):
-                    agent_1, agent_2 = (agents[i], agents[j]) if t % 2 == 0 else (agents[j], agents[i])
+                    agent_1, agent_2 = (
+                        (agents[i], agents[j]) if not self.swap_players or t % 2 == 0 else (agents[j], agents[i])
+                    )
                     result = self._play_game(agent_1, agent_2, f"game_{match_id:04d}")
                     results.append(result)
                     match_id += 1

--- a/deep_quoridor/src/arena_utils.py
+++ b/deep_quoridor/src/arena_utils.py
@@ -1,5 +1,6 @@
-from agents import Agent
 from dataclasses import dataclass
+
+from agents import Agent
 
 
 @dataclass

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -68,4 +68,4 @@ if __name__ == "__main__":
     arena_args = {k: v for k, v in arena_args.items() if v is not None}
     arena = Arena(**arena_args)
 
-    arena.play_games(renderers, players, args.times)
+    arena.play_games(players, args.times)

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -102,8 +102,8 @@ class QuoridorEnv(AECEnv):
 
         if self._check_win(agent):
             self.terminations = {a: True for a in self.agents}
-            self.rewards[agent] = 1000
-            self.rewards[self.get_opponent(agent)] = -1000
+            self.rewards[agent] = 1
+            self.rewards[self.get_opponent(agent)] = -1
         elif self.step_rewards:
             # Assign rewards as the difference in distance to the goal divided by
             # three times the board size.
@@ -111,8 +111,8 @@ class QuoridorEnv(AECEnv):
             agent_distance = self.distance_to_target(row, col, self.get_goal_row(agent), False)
             (row, col) = self.positions[self.get_opponent(agent)]
             oponent_distance = self.distance_to_target(row, col, self.get_goal_row(self.get_opponent(agent)), False)
-            self.rewards[agent] = (oponent_distance - agent_distance) / (3 * self.board_size)
-            self.rewards[self.get_opponent(agent)] = (agent_distance - oponent_distance) / (3 * self.board_size)
+            self.rewards[agent] = (oponent_distance - agent_distance) / (self.board_size**2)
+            self.rewards[self.get_opponent(agent)] = (agent_distance - oponent_distance) / (self.board_size**2)
 
         # TODO: Confirm if this is needed and if it's doing anything
         self._accumulate_rewards()

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -119,6 +119,12 @@ class QuoridorEnv(AECEnv):
 
         self._next_player()
 
+    def is_done(self):
+        """
+        Returns True if the game is done
+        """
+        return any(self.terminations.values())
+
     def observe(self, agent_id):
         """
         Returns the observation and action mask in a dict, like so:

--- a/deep_quoridor/src/replay_tool.py
+++ b/deep_quoridor/src/replay_tool.py
@@ -80,4 +80,4 @@ if __name__ == "__main__":
     arena_args = {k: v for k, v in arena_args.items() if v is not None}
     arena = Arena(**arena_args)
 
-    arena.replay_games(renderers, arena_data, args.game_ids)
+    arena.replay_games(arena_data, args.game_ids)

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -128,7 +128,7 @@ def train_dqn(
         agents=[agent2],
     )
     print_plugin = TrainingStatusRenderer(
-        update_every=save_frequency,
+        update_every=100,
         total_episodes=episodes,
         agents=[agent2],
     )

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -13,7 +13,7 @@ from arena_utils import ArenaPlugin
 from renderers import Renderer
 
 
-class PrintTrainStatusRenderer(Renderer):
+class TrainingStatusRenderer(Renderer):
     def __init__(self, update_every: int, total_episodes: int, agents: list[AbstractTrainableAgent]):
         self.agents = agents
         self.update_every = update_every
@@ -25,9 +25,9 @@ class PrintTrainStatusRenderer(Renderer):
             for agent in self.agents:
                 agent_name = agent.name()
                 avg_reward = (
-                    sum(agent.match_rewards[-1 * self.update_every :])
-                    / min(self.update_every, len(agent.match_rewards))
-                    if agent.match_rewards
+                    sum(agent.episodes_rewards[-1 * self.update_every :])
+                    / min(self.update_every, len(agent.episodes_rewards))
+                    if agent.episodes_rewards
                     else 0.0
                 )
                 avg_loss = (
@@ -129,7 +129,7 @@ def train_dqn(
         path=save_path,
         agents=[agent2],
     )
-    print_plugin = PrintTrainStatusRenderer(
+    print_plugin = TrainingStatusRenderer(
         update_every=save_frequency,
         total_episodes=episodes,
         agents=[agent2],

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -157,6 +157,13 @@ if __name__ == "__main__":
         default=False,
         help="Assign negative reward when agent loses",
     )
+    parser.add_argument(
+        "-i",
+        "--seed",
+        type=int,
+        default=42,
+        help="Initializes the random seed for the training. Default is 42",
+    )
 
     args = parser.parse_args()
 
@@ -168,7 +175,10 @@ if __name__ == "__main__":
     print(f"Using step rewards: {args.step_rewards}")
     print(f"Assign negative reward: {args.assign_negative_reward}")
     print(f"Device: {torch.device('cuda' if torch.cuda.is_available() else 'cpu')}")
+    print(f"Initializing random seed {args.seed}")
 
+    # Set random seed for reproducibility
+    set_deterministic(args.seed)
     train_dqn(
         episodes=args.episodes,
         batch_size=args.batch_size,

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -109,8 +109,6 @@ def train_dqn(
         save_frequency: How often to save the model (in episodes)
         step_rewards: Whether to use step rewards
     """
-    # Set random seed for reproducibility
-    set_deterministic(42)
     # Create directory for saving models if it doesn't exist
     os.makedirs(save_path, exist_ok=True)
 


### PR DESCRIPTION
One more refactoring :)
- All training logic is now inside the trainable agent and can be tweak independent of the environment
- Added hook methods to the Trainable agent, and calls from standard arena to allow arena to be reused for training purposes
- Removed most logic from train.py except from model saving and rendering of rewards/losses (done with arena plugins: Thanks Cucu for those plug ins)
- Using 1, -1 for win/loss. In theory we can add something in the agent to scale numbers if needed
- I changed the step_rewards to user board_size^2, which seem to work better

Side note
After the refactoring I was able to train DExp(Diego Experimental) Agent on a 5x5b 0w which has a win ration of .95. In theory, you should be able to reproduce it due to (-i 42).

Training cmd: **python3 deep_quoridor/src/train.py  -N 5 -W 0 -d 0.9999 -e 1000 -i 42 -s**
Play cmd:  **python3 deep_quoridor/src/play.py -N 5 -W 0 -t 100  -r matchresults -p simple dexppretrained**
