### PR TITLE
Integrate elo ratings in wandb

### DIFF
--- a/deep_quoridor/src/agents/core/agent.py
+++ b/deep_quoridor/src/agents/core/agent.py
@@ -121,7 +121,7 @@ class AgentRegistry:
         return AgentRegistry.agents[friendly_name](**kwargs)
 
     @staticmethod
-    def create_from_encoded_name(encoded_name: str, **kwargs) -> Agent:
+    def create_from_encoded_name(encoded_name: str, remove_training_args=False, **kwargs) -> Agent:
         parts = encoded_name.split(":")
         agent_type = parts[0]
         if len(parts) == 1:
@@ -132,7 +132,10 @@ class AgentRegistry:
         if subargs_class is None:
             raise ValueError(f"The agent {agent_type} doesn't support subarguments, but '{parts[1]}' was passed")
 
-        subargs = parse_subargs(parts[1], subargs_class)
+        if remove_training_args:
+            subargs = parse_subargs(parts[1], subargs_class, ignore_fields=subargs_class.training_only_params())
+        else:
+            subargs = parse_subargs(parts[1], subargs_class)
 
         return AgentRegistry.agents[agent_type](params=subargs, **kwargs)
 

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -58,6 +58,7 @@ class TrainableAgentParams(SubargsBase):
     # This is used to log the opponent's possible actions based on agent's qvalues
     inspect_opponent_possible_actions: bool = False
 
+    @classmethod
     def training_only_params(cls) -> set[str]:
         """Returns a set of parameter names that are only used during training."""
         # TODO: we should ideally have two set of params: one for training and one for inference
@@ -75,8 +76,6 @@ class TrainableAgentParams(SubargsBase):
             "use_negative_qvalue_function",
             "wandb_dir",
             "model_dir",
-            "wandb_alias",
-            "model_filename",
             "mask_targetq",
             "softmax_exploration",
             "inspect_opponent_possible_actions",

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -144,6 +144,8 @@ class AbstractTrainableAgent(Agent):
         self.player_id = player_id
 
     def end_game(self, game):
+        if not self.training_mode:
+            return
         """Store episode results and reset tracking"""
         self.episodes_rewards.append(self.current_episode_reward)
         self.games_count += 1

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -69,6 +69,7 @@ class DExpAgentParams(TrainableAgentParams):
     def __str__(self):
         return f"{int(self.rotate)}{int(self.turn)}{int(self.split)}{'1' if self.target_as_source_for_opponent else ''}"
 
+    @classmethod
     def training_only_params(cls) -> set[str]:
         """
         Returns a set of parameters that are used only during training.

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -97,7 +97,7 @@ class Arena:
         return result
 
     # Replace the existing _play_games method
-    def _play_games(self, players: list[str | Agent], times: int, mode: PlayMode):
+    def _play_games(self, players: list[str | Agent], times: int, mode: PlayMode) -> list[GameResult]:
         agents = []
         for p in players:
             if isinstance(p, Agent):
@@ -144,6 +144,7 @@ class Arena:
                     match_id += 1
 
         self.plugins.end_arena(self.game, results)
+        return results
 
     def _replay_games(self, arena_data: dict, game_ids_to_replay: list[str]):
         """Replays a series of games from previously recorded arena data.

--- a/deep_quoridor/src/metrics.py
+++ b/deep_quoridor/src/metrics.py
@@ -1,0 +1,95 @@
+from agents import AbstractTrainableAgent, Agent
+from agents.core.agent import AgentRegistry
+from arena import Arena, PlayMode
+from arena_utils import GameResult
+from utils.misc import compute_elo
+
+
+class Metrics:
+    """
+    Computes metrics for an agent by making it play against other agents.
+    """
+
+    def __init__(self, board_size: int, max_walls: int):
+        self.board_size = board_size
+        self.max_walls = max_walls
+        self.stored_elos = {}
+
+    def _win_perc(self, results: list[GameResult], agent_name: str):
+        played = 0
+        won = 0
+        for result in results:
+            if result.player1 == agent_name or result.player2 == agent_name:
+                played += 1
+
+            if result.winner == agent_name:
+                won += 1
+
+        return 100.0 * won / played if played > 1 else 0.0
+
+    def _compute_relative_elo(self, elo_table: dict[str, float], agent_name: str) -> int:
+        agent_rating = elo_table[agent_name]
+        best_opponent = 0
+        for name, elo in elo_table.items():
+            if name != agent_name:
+                best_opponent = max(best_opponent, elo)
+
+        return int(agent_rating - best_opponent)
+
+    def compute(self, agent: str | Agent) -> tuple[int, dict[str, float], int, float]:
+        """
+        Evaluates the performance of a given agent by running it against a set of predefined opponents and computing its Elo rating and win percentage.
+
+        Args:
+            agent (str | Agent): The agent to evaluate, specified either as a string identifier or an Agent instance.
+
+        Returns:
+            tuple[int, dict[str, float], int, float]: A tuple containing:
+                - VERSION (int): The version number of the scoring method.
+                - elo_table (dict[str, float]): A dictionary mapping agent names to their computed Elo ratings.
+                - relative_elo (int): The evaluated agent's Elo rating minus the elo for the best opponent.
+                - win_perc (float): The win percentage of the evaluated agent against the opponents.
+
+        Notes:
+            - The method disables training mode for trainable agents during evaluation and restores it afterward.
+            - Opponent Elo ratings are cached to avoid redundant computations.
+            - The evaluation is performed using a fixed set of baseline agents and a specified number of games.
+        """
+        # Bump if there's any change in the scoring
+        VERSION = 1
+        times = 50
+
+        players: list[str | Agent] = [
+            "greedy",
+            "greedy:p_random=0.1,nick=greedy-01",
+            "greedy:p_random=0.3,nick=greedy-03",
+            "greedy:p_random=0.5,nick=greedy-05",
+        ]
+
+        if isinstance(agent, str):
+            agent = AgentRegistry.create_from_encoded_name(agent, board_size=self.board_size, max_walls=self.max_walls)
+
+        # Make sure the agent is not in training mode to do the evaluation
+        if isinstance(agent, AbstractTrainableAgent):
+            prev_training_mode = agent.training_mode
+            agent.training_mode = False
+
+        arena = Arena(self.board_size, self.max_walls)
+
+        # We store the elos of the opponents playing against each other so we don't have to play those matches
+        # every time
+        if not self.stored_elos:
+            results = arena._play_games(players, times, PlayMode.ALL_VS_ALL)
+            self.stored_elos = compute_elo(results)
+
+        results = arena._play_games([agent] + players, times, PlayMode.FIRST_VS_RANDOM)
+
+        if isinstance(agent, AbstractTrainableAgent):
+            agent.training_mode = prev_training_mode
+
+        elo_table = compute_elo(results, initial_elos=self.stored_elos.copy())
+        relative_elo = self._compute_relative_elo(elo_table, agent.name())
+
+        win_perc = self._win_perc(results, agent.name())
+
+        return VERSION, elo_table, relative_elo, win_perc

--- a/deep_quoridor/src/plugins/save_model.py
+++ b/deep_quoridor/src/plugins/save_model.py
@@ -1,3 +1,5 @@
+from typing import Callable, Optional
+
 from agents.core import AbstractTrainableAgent
 from arena_utils import ArenaPlugin
 from utils import resolve_path
@@ -11,6 +13,7 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
         max_walls: int,
         save_final: bool = True,
         run_id: str = "",
+        after_save: Optional[Callable[[str], None]] = None,
     ):
         self.update_every = update_every
         self.episode_count = 0
@@ -18,6 +21,7 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
         self.max_walls = max_walls
         self.save_final = save_final
         self.run_id = run_id
+        self.after_save = after_save
 
     def start_game(self, game, agent1, agent2):
         self.agents = [agent1, agent2]
@@ -39,3 +43,6 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
             save_file = resolve_path(agent.params.model_dir, agent.resolve_filename(suffix))
             agent.save_model(save_file)
             print(f"{agent_name} Model saved to {save_file}")
+
+            if self.after_save:
+                self.after_save(str(save_file))

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -14,17 +14,23 @@ def train_dqn(
     episodes: int,
     board_size: int,
     max_walls: int,
-    save_frequency: int = 100,
+    save_frequency: int,
+    tournament_frequency: int,
     step_rewards: bool = True,
     use_wandb: bool = True,
-    players: list | None = None,
+    players: list = [],
     renderers: list[ArenaPlugin] = [],
     run_id: str = "",
 ):
     plugins = []
+    total_episodes = episodes * (len(players) - 1)
 
     if use_wandb:
-        plugins.append(WandbTrainPlugin(update_every=100, total_episodes=episodes, run_id=run_id))
+        plugins.append(
+            WandbTrainPlugin(
+                update_every=10, tournament_frequency=tournament_frequency, total_episodes=total_episodes, run_id=run_id
+            )
+        )
 
     plugins.append(
         SaveModelEveryNEpisodesPlugin(
@@ -36,10 +42,7 @@ def train_dqn(
         )
     )
 
-    print_plugin = TrainingStatusRenderer(
-        update_every=1,
-        total_episodes=episodes * (len(players) - 1),
-    )
+    print_plugin = TrainingStatusRenderer(update_every=1, total_episodes=total_episodes)
     arena = Arena(
         board_size=board_size,
         max_walls=max_walls,
@@ -63,6 +66,13 @@ if __name__ == "__main__":
     parser.add_argument("-sp", "--save_path", type=str, default="models", help="Directory to save models")
     parser.add_argument(
         "-f", "--save_frequency", type=int, default=500, help="How often to save the model (in episodes)"
+    )
+    parser.add_argument(
+        "-tf",
+        "--tournament_frequency",
+        type=int,
+        default=500,
+        help="How often to run a tournament to compute elo and win percentage (in episodes)",
     )
     parser.add_argument(
         "-i",
@@ -129,6 +139,7 @@ if __name__ == "__main__":
         board_size=args.board_size,
         max_walls=args.max_walls,
         save_frequency=args.save_frequency,
+        tournament_frequency=args.tournament_frequency,
         step_rewards=args.step_rewards,
         use_wandb=args.no_wandb,
         players=args.players,

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -25,12 +25,13 @@ def train_dqn(
     plugins = []
     total_episodes = episodes * (len(players) - 1)
 
+    after_save_method = None
     if use_wandb:
-        plugins.append(
-            WandbTrainPlugin(
-                update_every=10, tournament_frequency=tournament_frequency, total_episodes=total_episodes, run_id=run_id
-            )
+        wandb_plugin = WandbTrainPlugin(
+            update_every=10, total_episodes=total_episodes, run_id=run_id, agent_encoded_name=players[0]
         )
+        plugins.append(wandb_plugin)
+        after_save_method = wandb_plugin.compute_tournament_metrics
 
     plugins.append(
         SaveModelEveryNEpisodesPlugin(
@@ -39,6 +40,7 @@ def train_dqn(
             max_walls=max_walls,
             save_final=not use_wandb,
             run_id=run_id,
+            after_save=after_save_method,
         )
     )
 

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -15,7 +15,6 @@ def train_dqn(
     board_size: int,
     max_walls: int,
     save_frequency: int,
-    tournament_frequency: int,
     step_rewards: bool = True,
     use_wandb: bool = True,
     players: list = [],
@@ -68,13 +67,6 @@ if __name__ == "__main__":
     parser.add_argument("-sp", "--save_path", type=str, default="models", help="Directory to save models")
     parser.add_argument(
         "-f", "--save_frequency", type=int, default=500, help="How often to save the model (in episodes)"
-    )
-    parser.add_argument(
-        "-tf",
-        "--tournament_frequency",
-        type=int,
-        default=500,
-        help="How often to run a tournament to compute elo and win percentage (in episodes)",
     )
     parser.add_argument(
         "-i",
@@ -141,7 +133,6 @@ if __name__ == "__main__":
         board_size=args.board_size,
         max_walls=args.max_walls,
         save_frequency=args.save_frequency,
-        tournament_frequency=args.tournament_frequency,
         step_rewards=args.step_rewards,
         use_wandb=args.no_wandb,
         players=args.players,

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -24,7 +24,7 @@ def train_dqn(
     plugins = []
 
     if use_wandb:
-        plugins.append(WandbTrainPlugin(update_every=10, total_episodes=episodes, run_id=run_id))
+        plugins.append(WandbTrainPlugin(update_every=100, total_episodes=episodes, run_id=run_id))
 
     plugins.append(
         SaveModelEveryNEpisodesPlugin(

--- a/deep_quoridor/src/utils/misc.py
+++ b/deep_quoridor/src/utils/misc.py
@@ -118,8 +118,8 @@ def yargs(parser: argparse.ArgumentParser, default_path: str):
     return args_dict
 
 
-def compute_elo(results: list["GameResult"], k=32, initial_rating=1500) -> dict[str, float]:
-    ratings = {}
+def compute_elo(results: list["GameResult"], k=32, initial_rating=1500, initial_elos={}) -> dict[str, float]:
+    ratings = initial_elos
     random.shuffle(results)
 
     for result in results:

--- a/deep_quoridor/src/utils/subargs.py
+++ b/deep_quoridor/src/utils/subargs.py
@@ -23,7 +23,7 @@ class ParseSubargsError(ValueError):
     pass
 
 
-def parse_subargs(s: str, cls: Type[SubargsBase], separator=",", assign="="):
+def parse_subargs(s: str, cls: Type[SubargsBase], separator=",", assign="=", ignore_fields=set()):
     """Parses the string s and uses it to instantiate a class cls and return it."""
     if s == "":
         return cls()
@@ -35,6 +35,9 @@ def parse_subargs(s: str, cls: Type[SubargsBase], separator=",", assign="="):
             raise ParseSubargsError(f"The subargument '{part}' needs to have an assignment using '{assign}'")
 
         k, v = part.split(assign)
+        if k in ignore_fields:
+            continue
+
         if k not in class_fields:
             raise ParseSubargsError(
                 f"Field '{k}' not in class {cls.__name__}.  Available fields are: {', '.join(class_fields.keys())}"


### PR DESCRIPTION
When training an agent, send the elo rating and the win percentage to wandb, so we can have a single number (or two) of how it is performing.
The whole elo table is sent to wandb every interval, but the tables are clunky and I still haven't figured out how they work.
It also sends what I call the "relative elo" score, which is the score the agent got minus the score of the best opponent.  The rationale behind this is the following: we want to have information on how good the model is performing with just 1 number, but if we just see our agent's elo rating, it's hard to draw conclusions.  Is an elo rating of 1800 good? well, it depends, if a few other agents are above 1800 it's not that great, but if everyone is below 1800 it looks much better.
So, if the relative elo is positive, it means that the agent is in the first position.  A relative elo score of 200 would indicate for example that our agent has about 75% chances of beating the second one, and a score of 400 would indicate 91% chances.
When the score is negative, we know the agent is not the best.

I'm also logging the win percentage, that has the same shape than the relative elo, so we may end up just using the win percentage.  The main difference is that the elo takes into account how good the adversaries are, e.g. you get your elo increased more if you beat an adversary with higher elo, so winning against greedy is more significant than winning against random.

The win_perc has the advantage that if it reaches 100%, you know that you topped the metric, so you won't be trying to improve it without devising a harder metric first.  With elo score, you may think you still have room for improvement because there's no ceiling.

I'm currently running this training (copied from the command line from `dexp_B5W3_mv2:v15`, but added epsilon_min and reduced the number of episodes):

```
 /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py  -N 5 -W 3 -e 500 -i 43 -p dexp:rotate=true,split=true,turn=false,epsilon=1,epsilon_decay=0.9985,epsilon_min=0.1,final_reward_multiplier=20,training_mode=true,use_opponents_actions=true,update_target_every=100,gamma=0.95,target_as_source_for_opponent=true,use_negative_qvalue_function=true,batch_size=128,mask_targetq=true,nick=dexp_train greedy:p_random=0.3 greedy:p_random=0.1 simple -rp cucu -s
```

And this is what I got so far ([link to the run](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/cucu-20250423-164800)):
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/a71c94f3-5e03-4a1c-a2dd-346a497428d3" />
