### PR TITLE
Performance improvement by moving .to(device)

### DIFF
--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -380,12 +380,12 @@ class AbstractTrainableAgent(Agent):
         """Prepare batch data for training."""
         states, actions, rewards, next_states, dones, next_state_masks = zip(*batch)
 
-        states = torch.stack([torch.FloatTensor(s).to(self.device) for s in states])
+        states = torch.stack([torch.FloatTensor(s) for s in states]).to(self.device)
         actions = torch.LongTensor(actions).to(self.device).unsqueeze(1)
         rewards = torch.FloatTensor(rewards).to(self.device)
-        next_states = torch.stack([torch.FloatTensor(s).to(self.device) for s in next_states])
+        next_states = torch.stack([torch.FloatTensor(s) for s in next_states]).to(self.device)
         dones = torch.FloatTensor(dones).to(self.device)
-        next_state_masks = torch.stack([torch.FloatTensor(s).to(self.device) for s in next_state_masks])
+        next_state_masks = torch.stack([torch.FloatTensor(s) for s in next_state_masks]).to(self.device)
 
         return states, actions, rewards, next_states, dones, next_state_masks
 


### PR DESCRIPTION
tl;dr: big performance increase with a trivial change in 3 lines of code.

I was curious about what was making the training so slow, so I used cprofile and I what I found was not at all what I expected!

E.g. when running
```
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py  -N 7 -W 7 -e 20 -i 43 -p dexp:rotate=true,split=true,turn=false,epsilon=1,epsilon_decay=0.9999,epsilon_min=0.1,final_reward_multiplier=20,training_mode=true,use_opponents_actions=true,update_target_every=100,gamma=0.95,target_as_source_for_opponent=true,use_negative_qvalue_function=true,batch_size=128,mask_targetq=true,nick=dexp_train greedy:p_random=0.3 greedy:p_random=0.1 greedy:p_random=0.7 -rp cucu -s
```

I got:

```
         22207775 function calls (21385738 primitive calls) in 692.055 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 80554/63  221.463    0.003    0.239    0.004 {method 'acquire' of '_thread.lock' objects}
        1  215.263  215.263  215.263  215.263 serialization.py:1120(_save)
   765850  137.772    0.000  137.772    0.000 {method 'to' of 'torch._C.TensorBase' objects}
    21650   50.333    0.002   50.333    0.002 {method 'item' of 'torch._C.TensorBase' objects}
      287   38.284    0.133   38.310    0.133 {method 'recv' of '_socket.socket' objects}
     1968    4.273    0.002  138.283    0.070 trainable_agent.py:379(_prepare_batch)
```

So, it takes forever to serialize (I initially thought it's just wandb throtling upload speed), but also, it caught my attention that the method "to" is using 137s of total time.  Of all the complex things we're doing, copying the data to the gpu seems to be significantly problematic!
The last entry pointed me to the problem: `_prepare_batch` has a big cumtime just slightly more than `to`.  By looking at the code, I thought that the problem may be that we move each tensor to the gpu and then we stack it, so we're doing a bunch of moves (not sure if we're bringing  it back in order to stack).  So, I changed it to stack them first and then send to a device (which is this PR), and when running exactly the same training I got this:

```
Training completed!
         21447297 function calls (20626312 primitive calls) in 137.897 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1   66.609   66.609   66.609   66.609 serialization.py:1120(_save)
    21650   40.273    0.002   40.273    0.002 {method 'item' of 'torch._C.TensorBase' objects}
    16042    4.192    0.000    4.192    0.000 {method 'to' of 'torch._C.TensorBase' objects}
     1968    1.981    0.001    4.849    0.002 trainable_agent.py:379(_prepare_batch)
```

So, I have no idea why, but the top line for `acquire` dissapeared or moved way back, and I can see that the upload is very fast.   Maybe wandb is using threads that are blocked by moving data between cpu and gpu? 
In any case, the method `to` came down from 137s to 4s, and the overall time from 692s to 138s!
I did this with few episodes (150), so of course with more episodes the effects of the saving would be less, but still each episode runs faster.  Also, it may be different how it runs on PC with GPUs (I'm running on Mac with MPS).  If someone wants to try running that command in main vs this PR I'd be curious to see the results.

Also, [here](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/cucu-20250423-230459/overview) is the run from main, which wandb reports that took 3m26s (which is a great number because my birthday is on 3/26!), and [here](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/cucu-20250423-230311/overview) is the run with this PR, which took 1m5s.


BTW, also the `item` method seems to be taking too long, I tried making some changes but nothing happened or it broke stuff, so I'll look more later.