### PR TITLE
Some tweaks to PPO

### DIFF
--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -1,7 +1,7 @@
 from pettingzoo.utils import BaseWrapper
 from sb3_contrib import MaskablePPO
 
-from agents.core.agent import Agent, AgentRegistry
+from agents.core.agent import ActionLog, Agent, AgentRegistry
 from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentParams
 
 
@@ -88,6 +88,7 @@ class SB3PPOAgent(AbstractTrainableAgent):
             params: Optional parameters for the agent
             **kwargs: Additional arguments to pass to the parent class
         """
+        self.action_log = ActionLog()
         self.board_size = board_size
         self.max_walls = max_walls
         self.params = params

--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -1,5 +1,8 @@
+import torch
+from gymnasium import spaces
 from pettingzoo.utils import BaseWrapper
 from sb3_contrib import MaskablePPO
+from stable_baselines3.common.torch_layers import FlattenExtractor
 
 from agents.core.agent import ActionLog, Agent, AgentRegistry
 from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentParams
@@ -136,7 +139,7 @@ class SB3PPOAgent(AbstractTrainableAgent):
             self.fetch_model_from_wand_and_update_params()
 
             # Wrap the game to get access to action_mask method
-            self.wrapper = SB3ActionMaskWrapper(game)
+            self.wrapper = wrap_env(game)
 
             try:
                 # Find the most recent model file
@@ -172,6 +175,37 @@ class SB3PPOAgent(AbstractTrainableAgent):
         action = int(self.model.predict(observation, action_masks=action_mask, deterministic=self.deterministic)[0])
 
         return action
+
+
+def wrap_env(env):
+    env = SB3ActionMaskWrapper(env)
+    return env
+
+
+def make_env_fn(env_constructor):
+    def env_fn(**kwargs):
+        env = env_constructor(**kwargs)
+        env = wrap_env(env)
+        return env
+
+    return env_fn
+
+
+class DictFlattenExtractor(FlattenExtractor):
+    """
+    This class is necessary because the default FlattenExtractor does not work with dict spaces.
+    It just tries to call "flatten" directly which of course doesn't exist on a dict.
+    NOTE: It is important to be careful to not flatten the batch dimension (first one).
+    """
+
+    def __init__(self, observation_space: spaces.Box):
+        super().__init__(observation_space)
+
+    def forward(self, obs: dict) -> torch.Tensor:
+        thobs = torch.tensor([], device=list(obs.values())[0].device)
+        for v in obs.values():
+            thobs = torch.cat((thobs, torch.tensor(v).flatten(start_dim=1)), dim=1)
+        return thobs
 
 
 # Register the agent with the registry

--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -6,6 +6,7 @@ from stable_baselines3.common.torch_layers import FlattenExtractor
 
 from agents.core.agent import ActionLog, Agent, AgentRegistry
 from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentParams
+from deep_quoridor.src.environment.dict_split_board_wrapper import DictSplitBoardWrapper
 
 
 class SB3ActionMaskWrapper(BaseWrapper):
@@ -113,7 +114,7 @@ class SB3PPOAgent(AbstractTrainableAgent):
     @staticmethod
     def version():
         """Bump this version when compatibility with saved models is broken"""
-        return 0
+        return 1
 
     @staticmethod
     def params_class():
@@ -178,6 +179,7 @@ class SB3PPOAgent(AbstractTrainableAgent):
 
 
 def wrap_env(env):
+    env = DictSplitBoardWrapper(env)
     env = SB3ActionMaskWrapper(env)
     return env
 

--- a/deep_quoridor/src/environment/dict_split_board_wrapper.py
+++ b/deep_quoridor/src/environment/dict_split_board_wrapper.py
@@ -1,4 +1,5 @@
 import numpy as np
+from gymnasium import spaces
 from pettingzoo.utils.env import AgentID, ObsType
 from pettingzoo.utils.wrappers import BaseWrapper
 
@@ -28,18 +29,24 @@ class DictSplitBoardWrapper(BaseWrapper):
 
         return {"observation": observation, "action_mask": obs["action_mask"]}
 
-    def observation_space(self):
+    def observation_space(self, agent):
         """Define the observation space for the transformed observations."""
-        original_space = self.env.observation_space
+        original_space = self.env.observation_space(agent)
         board_shape = (self.board_size, self.board_size)  # Shape for each board (player and opponent)
         return {
-            "observation": {
-                "my_turn": original_space["observation"]["my_turn"],
-                "my_board": original_space["observation"]["board"].__class__(shape=board_shape, dtype=np.float32),
-                "opponent_board": original_space["observation"]["board"].__class__(shape=board_shape, dtype=np.float32),
-                "walls": original_space["observation"]["walls"],
-                "my_walls_remaining": original_space["observation"]["my_walls_remaining"],
-                "opponent_walls_remaining": original_space["observation"]["opponent_walls_remaining"],
-            },
+            "observation": spaces.Dict(
+                {
+                    "my_turn": original_space["observation"]["my_turn"],
+                    "my_board": original_space["observation"]["board"].__class__(
+                        0, 1, shape=board_shape, dtype=np.float32
+                    ),
+                    "opponent_board": original_space["observation"]["board"].__class__(
+                        0, 1, shape=board_shape, dtype=np.float32
+                    ),
+                    "walls": original_space["observation"]["walls"],
+                    "my_walls_remaining": original_space["observation"]["my_walls_remaining"],
+                    "opponent_walls_remaining": original_space["observation"]["opponent_walls_remaining"],
+                }
+            ),
             "action_mask": original_space["action_mask"],
         }

--- a/deep_quoridor/src/train_sb3.py
+++ b/deep_quoridor/src/train_sb3.py
@@ -18,7 +18,6 @@ import os
 import time
 
 import quoridor_env
-from agents.core.rotation import convert_rotated_action_index_to_original
 from agents.sb3_ppo import DictFlattenExtractor, make_env_fn
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy

--- a/deep_quoridor/src/train_sb3.py
+++ b/deep_quoridor/src/train_sb3.py
@@ -18,6 +18,7 @@ import os
 import time
 
 import quoridor_env
+from agents.core.rotation import convert_rotated_action_index_to_original
 from agents.sb3_ppo import DictFlattenExtractor, make_env_fn
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
@@ -148,7 +149,7 @@ if __name__ == "__main__":
     parser.add_argument("-g", "--num_games", type=int, default=100, help="Number of games for evaluation")
     parser.add_argument("-i", "--seed", type=int, default=0, help="Random seed for training and evaluation")
     parser.add_argument("--no-train", action="store_true", default=False, help="Skip training and only run evaluation")
-    parser.add_argument("--no-upload", action="store_true", default=False, help="Skip training and only run evaluation")
+    parser.add_argument("--no-upload", action="store_true", default=False, help="Skip uploading artifacts to wandb")
     parser.add_argument("--no-eval", action="store_true", default=False, help="Skip evaluation and only run training")
     parser.add_argument(
         "-rp",


### PR DESCRIPTION
Nothing that changes things much, but it all seems to still work out.

Most importantlly, incorporates two tricks developed by @muralx in the form of Wrappers
 - Split boards (as dict)
 - Rotated board

It also includes some unrelated refactoring:
 - Pushed more of the agent details to the PPO agent (instead of the train file)
 - Parameterized the training file
 - Made the environment wrapping a method so that it's in a single placed and used in both agent play and training

I think the evaluation part of train_sb3 is wrong in the case of the rotated board (how does it not crash??) but that seems not too critical.