### PR TITLE
Re-do: Weights & Biases (wandb) integration

### DIFF
--- a/deep_quoridor/src/agents/__init__.py
+++ b/deep_quoridor/src/agents/__init__.py
@@ -1,14 +1,15 @@
 __all__ = [
     "AbstractTrainableAgent",
+    "ActionLog",
     "Agent",
     "AgentRegistry",
     "DExpAgent",
     "FlatDQNAgent",
-    "Pretrained01FlatDQNAgent",
     "RandomAgent",
     "ReplayAgent",
     "ReplayBuffer",
     "SimpleAgent",
+    "TrainableAgentParams",
 ]
 
 
@@ -18,16 +19,17 @@ from agents.core import (  # noqa: E402, F401  # noqa: E402, F401
     Agent,
     AgentRegistry,
     ReplayBuffer,
+    TrainableAgentParams,
 )
-from agents.dexp import DExpAgent, DExpPretrainedAgent  # noqa: E402
-from agents.flat_dqn import FlatDQNAgent, Pretrained01FlatDQNAgent  # noqa: E402
+from agents.dexp import DExpAgent  # noqa: E402
+from agents.flat_dqn import FlatDQNAgent  # noqa: E402
 from agents.greedy import GreedyAgent  # noqa: E402, F401
 from agents.random import RandomAgent  # noqa: E402, F401
 from agents.replay import ReplayAgent  # noqa: E402, F401
 from agents.simple import SimpleAgent  # noqa: E402, F401
 
-AgentRegistry.register("dexppretrained", DExpPretrainedAgent)
-AgentRegistry.register("pretrained01flatdqn", Pretrained01FlatDQNAgent)
+AgentRegistry.register("dexp", DExpAgent)
+AgentRegistry.register("flatdqn", FlatDQNAgent)
 AgentRegistry.register("greedy", GreedyAgent)
 AgentRegistry.register("random", RandomAgent)
 AgentRegistry.register("simple", SimpleAgent)

--- a/deep_quoridor/src/agents/core/__init__.py
+++ b/deep_quoridor/src/agents/core/__init__.py
@@ -1,6 +1,6 @@
-__all__ = ["Agent", "AgentRegistry", "ActionLog", "ReplayBuffer", "AbstractTrainableAgent"]
+__all__ = ["Agent", "AgentRegistry", "ActionLog", "ReplayBuffer", "AbstractTrainableAgent", "TrainableAgentParams"]
 
 
 from agents.core.agent import ActionLog, Agent, AgentRegistry
 from agents.core.replay_buffer import ReplayBuffer
-from agents.core.trainable_agent import AbstractTrainableAgent
+from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentParams

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -1,15 +1,29 @@
 import os
 import random
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+from utils.subargs import SubargsBase
 
+import wandb
 from agents.core.agent import Agent
 from agents.core.replay_buffer import ReplayBuffer
+
+
+@dataclass
+class TrainableAgentParams(SubargsBase):
+    # Just used to display a user friendly name
+    nick: Optional[str] = None
+    # If wandb_alias is provided, the model will be fetched from wandb using the model_id and the alias
+    wandb_alias: Optional[str] = None
+    # If a filename is provided, the model will be loaded from disc
+    model_filename: Optional[str] = None
 
 
 class AbstractTrainableAgent(Agent):
@@ -26,6 +40,8 @@ class AbstractTrainableAgent(Agent):
         batch_size=64,
         update_target_every=100,
         assign_negative_reward=False,
+        training_mode=False,
+        params: TrainableAgentParams = TrainableAgentParams(),
         **kwargs,
     ):
         super().__init__()
@@ -40,9 +56,13 @@ class AbstractTrainableAgent(Agent):
         self.assign_negative_reward = assign_negative_reward
         self.final_reward_multiplier = 1
         self.action_size = self._calculate_action_size()
+        self.training_mode = training_mode
+        self.params = params
 
         # Setup device
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        self.fetch_model_from_wand_and_update_params()
 
         # Initialize networks
         self.online_network = self._create_network()
@@ -56,10 +76,10 @@ class AbstractTrainableAgent(Agent):
         self.optimizer = self._create_optimizer()
         self.criterion = self._create_criterion()
         self.replay_buffer = ReplayBuffer(capacity=10000)
-        self.training_mode = False
         self.episodes_rewards = []
         self.train_call_losses = []
         self.reset_episode_related_info()
+        self.resolve_and_load_model()
 
     def reset_episode_related_info(self):
         self.current_episode_reward = 0
@@ -134,6 +154,16 @@ class AbstractTrainableAgent(Agent):
         )
 
         return avg_loss, avg_reward
+
+    def model_hyperparameters(self):
+        return {
+            "epsilon_min": self.epsilon_min,
+            "epsilon_decay": self.epsilon_decay,
+            "gamma": self.gamma,
+            "batch_size": self.batch_size,
+            "update_target_every": self.update_target_every,
+            "assign_negative_reward": self.assign_negative_reward,
+        }
 
     def _calculate_action_size(self):
         """Calculate the size of the action space."""
@@ -280,6 +310,9 @@ class AbstractTrainableAgent(Agent):
     def model_name(self):
         raise NotImplementedError("Trainable agents should return a model name")
 
+    def wandb_local_filename(self, artifact: wandb.Artifact) -> str:
+        return f"{self.model_id()}_{artifact.digest[:5]}.pt"
+
     def resolve_filename(self, suffix):
         return f"{self.model_id()}_{suffix}.pt"
 
@@ -293,10 +326,57 @@ class AbstractTrainableAgent(Agent):
         self.online_network.load_state_dict(torch.load(path))
         self.update_target_network()
 
-    def load_pretrained_file(self):
-        filename = self.resolve_filename("final")
-        model_path = Path(__file__).resolve().parents[4] / "models" / filename
-        if os.path.exists(model_path):
-            self.load_model(model_path)
+    def resolve_and_load_model(self):
+        """Figure out what model needs to be loaded based on the settings and loads it."""
+        if self.params.model_filename:
+            filename = self.params.model_filename
         else:
-            raise FileNotFoundError(f"Model file {model_path} not found. Please provide the weights file.")
+            # If no filename is passed in training mode, assume we are not loading a model
+            if self.training_mode:
+                return
+
+            # If it's not training mode, we definitely need to load a pretrained model, so try the
+            # default path for local files
+            filename = Path(__file__).resolve().parents[4] / "models" / self.resolve_filename("final")
+
+        if not os.path.exists(filename):
+            raise FileNotFoundError(f"Model file {filename} not found.")
+
+        self.load_model(filename)
+
+    @classmethod
+    def params_class(cls):
+        raise NotImplementedError("Trainable agents must implement method params_class")
+
+    def fetch_model_from_wand_and_update_params(self):
+        """
+        This function doesn't do anything if wandb_alias is not set in self.params.
+        Otherwise, it will download the file if there's not a local copy.
+        The params are updated to the artifact metadata.
+
+        """
+        alias = self.params.wandb_alias
+        if not alias:
+            return
+
+        api = wandb.Api()
+        artifact = api.artifact(f"the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}", type="model")
+        local_filename = Path(__file__).resolve().parents[4] / "models" / self.wandb_local_filename(artifact)
+
+        self.params = self.params_class()(**artifact.metadata)
+        self.params.model_filename = str(local_filename)
+
+        if os.path.exists(local_filename):
+            return local_filename
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_dir = artifact.download(root=tmpdir)
+
+            path = artifact.download(root=artifact_dir)
+            tmp_filename = Path(path) / f"{self.model_id()}.pt"
+            if not os.path.exists(tmp_filename):
+                raise FileNotFoundError(f"Model file {tmp_filename} was not downloaded.  Please check the artifact")
+
+            os.rename(tmp_filename, local_filename)
+
+            print(f"Model downloaded from wandb to {local_filename}")

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import torch
 import torch.nn as nn
 import yaml
-from utils.subargs import SubargsBase
 
 from agents.core import AbstractTrainableAgent, rotation
+from agents.core.trainable_agent import TrainableAgentParams
 
 
 class DExpNetwork(nn.Module):
@@ -47,16 +46,17 @@ class DExpNetwork(nn.Module):
 
 
 @dataclass
-class DExpPlayParams(SubargsBase):
+class DExpPlayParams(TrainableAgentParams):
     use_rotate_board: bool = False
     include_turn: bool = False
     split_board: bool = False
-    nick: Optional[str] = None
 
     @classmethod
     def from_str(cls, agent_params_str="000"):
         p = DExpPlayParams(
-            bool(int(agent_params_str[0])), bool(int(agent_params_str[1])), bool(int(agent_params_str[2]))
+            use_rotate_board=bool(int(agent_params_str[0])),
+            include_turn=bool(int(agent_params_str[1])),
+            split_board=bool(int(agent_params_str[2])),
         )
         return p
 
@@ -75,7 +75,7 @@ class DExpAgent(AbstractTrainableAgent):
     ):
         self.use_opponents_actions = use_opponents_actions
         self.params = params
-        super().__init__(**kwargs)
+        super().__init__(params=params, **kwargs)
 
     def name(self):
         if self.params.nick:
@@ -213,13 +213,3 @@ class DExpAgent(AbstractTrainableAgent):
             },
         }
         return yaml.dump(config, indent=2)
-
-
-class DExpPretrainedAgent(DExpAgent):
-    """
-    A DExpAgent that is initialized with the pre-trained model from main.py.
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.load_pretrained_file()

--- a/deep_quoridor/src/agents/flat_dqn.py
+++ b/deep_quoridor/src/agents/flat_dqn.py
@@ -1,8 +1,10 @@
+from dataclasses import dataclass
+
 import numpy as np
 import torch
 import torch.nn as nn
 
-from agents.core import AbstractTrainableAgent
+from agents.core import AbstractTrainableAgent, TrainableAgentParams
 
 
 class DQNNetwork(nn.Module):
@@ -32,15 +34,25 @@ class DQNNetwork(nn.Module):
         return self.model(x)
 
 
+@dataclass
+class FlatDQNAParams(TrainableAgentParams):
+    pass
+
+
 class FlatDQNAgent(AbstractTrainableAgent):
     """Agent that uses Deep Q-Network with flat state representation."""
 
+    def __init__(
+        self,
+        params=FlatDQNAParams(),
+        **kwargs,
+    ):
+        self.params = params
+        super().__init__(params=params, **kwargs)
+
     @classmethod
     def params_class(cls):
-        """If we want to receive parameters from the command line, return a class that uses @dataclass
-        containing the fields.   They will be parsed using subargs.
-        """
-        return None
+        return FlatDQNAParams
 
     def name(self):
         return "flatdqn"
@@ -70,13 +82,3 @@ class FlatDQNAgent(AbstractTrainableAgent):
 
         flat_obs = np.concatenate([board, walls, my_walls, opponent_walls])
         return torch.FloatTensor(flat_obs).to(self.device)
-
-
-class Pretrained01FlatDQNAgent(FlatDQNAgent):
-    """
-    A FlatDQNAgent that is initialized with the pre-trained model from main.py.
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.load_pretrained_file()

--- a/deep_quoridor/src/plugins/__init__.py
+++ b/deep_quoridor/src/plugins/__init__.py
@@ -1,2 +1,3 @@
 from plugins.arena_yaml_recorder import ArenaYAMLRecorder  # noqa: E402, F401
 from plugins.save_model import SaveModelEveryNEpisodesPlugin  # noqa: E402, F401
+from plugins.wandb_train import WandbTrainPlugin  # noqa: E402, F401

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -1,0 +1,54 @@
+import os
+from dataclasses import asdict
+
+from agents.core.trainable_agent import AbstractTrainableAgent
+from arena_utils import ArenaPlugin
+
+import wandb
+
+
+class WandbTrainPlugin(ArenaPlugin):
+    def __init__(self, update_every: int, total_episodes: int, agent: AbstractTrainableAgent, path: str):
+        self.agent = agent
+        self.update_every = update_every
+        self.total_episodes = total_episodes
+        self.episode_count = 0
+        self.path = path
+
+    def start_arena(self, game, total_games: int):
+        config = {
+            "board_size": game.board_size,
+            "max_walls": game.max_walls,
+            "episodes": self.total_episodes,
+            "player_args": self.agent.params,
+        }
+        config.update(self.agent.model_hyperparameters())
+
+        self.run = wandb.init(
+            project="deep_quoridor",
+            job_type="train",
+            config=config,
+            tags=[self.agent.model_id()],
+        )
+
+    def end_game(self, game, result):
+        if self.episode_count % self.update_every == 0 or self.episode_count == (self.total_episodes - 1):
+            avg_reward, avg_loss = self.agent.compute_loss_and_reward(self.update_every)
+
+            self.run.log(
+                {"loss": avg_loss, "reward": avg_reward, "epsilon": self.agent.epsilon},
+                step=self.episode_count,
+            )
+        self.episode_count += 1
+
+    def end_arena(self, game, results):
+        save_file = os.path.join(self.path, f"{self.agent.model_id()}.pt")
+        self.agent.save_model(save_file)
+
+        artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
+        artifact.add_file(local_path=save_file)
+        artifact.save()
+
+        wand_file = os.path.join(self.path, self.agent.wandb_local_filename(artifact))
+
+        os.rename(save_file, wand_file)

--- a/deep_quoridor/src/renderers/training_status.py
+++ b/deep_quoridor/src/renderers/training_status.py
@@ -1,4 +1,5 @@
 from agents.core import AbstractTrainableAgent
+
 from renderers import Renderer
 
 


### PR DESCRIPTION
This is an improved version of https://github.com/jonbinney/deep_rabbit_hole/pull/144

This PR allows to track the training in wandb, as well as save and load model parameters and configuration.

**Usage**
If you don't want to use wandb during training (e.g. you're just doing some quick tests and care more about the code running than actually storing the results), either pass to the training `--no-wandb` or run from the command line `wand disabled` and then it won't be used until re-enabled

Otherwise, the same train command than before will log to wandb and provide a link to see the run. 

When using `play.py`:
- if you don't provide any additional information to the player (e.g. just `dexp`), then it will try to load the file as if it was saved without wandb (ending in `_final.py`).  If you run the training with wandb, you should use wandb in play as well.
- You can specify a local file to load, e.g. `dexp:model_filename=models/dexp_B7W0_mv1_C110_final.pt`
- In order to load a model from wandb, you need to pass the alias.  Each model can have more than 1 alias (but no alias can be in more than 1 model).  For example, by default you'll have the aliases v0, v1, v2...etc, increasing in each new model, and latest for the last one.  So, if you just want to use the last one, you can pass it as follows: `dexp:wandb_alias=latest`.  You could also choose a specific one, e.g. v0, or manually label something as `best` or whatever.
  - The "play parameters" are stored in wandb metadata when running the training and will be restored when loading.  E.g. if you train a model using `use_rotate_board=True` in DExpAgent, then when the model is loaded from wandb, the agent will have that configuration set.  If loading from a local file, you need to specify the parameters manually. (If useful, we could save the configuration in a local file in the future)
  - Notice that the wandb files are stored locally in the models directory to avoid re-downloading every time, using the first 5 digits of the digest in the name, e.g. `dexp_B5W5_mv1_b0c11.pt`, this way, if you're trying to load `latest` but the alias was moved to a different model, it will recognize that it's different and download it.
