### PR TITLE
Multiple minor fixes

### DIFF
--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -52,6 +52,7 @@ class TrainableAgentParams(SubargsBase):
 
     def training_only_params(cls) -> set[str]:
         """Returns a set of parameter names that are only used during training."""
+        # TODO: we should ideally have two set of params: one for training and one for inference
         return {
             "epsilon",
             "epsilon_min",
@@ -159,12 +160,11 @@ class AbstractTrainableAgent(Agent):
             ## TODO: Revisit this since it won't work for the case in which
             ## opponents actions are used
             if self.assign_negative_reward:
-                if self.assign_negative_reward:
-                    if len(self.replay_buffer) > 0:
-                        last = self.replay_buffer.get_last()
-                        last[2] = reward  # update final reward
-                        last[4] = 1.0  # mark as done
-                        return reward
+                if len(self.replay_buffer) > 0:
+                    last = self.replay_buffer.get_last()
+                    last[2] = reward  # update final reward
+                    last[4] = 1.0  # mark as done
+                    return reward
             return 0
 
         state_before_action = self.observation_to_tensor(observation_before_action, player_id)

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -50,6 +50,23 @@ class TrainableAgentParams(SubargsBase):
     # If True, the target q-value function will substract maxq_a'(s', a') instead of adding it
     use_negative_qvalue_function: bool = False
 
+    def training_only_params(cls) -> set[str]:
+        """Returns a set of parameter names that are only used during training."""
+        return {
+            "epsilon",
+            "epsilon_min",
+            "epsilon_decay",
+            "gamma",
+            "batch_size",
+            "update_target_every",
+            "assign_negative_reward",
+            "training_mode",
+            "final_reward_multiplier",
+            "use_negative_qvalue_function",
+            "wandb_dir",
+            "model_dir",
+        }
+
 
 class AbstractTrainableAgent(Agent):
     """Base class for trainable agents using neural networks."""
@@ -141,12 +158,14 @@ class AbstractTrainableAgent(Agent):
         if action is None:
             ## TODO: Revisit this since it won't work for the case in which
             ## opponents actions are used
-            if self.assign_negative_reward and len(self.replay_buffer) > 0:
-                last = self.replay_buffer.get_last()
-                last[2] = reward  # update final reward
-                last[4] = 1.0  # mark as done
-                self.current_episode_reward += reward
-            return reward
+            if self.assign_negative_reward:
+                if self.assign_negative_reward:
+                    if len(self.replay_buffer) > 0:
+                        last = self.replay_buffer.get_last()
+                        last[2] = reward  # update final reward
+                        last[4] = 1.0  # mark as done
+                        return reward
+            return 0
 
         state_before_action = self.observation_to_tensor(observation_before_action, player_id)
         state_after_action = self.observation_to_tensor(game.observe(player_id), player_id)
@@ -395,7 +414,13 @@ class AbstractTrainableAgent(Agent):
         artifact = api.artifact(f"the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}", type="model")
         local_filename = resolve_path(self.params.wandb_dir, self.wandb_local_filename(artifact))
 
-        self.params = self.params_class()(**artifact.metadata)
+        all_params = self.params_class()(**artifact.metadata)
+
+        # Override params, but only the ones that are not training only
+        for key, value in artifact.metadata.items():
+            if key not in all_params.training_only_params():
+                setattr(self.params, key, value)
+
         self.params.model_filename = str(local_filename)
 
         if os.path.exists(local_filename):

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -98,10 +98,6 @@ class DExpAgent(AbstractTrainableAgent):
     ):
         super().__init__(params=params, **kwargs)
         self.check_congiguration()
-        # Print all parameters, including those from the parent class
-        print("All parameters:")
-        for param_name, param_value in self.params.__dict__.items():
-            print(f"  {param_name}: {param_value}")
 
     def name(self):
         if self.params.nick:

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -67,6 +67,16 @@ class DExpAgentParams(TrainableAgentParams):
     def __str__(self):
         return f"{int(self.rotate)}{int(self.turn)}{int(self.split)}"
 
+    def training_only_params(cls) -> set[str]:
+        """
+        Returns a set of parameters that are used only during training.
+        These parameters should not be used during playing.
+        """
+        return super().training_only_params() | {
+            "use_opponents_actions",
+            "target_as_source_for_opponent",
+        }
+
 
 class DExpAgent(AbstractTrainableAgent):
     """Diego experimental Agent using DRL."""
@@ -88,6 +98,10 @@ class DExpAgent(AbstractTrainableAgent):
     ):
         super().__init__(params=params, **kwargs)
         self.check_congiguration()
+        # Print all parameters, including those from the parent class
+        print("All parameters:")
+        for param_name, param_value in self.params.__dict__.items():
+            print(f"  {param_name}: {param_value}")
 
     def name(self):
         if self.params.nick:

--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -7,8 +7,8 @@ from stable_baselines3.common.torch_layers import FlattenExtractor
 from agents.core.agent import ActionLog, Agent, AgentRegistry
 from agents.core.rotation import convert_rotated_action_index_to_original
 from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentParams
-from deep_quoridor.src.environment.dict_split_board_wrapper import DictSplitBoardWrapper
-from deep_quoridor.src.environment.rotate_wrapper import RotateWrapper
+from environment.dict_split_board_wrapper import DictSplitBoardWrapper
+from environment.rotate_wrapper import RotateWrapper
 
 
 class SB3ActionMaskWrapper(BaseWrapper):

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -66,6 +66,7 @@ class WandbTrainPlugin(ArenaPlugin):
         artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
         artifact.add_file(local_path=str(save_file))
         artifact.save()
+        print("Model being uploaded to wandb")
         wandb.log_artifact(artifact).wait()
         print(f"Model uploaded with version {artifact.version}")
 

--- a/deep_quoridor/src/renderers/training_status.py
+++ b/deep_quoridor/src/renderers/training_status.py
@@ -18,7 +18,7 @@ class TrainingStatusRenderer(Renderer):
     def end_game(self, game, result):
         if self.episode_count % self.update_every == 0:
             for agent in self.agents:
-                if not isinstance(agent, AbstractTrainableAgent):
+                if not isinstance(agent, AbstractTrainableAgent) or not agent.training_mode:
                     continue
                 agent_name = agent.name()
                 avg_loss, avg_reward = agent.compute_loss_and_reward(self.update_every)


### PR DESCRIPTION
- Avoids loading training params when loading a model. During play those should not be used, and if training, new params should be passed.
- Fix negative rewards that was a TODO and was broken from previous PR. 
- Fix import that is using src.deep_quoridor to match current style being used.
- Fix training status renderer to skip agents if they are not in training mode.