### PR TITLE
Adding new options to DExp

### DIFF
--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -112,10 +112,6 @@ class Agent:
     def get_action(self, game) -> int:
         raise NotImplementedError("You must implement the get_action method")
 
-    def yaml_config(self) -> str:
-        """Returns a YAML string representation of the agent's configuration."""
-        return ""
-
 
 class AgentRegistry:
     agents = {}

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -139,14 +139,14 @@ class AbstractTrainableAgent(Agent):
 
         # Handle end of episode
         if action is None:
-            return 0
-        #            ## FIX THIS
-        #            if self.assign_negative_reward and len(self.replay_buffer) > 0:
-        #                last = self.replay_buffer.get_last()
-        #                last[2] = reward  # update final reward
-        #                last[4] = 1.0  # mark as done
-        #                self.current_episode_reward += reward
-        #            return
+            ## TODO: Revisit this since it won't work for the case in which
+            ## opponents actions are used
+            if self.assign_negative_reward and len(self.replay_buffer) > 0:
+                last = self.replay_buffer.get_last()
+                last[2] = reward  # update final reward
+                last[4] = 1.0  # mark as done
+                self.current_episode_reward += reward
+            return reward
 
         state_before_action = self.observation_to_tensor(observation_before_action, player_id)
         state_after_action = self.observation_to_tensor(game.observe(player_id), player_id)

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -47,6 +47,8 @@ class TrainableAgentParams(SubargsBase):
     training_mode: bool = False
     # If True, final reward will be multiplied by this value (positive or negative)
     final_reward_multiplier: float = 1.0
+    # If True, the target q-value function will substract maxq_a'(s', a') instead of adding it
+    use_negative_qvalue_function: bool = False
 
 
 class AbstractTrainableAgent(Agent):
@@ -309,7 +311,8 @@ class AbstractTrainableAgent(Agent):
         """Compute target Q-values."""
         with torch.no_grad():
             next_q_values = self.target_network(next_states).max(1)[0]
-            return rewards - (1 - dones) * self.gamma * next_q_values
+            negate = -1 if self.params.use_negative_qvalue_function else 1
+            return rewards + negate * (1 - dones) * self.gamma * next_q_values
 
     def _update_network(self, current_q_values, target_q_values):
         """Update the network using computed Q-values."""

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -391,6 +391,7 @@ class AbstractTrainableAgent(Agent):
             return
 
         api = wandb.Api()
+        print(f"Fetching model from wandb: the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}")
         artifact = api.artifact(f"the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}", type="model")
         local_filename = resolve_path(self.params.wandb_dir, self.wandb_local_filename(artifact))
 

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -71,12 +71,29 @@ class DExpAgentParams(TrainableAgentParams):
 class DExpAgent(AbstractTrainableAgent):
     """Diego experimental Agent using DRL."""
 
+    def check_congiguration(self):
+        """
+        Check the configuration of the agent.
+        This is used to check if the agent is configured correctly.
+        """
+        if self.params.use_opponents_actions and self.params.assign_negative_rewards:
+            raise ValueError(
+                "use_opponents_actions and assign_negative_rewards cannot be used together. "
+                "use_opponents_actions is used for training only, not for playing."
+            )
+        if self.params.target_as_source_for_opponent and self.params.assign_negative_rewards:
+            raise ValueError(
+                "target_as_source_for_opponent and assign_negative_rewards cannot be used together. "
+                "target_as_source_for_opponent is used for training only, not for playing."
+            )
+
     def __init__(
         self,
         params=DExpAgentParams(),
         **kwargs,
     ):
         super().__init__(params=params, **kwargs)
+        self.check_congiguration()
 
     def name(self):
         if self.params.nick:

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -77,15 +77,9 @@ class DExpAgent(AbstractTrainableAgent):
         This is used to check if the agent is configured correctly.
         """
         if self.params.use_opponents_actions and self.params.assign_negative_reward:
-            raise ValueError(
-                "use_opponents_actions and assign_negative_reward cannot be used together. "
-                "use_opponents_actions is used for training only, not for playing."
-            )
+            raise ValueError("use_opponents_actions and assign_negative_reward cannot be used together. ")
         if self.params.target_as_source_for_opponent and self.params.assign_negative_reward:
-            raise ValueError(
-                "target_as_source_for_opponent and assign_negative_reward cannot be used together. "
-                "target_as_source_for_opponent is used for training only, not for playing."
-            )
+            raise ValueError("target_as_source_for_opponent and assign_negative_reward cannot be used together. ")
 
     def __init__(
         self,

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -55,11 +55,11 @@ class DExpAgentParams(TrainableAgentParams):
 
     # Whether oppoments actions are used for training
     # This is used for training only, not for playing
-    # This should not be combined with assign_negative_rewards
+    # This should not be combined with assign_negative_reward
     use_opponents_actions: bool = False
 
     # Whether the target state generated for a player should match the source state of the opponent
-    # in the next step. This should not be combined with assign_negative_rewards
+    # in the next step. This should not be combined with assign_negative_reward
     target_as_source_for_opponent: bool = False
 
     # Parameters used for training which are required to be used with the same set of values during training
@@ -76,14 +76,14 @@ class DExpAgent(AbstractTrainableAgent):
         Check the configuration of the agent.
         This is used to check if the agent is configured correctly.
         """
-        if self.params.use_opponents_actions and self.params.assign_negative_rewards:
+        if self.params.use_opponents_actions and self.params.assign_negative_reward:
             raise ValueError(
-                "use_opponents_actions and assign_negative_rewards cannot be used together. "
+                "use_opponents_actions and assign_negative_reward cannot be used together. "
                 "use_opponents_actions is used for training only, not for playing."
             )
-        if self.params.target_as_source_for_opponent and self.params.assign_negative_rewards:
+        if self.params.target_as_source_for_opponent and self.params.assign_negative_reward:
             raise ValueError(
-                "target_as_source_for_opponent and assign_negative_rewards cannot be used together. "
+                "target_as_source_for_opponent and assign_negative_reward cannot be used together. "
                 "target_as_source_for_opponent is used for training only, not for playing."
             )
 

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -31,9 +31,11 @@ class DExpNetwork(nn.Module):
 
         # Define network architecture
         self.model = nn.Sequential(
-            nn.Linear(flat_input_size, 1024),
+            nn.Linear(flat_input_size, 2048),
             nn.ReLU(),
-            nn.Linear(1024, 1024),
+            nn.Linear(2048, 2048),
+            nn.ReLU(),
+            nn.Linear(2048, 1024),
             nn.ReLU(),
             nn.Linear(1024, 512),
             nn.ReLU(),
@@ -139,10 +141,10 @@ class DExpAgent(AbstractTrainableAgent):
         """Convert the observation dict to a flat tensor."""
         obs = observation["observation"]
         obs_player_turn = 1 if obs["my_turn"] else 0
-        obs = observation["observation"]
 
         # Rotate board and walls if needed for player_1 xor (not players turn)
         # This ensures board always faces to the player that will act on it
+        #
         should_rotate = ((obs_player_id == "player_1") ^ (not obs_player_turn)) and self.params.rotate
         board = rotation.rotate_board(obs["board"]) if should_rotate else obs["board"]
         walls = rotation.rotate_walls(obs["walls"]) if should_rotate else obs["walls"]
@@ -194,9 +196,9 @@ class DExpAgent(AbstractTrainableAgent):
 
         return rotation.convert_rotated_action_index_to_original(self.board_size, action_index_in_tensor)
 
-    def convert_to_tensor_index_from_action(self, action):
-        if self.player_id == "player_0" or not self.params.rotate:
-            return super().convert_to_tensor_index_from_action(action)
+    def convert_to_tensor_index_from_action(self, action, action_player_id):
+        if action_player_id == "player_0" or not self.params.rotate:
+            return super().convert_to_tensor_index_from_action(action, action_player_id)
         return rotation.convert_original_action_index_to_rotated(self.board_size, action)
 
     def yaml_config(self) -> str:

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -30,11 +30,9 @@ class DExpNetwork(nn.Module):
 
         # Define network architecture
         self.model = nn.Sequential(
-            nn.Linear(flat_input_size, 2048),
+            nn.Linear(flat_input_size, 1024),
             nn.ReLU(),
-            nn.Linear(2048, 2048),
-            nn.ReLU(),
-            nn.Linear(2048, 1024),
+            nn.Linear(1024, 1024),
             nn.ReLU(),
             nn.Linear(1024, 512),
             nn.ReLU(),

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -56,7 +56,7 @@ class DExpAgentParams(TrainableAgentParams):
 
     # Whether oppoments actions are used for training
     # This is used for training only, not for playing
-    use_opponents_actions = False
+    use_opponents_actions: bool = False
 
     # Parameters used for training which are required to be used with the same set of values during training
     #  and playing are used to generate a 'key' to identify the model.
@@ -101,27 +101,22 @@ class DExpAgent(AbstractTrainableAgent):
         """Create the neural network model."""
         return DExpNetwork(self.board_size, self.action_size, self.params.split, self.params.turn)
 
-    def handle_opponent_step_outcome(self, observation_before_action, action, game):
+    def handle_opponent_step_outcome(self, opponent_observation_before_action, action, game):
         if not self.training_mode or not self.params.use_opponents_actions:
             return
 
         opponent_player = "player_1" if self.player_id == "player_0" else "player_0"
 
-        reward = game.rewards[opponent_player]
+        reward = self.adjust_reward(game.rewards[opponent_player], game)
 
-        # Handle end of episode
-        if action is None:
-            # TODO: Check whether it is worth it
-            # if self.assign_negative_reward and len(self.replay_buffer) > 0:
-            #    last = self.replay_buffer.get_last()
-            #    last[2] = reward  # update final reward
-            #    last[4] = 1.0  # mark as done
-            #    self.current_episode_reward += reward
-            return
-
-        state_before_action = self.observation_to_tensor_by_player(observation_before_action, True, opponent_player)
-        state_after_action = self.observation_to_tensor_by_player(game.observe(opponent_player), False, opponent_player)
+        observation_after_action = game.observe(opponent_player)
+        state_before_action = self.observation_to_tensor_by_player(
+            opponent_observation_before_action, True, opponent_player
+        )
+        state_after_action = self.observation_to_tensor_by_player(observation_after_action, False, opponent_player)
         done = game.is_done()
+        if opponent_player == "player_1" and self.params.rotate:
+            action = rotation.convert_original_action_index_to_rotated(self.board_size, action)
 
         self.replay_buffer.add(
             state_before_action.cpu().numpy(),
@@ -144,27 +139,21 @@ class DExpAgent(AbstractTrainableAgent):
         my_turn = 1 if obs["my_turn"] else 0
         return self.observation_to_tensor_by_player(observation, my_turn, self.player_id)
 
-    def observation_to_tensor_by_player(self, observation, my_turn, player_id):
+    def observation_to_tensor_by_player(self, observation, obs_player_turn, obs_player_id):
         obs = observation["observation"]
 
         # Rotate board and walls if needed for player_1
-        should_rotate = player_id == "player_1" and self.params.rotate
+        should_rotate = obs_player_id == "player_1" and self.params.rotate
         board = rotation.rotate_board(obs["board"]) if should_rotate else obs["board"]
         walls = rotation.rotate_walls(obs["walls"]) if should_rotate else obs["walls"]
 
         # Create position matrices for player and opponent
-        is_player_turn = my_turn
-        player_board = (board == 1 if is_player_turn else board == 2).astype(np.float32)
-        opponent_board = (board == 2 if is_player_turn else board == 1).astype(np.float32)
+        player_board = (board == 1).astype(np.float32)
+        opponent_board = (board == 2).astype(np.float32)
 
         # Get wall counts
         my_walls = np.array([obs["my_walls_remaining"]])
         opponent_walls = np.array([obs["opponent_walls_remaining"]])
-
-        # Swap positions and walls if not player's turn and include_turn is True
-        if not is_player_turn and self.params.turn:
-            my_walls, opponent_walls = opponent_walls, my_walls
-            player_board, opponent_board = opponent_board, player_board
 
         # Prepare board representation
         board = np.stack([player_board, opponent_board]) if self.params.split else board
@@ -172,7 +161,7 @@ class DExpAgent(AbstractTrainableAgent):
         # Flatten all components
         board_flat = board.flatten()
         walls_flat = walls.flatten()
-        turn_info = [my_turn] if self.params.turn else []
+        turn_info = [obs_player_turn] if self.params.turn else []
 
         # Combine all features into single tensor
         flat_obs = np.concatenate([turn_info, board_flat, walls_flat, my_walls, opponent_walls])

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -196,6 +196,11 @@ class DExpAgent(AbstractTrainableAgent):
 
         return rotation.convert_rotated_action_index_to_original(self.board_size, action_index_in_tensor)
 
+    def convert_to_tensor_index_from_action(self, action):
+        if self.player_id == "player_0" or not self.params.rotate:
+            return super().convert_to_tensor_index_from_action(action)
+        return rotation.convert_original_action_index_to_rotated(self.board_size, action)
+
     def yaml_config(self) -> str:
         config = {
             "board_size": self.board_size,

--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -139,6 +139,7 @@ class SB3PPOAgent(AbstractTrainableAgent):
 
             try:
                 # Find the most recent model file
+                print(f"Loading model from {self.params.model_filename}")
                 self.model = MaskablePPO.load(self.params.model_filename)
                 print(f"Loaded model from {self.params.model_filename}")
             except (ValueError, FileNotFoundError):

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -64,8 +64,9 @@ class WandbTrainPlugin(ArenaPlugin):
         self.agent.save_model(save_file)
 
         artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
-        artifact.add_file(local_path=str(save_file))
         artifact.save()
+        wandb.log_artifact(artifact).wait()
+        print(f"Model uploaded with version {artifact.version}")
 
         wand_file = resolve_path(self.agent.params.wandb_dir, self.agent.wandb_local_filename(artifact))
 

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -64,6 +64,7 @@ class WandbTrainPlugin(ArenaPlugin):
         self.agent.save_model(save_file)
 
         artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
+        artifact.add_file(local_path=str(save_file))
         artifact.save()
         wandb.log_artifact(artifact).wait()
         print(f"Model uploaded with version {artifact.version}")

--- a/deep_quoridor/test/agents/dexp_test.py
+++ b/deep_quoridor/test/agents/dexp_test.py
@@ -21,7 +21,6 @@ def mock_observation():
 def base_agent():
     params = DExpAgentParams(rotate=False, turn=False, split=False, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
-    agent.device = torch.device("cpu")
     return agent
 
 
@@ -29,7 +28,6 @@ def base_agent():
 def rotate_agent():
     params = DExpAgentParams(rotate=True, turn=False, split=False, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
-    agent.device = torch.device("cpu")
     return agent
 
 
@@ -37,7 +35,6 @@ def rotate_agent():
 def split_agent():
     params = DExpAgentParams(rotate=False, turn=False, split=True, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
-    agent.device = torch.device("cpu")
     return agent
 
 
@@ -47,7 +44,6 @@ def target_as_source_agent():
         rotate=True, turn=False, split=False, target_as_source_for_opponent=True, training_mode=True
     )
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
-    agent.device = torch.device("cpu")
     return agent
 
 

--- a/deep_quoridor/test/agents/dexp_test.py
+++ b/deep_quoridor/test/agents/dexp_test.py
@@ -21,6 +21,7 @@ def mock_observation():
 def base_agent():
     params = DExpAgentParams(rotate=False, turn=False, split=False, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
     return agent
 
 
@@ -28,6 +29,7 @@ def base_agent():
 def rotate_agent():
     params = DExpAgentParams(rotate=True, turn=False, split=False, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
     return agent
 
 
@@ -35,6 +37,7 @@ def rotate_agent():
 def split_agent():
     params = DExpAgentParams(rotate=False, turn=False, split=True, training_mode=True)
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
     return agent
 
 
@@ -44,6 +47,7 @@ def target_as_source_agent():
         rotate=True, turn=False, split=False, target_as_source_for_opponent=True, training_mode=True
     )
     agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
     return agent
 
 

--- a/deep_quoridor/test/agents/dexp_test.py
+++ b/deep_quoridor/test/agents/dexp_test.py
@@ -1,0 +1,99 @@
+import numpy as np
+import pytest
+import torch
+from agents.dexp import DExpAgent, DExpAgentParams
+
+
+@pytest.fixture
+def mock_observation():
+    return {
+        "observation": {
+            "board": np.array([[0, 0, 0], [1, 0, 0], [0, 0, 2]]),
+            "walls": np.array([[[0, 0], [0, 0]], [[0, 0], [0, 0]]]),
+            "my_walls_remaining": 5,
+            "opponent_walls_remaining": 4,
+            "my_turn": True,
+        }
+    }
+
+
+@pytest.fixture
+def base_agent():
+    params = DExpAgentParams(rotate=False, turn=False, split=False, training_mode=True)
+    agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
+    return agent
+
+
+@pytest.fixture
+def rotate_agent():
+    params = DExpAgentParams(rotate=True, turn=False, split=False, training_mode=True)
+    agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
+    return agent
+
+
+@pytest.fixture
+def split_agent():
+    params = DExpAgentParams(rotate=False, turn=False, split=True, training_mode=True)
+    agent = DExpAgent(params=params, board_size=3, max_walls=5)
+    agent.device = torch.device("cpu")
+    return agent
+
+
+def test_base_observation_conversion(base_agent, mock_observation):
+    result = base_agent.observation_to_tensor_by_player(
+        mock_observation, is_source_state=True, obs_player_id="player_0"
+    )
+
+    # Expected tensor size: board (9) + walls (8) + wall counts (2) = 19
+    assert result.shape == torch.Size([19])
+    assert isinstance(result, torch.FloatTensor)
+
+    # Verify board state conversion
+    board_part = result[:9].numpy()
+    expected_board = mock_observation["observation"]["board"].flatten()
+    np.testing.assert_array_almost_equal(board_part, expected_board)
+
+
+def test_rotation_for_player1(rotate_agent, mock_observation):
+    result = rotate_agent.observation_to_tensor_by_player(
+        mock_observation, is_source_state=True, obs_player_id="player_1"
+    )
+
+    # For player_1 with rotation, the board should be rotated 180 degrees
+    board_part = result[:9].numpy()
+    expected_board = np.rot90(mock_observation["observation"]["board"], k=2)
+    np.testing.assert_array_almost_equal(board_part, expected_board.flatten())
+
+
+def test_split_board_representation(split_agent, mock_observation):
+    result = split_agent.observation_to_tensor_by_player(
+        mock_observation, is_source_state=True, obs_player_id="player_0"
+    )
+
+    # Expected tensor size: split board (18) + walls (8) + wall counts (2) = 28
+    assert result.shape == torch.Size([28])
+
+    # Check player and opponent channels are correctly split
+    player_channel = result[:9].numpy()
+    opponent_channel = result[9:18].numpy()
+
+    expected_player = (mock_observation["observation"]["board"] == 1).astype(np.float32).flatten()
+    expected_opponent = (mock_observation["observation"]["board"] == 2).astype(np.float32).flatten()
+
+    np.testing.assert_array_almost_equal(player_channel, expected_player)
+    np.testing.assert_array_almost_equal(opponent_channel, expected_opponent)
+
+
+def test_state_conversion_with_turn_swap(base_agent, mock_observation):
+    result = base_agent.observation_to_tensor_by_player(
+        mock_observation,
+        is_source_state=False,  # This should swap player/opponent perspectives
+        obs_player_id="player_0",
+    )
+
+    # Check wall counts are swapped
+    wall_counts = result[-2:].numpy()
+    assert wall_counts[0] == mock_observation["observation"]["opponent_walls_remaining"]
+    assert wall_counts[1] == mock_observation["observation"]["my_walls_remaining"]


### PR DESCRIPTION
- Use substraction for the target qfunction (option use_negative_qvalue_function, default false)
- Supporting target_as_source_for_opponent, to make target states to match next step source step. This make the target state of the player 0/1's s2  (eg: (r1, s1, s2, a1)) to match the source state of player 1/0 (r2, s2, s3, a2) for all states. This can be combined with target_as_source_for_opponent and use_opponents_actions.
