### PR TITLE
Elo computation and renderer

### DIFF
--- a/deep_quoridor/src/renderers/__init__.py
+++ b/deep_quoridor/src/renderers/__init__.py
@@ -25,6 +25,7 @@ __all__ = [
     "ArenaResults2Renderer",
     "ArenaResultsRenderer",
     "CursesBoardRenderer",
+    "EloResultsRenderer",
     "MatchResultsRenderer",
     "NoneRenderer",
     "ProgressBarRenderer",
@@ -38,6 +39,7 @@ __all__ = [
 from renderers.arena_results import ArenaResultsRenderer  # noqa: E402, F401
 from renderers.arena_results2 import ArenaResults2Renderer  # noqa: E402, F401
 from renderers.curses_board import CursesBoardRenderer  # noqa: E402, F401
+from renderers.elo_results import EloResultsRenderer  # noqa: E402, F401
 from renderers.match_results import MatchResultsRenderer  # noqa: E402, F401
 from renderers.none import NoneRenderer  # noqa: E402, F401
 from renderers.progress_bar import ProgressBarRenderer  # noqa: E402, F401

--- a/deep_quoridor/src/renderers/elo_results.py
+++ b/deep_quoridor/src/renderers/elo_results.py
@@ -1,0 +1,18 @@
+from arena import GameResult
+from prettytable import PrettyTable
+from utils import compute_elo
+
+from renderers import Renderer
+
+
+class EloResultsRenderer(Renderer):
+    def end_arena(self, game, results: list[GameResult]):
+        ratings = compute_elo(results)
+        table = PrettyTable()
+        table.field_names = ["Player", "Elo Rating"]
+
+        sorted_ratings = sorted(ratings.items(), key=lambda x: x[1], reverse=True)
+        for player, rating in sorted_ratings:
+            table.add_row([player, f"{int(rating)}"])
+
+        print(table)

--- a/deep_quoridor/src/utils/__init__.py
+++ b/deep_quoridor/src/utils/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ["my_device", "parse_subargs", "resolve_path", "set_deterministic", "SubargsBase", "yargs"]
 
-from utils.misc import my_device, resolve_path, set_deterministic, yargs
+from utils.misc import compute_elo, my_device, resolve_path, set_deterministic, yargs
 from utils.subargs import SubargsBase, parse_subargs

--- a/yargs/play/agent_benchmark.yaml
+++ b/yargs/play/agent_benchmark.yaml
@@ -1,5 +1,5 @@
 benchmark_B5W3:
-  args: -t 100 -N 5 -W 3 --players greedy greedy:p_random=0.1,nick=greedy-01 greedy:p_random=0.3,nick=greedy-03 sb3ppo:wandb_alias=latest dexp:wandb_alias=best simple
+  args: -t 100 -N 5 -W 3 --players random greedy greedy:p_random=0.1,nick=greedy-01 greedy:p_random=0.3,nick=greedy-03 sb3ppo:wandb_alias=latest dexp:wandb_alias=best simple -r progressbar arenaresults eloresults
 
 benchmark_B9W10:
-  args: -t 100 --players greedy greedy:p_random=0.1,nick=greedy-ish dexp:wandb_alias=latest
+  args: -t 100 --players greedy greedy:p_random=0.1,nick=greedy-ish dexp:wandb_alias=latest -r progressbar arenaresults eloresults


### PR DESCRIPTION
Defines a method to compute the elo rating from the results, and uses it in a renderer.
In a future PR I'll use this to get the score of the agent that we're training and log it in wandb.  For now, I think it's interesting to see the scores.  E.g.:

```
% python deep_quoridor/src/play.py -yi benchmark_B5W3
.....
+-------------+-------------+--------+-----------+-----------+--------+--------+--------+--------+
|   P1 \ P2   | dexp (1011) | greedy | greedy-01 | greedy-03 | random | sb3ppo | simple | Total  |
+-------------+-------------+--------+-----------+-----------+--------+--------+--------+--------+
| dexp (1011) |      -      |  100%  |    90%    |    74%    |  82%   |  100%  |  82%   |  88%   |
|    greedy   |      0%     |   -    |    100%   |    98%    |  100%  |  100%  |  100%  |  83%   |
|  greedy-01  |     14%     |  78%   |     -     |    94%    |  98%   |  100%  |  100%  |  81%   |
|  greedy-03  |     22%     |  30%   |    34%    |     -     |  100%  |  92%   |  100%  |  63%   |
|    random   |     18%     |   0%   |     0%    |     2%    |   -    |  44%   |  22%   |  14%   |
|    sb3ppo   |      0%     |   0%   |     2%    |    20%    |  52%   |   -    |  32%   |  18%   |
|    simple   |     22%     |   0%   |     4%    |     2%    |  58%   |  34%   |   -    |  20%   |
|    ======   |    ======   | ====== |   ======  |   ======  | ====== | ====== | ====== | ====== |
|    Total    |     13%     |  35%   |    38%    |    48%    |  82%   |  78%   |  73%   |  52%   |
+-------------+-------------+--------+-----------+-----------+--------+--------+--------+--------+
+-------------+------------+
|    Player   | Elo Rating |
+-------------+------------+
| dexp (1011) |    1962    |
|    greedy   |    1758    |
|  greedy-01  |    1756    |
|  greedy-03  |    1527    |
|    simple   |    1250    |
|    sb3ppo   |    1191    |
|    random   |    1054    |
+-------------+------------+
```