### PR TITLE
yargs: a command line augmentation using yaml

### DIFF
--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -4,7 +4,7 @@ from agents import AgentRegistry
 from arena import Arena
 from plugins.arena_yaml_recorder import ArenaYAMLRecorder
 from renderers import Renderer
-from utils import set_deterministic
+from utils import set_deterministic, yargs
 
 
 def player_with_params(arg):
@@ -63,27 +63,30 @@ if __name__ == "__main__":
         help="Initializes the random seed for the training. Default is 42",
     )
 
-    args = parser.parse_args()
+    args_dict = yargs(parser, "yargs/play")
 
-    set_deterministic(args.seed)
+    for id, args in args_dict.items():
+        if id:
+            print(f"====< Running {id} >====")
+        set_deterministic(args.seed)
 
-    renderers = [Renderer.create(r) for r in args.renderers]
+        renderers = [Renderer.create(r) for r in args.renderers]
 
-    saver = None
-    if args.games_output_filename != "None":
-        saver = ArenaYAMLRecorder(args.games_output_filename)
+        saver = None
+        if args.games_output_filename != "None":
+            saver = ArenaYAMLRecorder(args.games_output_filename)
 
-    players = AgentRegistry.names() if args.all else args.players
+        players = AgentRegistry.names() if args.all else args.players
 
-    arena_args = {
-        "board_size": args.board_size,
-        "max_walls": args.max_walls,
-        "step_rewards": args.step_rewards,
-        "renderers": renderers,
-        "saver": saver,
-    }
+        arena_args = {
+            "board_size": args.board_size,
+            "max_walls": args.max_walls,
+            "step_rewards": args.step_rewards,
+            "renderers": renderers,
+            "saver": saver,
+        }
 
-    arena_args = {k: v for k, v in arena_args.items() if v is not None}
-    arena = Arena(**arena_args)
+        arena_args = {k: v for k, v in arena_args.items() if v is not None}
+        arena = Arena(**arena_args)
 
-    arena.play_games(players, args.times)
+        arena.play_games(players, args.times)

--- a/deep_quoridor/src/utils/__init__.py
+++ b/deep_quoridor/src/utils/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["my_device", "parse_subargs", "resolve_path", "set_deterministic", "SubargsBase"]
+__all__ = ["my_device", "parse_subargs", "resolve_path", "set_deterministic", "SubargsBase", "yargs"]
 
-from utils.misc import my_device, resolve_path, set_deterministic
+from utils.misc import my_device, resolve_path, set_deterministic, yargs
 from utils.subargs import SubargsBase, parse_subargs

--- a/deep_quoridor/src/utils/misc.py
+++ b/deep_quoridor/src/utils/misc.py
@@ -1,10 +1,13 @@
+import argparse
 import random
+from glob import glob
 from pathlib import Path
 from typing import Optional
 
 import gymnasium.utils.seeding
 import numpy as np
 import torch
+import yaml
 
 
 def resolve_path(dir: str, filename: Optional[str] = None) -> Path:
@@ -35,3 +38,81 @@ def my_device():
         return torch.device("mps")
 
     return torch.device("cpu")
+
+
+def yargs(parser: argparse.ArgumentParser, default_path: str):
+    """
+    This function enhances the command line argument parsing by allowing arguments to be
+    specified in YAML configuration files. It supports both single file and directory inputs,
+    where multiple YAML configurations can be defined.
+
+    Args:
+        parser (argparse.ArgumentParser): The argument parser to augment with YAML support
+        default_path (str): The default path to look for YAML configuration files
+
+    Returns:
+        dict: A dictionary mapping configuration IDs to their parsed arguments. If no YAML
+            configuration is used, returns a dictionary with an empty string key and the
+            parsed command line arguments as value.
+
+    The function adds two optional arguments to the parser:
+        -yp/--yargs_path: Path to the YAML configuration file or directory (if none, the default_path will be used)
+        -yi/--yargs_ids: List of configuration IDs to run (if None, runs all configs)
+
+    Example yaml file:
+        benchmark_B5W3:
+            args: -t 100 -N 5 -W 3 --players greedy greedy:p_random=0.1,nick=greedy-ish
+        benchmark_B9W10:
+            args: -t 100 -N 9 -W 10 --players greedy greedy:p_random=0.1,nick=greedy-ish
+
+    Example calls from the command line:
+        # Execute all the entries in all the yaml files in default_path
+        python myapp.py -yp
+
+        # Execute all the entries in the file {default_path}/agent_benchmark.yaml
+        python myapp.py -yp agent_benchmark.yaml
+
+        # Execute the entries benchmark_B5W3 benchmark_B9W10 (should be found in the files in the default_path)
+        python myapp.py -yi benchmark_B5W3 benchmark_B9W10
+
+    """
+    parser.add_argument(
+        "-yp",
+        "--yargs_path",
+        nargs="?",
+        default=None,
+        const="",
+        help=f"File name to read the yaml configuration, relative to {default_path}",
+    )
+    parser.add_argument(
+        "-yi",
+        "--yargs_ids",
+        nargs="+",
+        default=None,
+        help="List of ids to run",
+    )
+
+    args = parser.parse_args()
+    if args.yargs_path is None and args.yargs_ids is None:
+        # Not using yargs
+        return {"": args}
+
+    if args.yargs_path is None:
+        path = Path(default_path)
+    else:
+        path = Path(default_path) / args.yargs_path
+
+    if path.is_dir():
+        files = glob(str(path / "*.yaml"))
+    else:
+        files = [str(path)]
+
+    args_dict = {}
+    for file in files:
+        with open(file, "r") as f:
+            file_dict = yaml.load(f, Loader=yaml.FullLoader)
+            for k, v in file_dict.items():
+                if args.yargs_ids is None or k in args.yargs_ids:
+                    args_dict[k] = parser.parse_args(v["args"].split(" "))
+
+    return args_dict

--- a/deep_quoridor/src/utils/misc.py
+++ b/deep_quoridor/src/utils/misc.py
@@ -78,7 +78,7 @@ def yargs(parser: argparse.ArgumentParser, default_path: str):
     """
     parser.add_argument(
         "-yp",
-        "--yargs_path",
+        "--yargs-path",
         nargs="?",
         default=None,
         const="",
@@ -86,7 +86,7 @@ def yargs(parser: argparse.ArgumentParser, default_path: str):
     )
     parser.add_argument(
         "-yi",
-        "--yargs_ids",
+        "--yargs-ids",
         nargs="+",
         default=None,
         help="List of ids to run",

--- a/yargs/play/agent_benchmark.yaml
+++ b/yargs/play/agent_benchmark.yaml
@@ -1,0 +1,5 @@
+benchmark_B5W3:
+  args: -t 100 -N 5 -W 3 --players greedy greedy:p_random=0.1,nick=greedy-ish sb3ppo:wandb_alias=latest dexp:wandb_alias=best
+
+benchmark_B9W10:
+  args: -t 100 --players greedy greedy:p_random=0.1,nick=greedy-ish dexp:wandb_alias=latest

--- a/yargs/play/demo.yaml
+++ b/yargs/play/demo.yaml
@@ -1,0 +1,2 @@
+human_vs_greedy:
+  args: -t 1 -r pygame --players human greedy


### PR DESCRIPTION
Passing all the arguments to play.py or train.py is getting out of control.
This allows us to store configurations in yaml file, and then we can run them just by referencing the ids or the file name.
We could easily incorporate this in train.py.
We can also extend it in the future, e.g.:
- adding tags, so you can run all the entries with a certain tag
- allowing to override parameters from the command line

For example, with the current setup, you could play human vs greedy just by doing:
```
 python deep_quoridor/src/play.py -yi human_vs_greedy
```

I also started collecting our "benchmarks" (we can later log them in wandb) in the `agent_benchmark.yaml` file, so now you can run them all as follows:

```
deep_rabbit_hole % python deep_quoridor/src/play.py -yp agent_benchmark.yaml
====< Running benchmark_B5W3 >====
Loading pre-trained model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/dexp_B5W3_mv1_6c57b.pt
Progress: [========------------------------------------------] 16.7% (100/600)Loaded model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/sb3ppo_B5W3_mv0_cd5f0.zip
/home/julian/aaae/deep-rabbit-hole/code/deep_rabbit_hole/deep_quoridor/src/train_sb3.py:45: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
Progress: [==================================================] 100.0% (600/600)
Arena stats
===========
Board size:  5
Max walls:  3
Step rewards:  False
Total number of games:  600

+------------+------------+--------+------------+--------+--------+
|  P1 \ P2   | dexp (111) | greedy | greedy-ish | sb3ppo | Total  |
+------------+------------+--------+------------+--------+--------+
| dexp (111) |     -      |  86%   |    74%     |  100%  |  87%   |
|   greedy   |     8%     |   -    |    100%    |  100%  |  69%   |
| greedy-ish |    20%     |  74%   |     -      |  100%  |  65%   |
|   sb3ppo   |     2%     |   0%   |     0%     |   -    |   1%   |
|   ======   |   ======   | ====== |   ======   | ====== | ====== |
|   Total    |    10%     |  53%   |    58%     |  100%  |  55%   |
+------------+------------+--------+------------+--------+--------+
====< Running benchmark_B9W10 >====
Loading pre-trained model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/dexp_B9W10_mv1_377a4.pt
Progress: [==================================================] 100.0% (300/300)
Arena stats
===========
Board size:  9
Max walls:  10
Step rewards:  False
Total number of games:  300

+------------+------------+--------+------------+--------+
|  P1 \ P2   | dexp (000) | greedy | greedy-ish | Total  |
+------------+------------+--------+------------+--------+
| dexp (000) |     -      |   0%   |     0%     |   0%   |
|   greedy   |    100%    |   -    |    94%     |  97%   |
| greedy-ish |    100%    |  22%   |     -      |  61%   |
|   ======   |   ======   | ====== |   ======   | ====== |
|   Total    |    100%    |  11%   |    47%     |  53%   |
+------------+------------+--------+------------+--------+
```