### PR TITLE
Weights & Biases (wandb) integration

### DIFF
--- a/deep_quoridor/requirements.txt
+++ b/deep_quoridor/requirements.txt
@@ -6,3 +6,4 @@ pygame
 pytest
 pyyaml
 torch
+wandb

--- a/deep_quoridor/src/agents/__init__.py
+++ b/deep_quoridor/src/agents/__init__.py
@@ -4,7 +4,6 @@ __all__ = [
     "AgentRegistry",
     "DExpAgent",
     "FlatDQNAgent",
-    "Pretrained01FlatDQNAgent",
     "RandomAgent",
     "ReplayAgent",
     "ReplayBuffer",
@@ -19,15 +18,15 @@ from agents.core import (  # noqa: E402, F401  # noqa: E402, F401
     AgentRegistry,
     ReplayBuffer,
 )
-from agents.dexp import DExpAgent, DExpPretrainedAgent  # noqa: E402
-from agents.flat_dqn import FlatDQNAgent, Pretrained01FlatDQNAgent  # noqa: E402
+from agents.dexp import DExpAgent  # noqa: E402
+from agents.flat_dqn import FlatDQNAgent  # noqa: E402
 from agents.greedy import GreedyAgent  # noqa: E402, F401
 from agents.random import RandomAgent  # noqa: E402, F401
 from agents.replay import ReplayAgent  # noqa: E402, F401
 from agents.simple import SimpleAgent  # noqa: E402, F401
 
-AgentRegistry.register("dexppretrained", DExpPretrainedAgent)
-AgentRegistry.register("pretrained01flatdqn", Pretrained01FlatDQNAgent)
+AgentRegistry.register("dexp", DExpAgent)
+AgentRegistry.register("flatdqn", FlatDQNAgent)
 AgentRegistry.register("greedy", GreedyAgent)
 AgentRegistry.register("random", RandomAgent)
 AgentRegistry.register("simple", SimpleAgent)

--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -36,6 +36,10 @@ class AgentRegistry:
 
     @staticmethod
     def create(friendly_name: str, **kwargs) -> Agent:
+        if ":" in friendly_name:
+            friendly_name, wandb_alias = friendly_name.split(":")
+            kwargs["wandb_alias"] = wandb_alias
+
         return AgentRegistry.agents[friendly_name](**kwargs)
 
     @staticmethod

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -272,7 +272,7 @@ class AbstractTrainableAgent(Agent):
                 )
         else:
             api = wandb.Api()
-            artifact = api.artifact(f"lazy-learning-liar/deep_quoridor/{model_id}:{wandb_alias}", type="model")
+            artifact = api.artifact(f"the-lazy-learning-lair/deep_quoridor/{model_id}:{wandb_alias}", type="model")
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 artifact_dir = artifact.download(root=tmpdir)

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -43,6 +43,10 @@ class DExpNetwork(nn.Module):
 class DExpAgent(AbstractTrainableAgent):
     """Diego experimental Agent using DRL."""
 
+    def version(self):
+        """Bump this version when compatibility with saved models is broken"""
+        return 1
+
     def _calculate_action_size(self):
         """Calculate the size of the action space."""
         return self.board_size**2 + (self.board_size - 1) ** 2 * 2
@@ -62,13 +66,3 @@ class DExpAgent(AbstractTrainableAgent):
 
         flat_obs = np.concatenate([board, walls, my_walls, opponent_walls])
         return torch.FloatTensor(flat_obs).to(self.device)
-
-
-class DExpPretrainedAgent(DExpAgent):
-    """
-    A DExpAgent that is initialized with the pre-trained model from main.py.
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.load_pretrained_file()

--- a/deep_quoridor/src/agents/flat_dqn.py
+++ b/deep_quoridor/src/agents/flat_dqn.py
@@ -35,6 +35,10 @@ class DQNNetwork(nn.Module):
 class FlatDQNAgent(AbstractTrainableAgent):
     """Agent that uses Deep Q-Network with flat state representation."""
 
+    def version(self):
+        """Bump this version when compatibility with saved models is broken"""
+        return 1
+
     def _calculate_action_size(self):
         """Calculate the size of the action space."""
         return self.board_size**2 + (self.board_size - 1) ** 2 * 2
@@ -53,13 +57,3 @@ class FlatDQNAgent(AbstractTrainableAgent):
 
         flat_obs = np.concatenate([board, walls, my_walls, opponent_walls])
         return torch.FloatTensor(flat_obs).to(self.device)
-
-
-class Pretrained01FlatDQNAgent(FlatDQNAgent):
-    """
-    A FlatDQNAgent that is initialized with the pre-trained model from main.py.
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.load_pretrained_file()

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -6,6 +6,16 @@ from arena import Arena
 from arena_yaml_recorder import ArenaYAMLRecorder
 from renderers import Renderer
 
+
+def validate_players(value):
+    agent_name = value.split(":")[0]
+
+    if agent_name in AgentRegistry.names():
+        return value
+
+    raise argparse.ArgumentTypeError(f"Invalid value: '{value}'.")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Deep Quoridor")
     parser.add_argument("-N", "--board_size", type=int, default=None, help="Board Size")
@@ -23,9 +33,9 @@ if __name__ == "__main__":
         "-p",
         "--players",
         nargs="+",
-        choices=AgentRegistry.names(),
+        type=validate_players,
         default=["random", "simple"],
-        help="List of players to compete against each other",
+        help=f"List of players to compete against each other. Available players: f{', '.join(AgentRegistry.names())}. If the player is a trainable agent, the model will be loaded locally or from wandb if an alias is specified, e.g. 'dex:v1'",
     )
     parser.add_argument(
         "-A",


### PR DESCRIPTION
This PR allows to track the training in wandb, as well as save and load model parameters.

**When Training**
- If you don't want to use wandb, either pass to the training `--no-wandb` or run from the command line `wand disabled` and then it won't be used until re-enabled
- To use wandb you can:
-- set in your environment WANDB_API_KEY to your API key
-- when running the training script, it will give instructions on how to create an account or log in
-- run 'wandb login` form the command line

A new wandb run will be created, containing all the metadata to reproduce and showing graphs in real time of the loss, rewards and epsilon and more.
E.g. [Run data image](https://github.com/user-attachments/assets/dc23fa8c-1b96-498a-8561-64c255799ae8), [Run metrics image](https://github.com/user-attachments/assets/f5708519-7442-454a-a4e4-d2590f781f07)

When the run finishes, the model file will be uploaded to wandb as an artifact under a name such as `dexp_B5W2_mv1`.  The first part is the model name, then board size and wall max, and the "model version", which needs to be changed every time we make changes that are not backwards compatible (e.g. you change the number of parametrs).
If the file generated is the same than an existing one, wandb won't create a duplicate, but you may have different versions if you change the hyperparameters, e.g.:

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/19dc672d-20c0-4da4-ae24-c474aa9462b7" />

**When Playing** 
- I removed the pretrained subclasses, so now the player name is for example dexp, not dexppretrained.  When the model is instantiated with `training_mode=False`, then the parameters are going to be loaded
- If the player is just the friendly name of the agent, it will try to load locally, e.g. `--players dex greedy`.
- The agent can contain an "alias" for wandb, in the above image they are v2, latest, v1 or v0.  To make it use a model from wandb, just pass an alias, e.g. `--players dex:latest dex:v1` (yeah, you can make it play against a different model of itself!).  One issue that I just realized is that if there's more than 1 person training the same model, when they play they may not grab their own model when using latest.  Maybe we should use an alias with the nickname (notice that no more than one thing can have the same alias, so when you put it in a new one, it's removed from the older one)
- One thing that I suggest is to have a process for aliases, e.g. we can create one that is `default` that we'll use to indicate a good working model, or we may have `best` to track which one is producing the best results.

