### PR TITLE
Treat edge of board as a wall for jump checking

### DIFF
--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -147,8 +147,20 @@ class Board:
         """
         assert is_valid_position_type(position1)
         assert is_valid_position_type(position2)
-        wall_position = position1 + position2
-        return self._grid[*wall_position] == Board.PLAYER1_WALL
+        assert np.sum(np.abs(position1 - position2)) == 1, "Positions must be adjacent"
+
+        position1_on_board = self.is_position_on_board(position1)
+        position2_on_board = self.is_position_on_board(position2)
+        assert position1_on_board or position2_on_board, "At least one position must be on the board"
+
+        if position1_on_board and position2_on_board:
+            wall_position = position1 + position2
+            return self._grid[*wall_position] == Board.PLAYER1_WALL
+        else:
+            # By convention we treat the border as a "wall". This is makes checking jumps more convenient, since
+            # players are allowed to jump diagonally if they are adjacent to another player and the border of the
+            # board is on the other side of that player.
+            return True
 
     def is_position_on_board(self, position: Position) -> bool:
         assert is_valid_position_type(position)

--- a/deep_quoridor/test/quoridor_test.py
+++ b/deep_quoridor/test/quoridor_test.py
@@ -111,7 +111,7 @@ class TestQuoridor:
                 if game.is_action_valid(MoveAction(position)):
                     game_moves.append(position)
 
-        assert [game_move == potential_move for game_move, potential_move in zip(game_moves, potential_moves)]
+        np.testing.assert_equal(np.array(game_moves), np.array(potential_moves))
 
     def _test_wall_placements(self, s):
         game, _, forbidden_walls = parse_board(s)
@@ -230,6 +230,12 @@ class TestQuoridor:
              -+-
            . . . .
            . . . .
+        """)
+
+        self._test_pawn_movements("""
+            . * .
+            * 1 *
+            * 2 *
         """)
 
     def test_forbidden_walls(self):


### PR DESCRIPTION
Also fixes the comparison logic that makes sure that the moves allowed by the Quoridor class are the same as the moves expected by the test. There were two problems before. When the two lists of moves were different lengths, zip() was ignoring the elements at the end of the longer array. Also the assert was on a list of truth values, and would always evaluate as true as long as the lists weren't of length zero.
  To fix this, we now convert the lists of moves to 2d numpy arrays of
size (num_points, 2) and then assert equality with np.testing.assert_equal.