### PR TITLE
Another fix for SB3PPO and added to new benchmark

### DIFF
--- a/deep_quoridor/src/agents/sb3_ppo.py
+++ b/deep_quoridor/src/agents/sb3_ppo.py
@@ -14,6 +14,8 @@ from agents.core.trainable_agent import AbstractTrainableAgent, TrainableAgentPa
 class SB3ActionMaskWrapper(BaseWrapper):
     """
     Wrapper to allow PettingZoo environments to be used with SB3 illegal action masking.
+    Taken from https://github.com/dm-ackerman/PettingZoo/blob/master/tutorials/SB3/connect_four/sb3_connect_four_action_mask.py
+
     In particular it adapts PettingZoo, since the Action Masking part of it is already implemented
     in SB3_contrib as the MaskablePPO.
     The required changes are minor:
@@ -54,7 +56,7 @@ class SB3ActionMaskWrapper(BaseWrapper):
         super().step(action)
 
         return (
-            self.observe(current_agent),
+            self.observe(self.agent_selection),
             self.rewards[current_agent] * self.rewards_multiplier,
             self.terminations[current_agent],
             self.truncations[current_agent],
@@ -64,15 +66,6 @@ class SB3ActionMaskWrapper(BaseWrapper):
     def observe(self, agent):
         """Return only raw observation, removing action mask."""
         obs = super().observe(agent)["observation"]
-        # # Take obs, which is a dict with some arrays, and convert it to a flat numpy array
-        # return np.concatenate(
-        #     [
-        #         obs["board"].flatten(),
-        #         obs["walls"][0].flatten(),
-        #         obs["walls"][1].flatten(),
-        #         [obs["my_walls_remaining"], obs["opponent_walls_remaining"]],
-        #     ]
-        # )
         return obs
 
     def action_mask(self):

--- a/yargs/play/agent_benchmark.yaml
+++ b/yargs/play/agent_benchmark.yaml
@@ -1,3 +1,6 @@
+benchmark_B3W0:
+  args: -t 100 -N 3 -W 0 --players greedy greedy:p_random=0.1,nick=greedy-ish random sb3ppo:wandb_alias=v3 -r progressbar arenaresults eloresults
+
 benchmark_B5W3:
   args: -t 100 -N 5 -W 3 --players random greedy greedy:p_random=0.1,nick=greedy-01 greedy:p_random=0.3,nick=greedy-03 sb3ppo:wandb_alias=latest dexp:wandb_alias=best simple -r progressbar arenaresults eloresults
 


### PR DESCRIPTION
Thanks to @muralx´s explanation, I understood why the PettingZoo tutorial was correct and adapted the SB3ActionMaskWrapper to match.

I also took the opportunity to try the agent benchmarks and added one for N3W0:

```
------------+------------+
|   Player   | Elo Rating |
+------------+------------+
|   greedy   |    1582    |
|   sb3ppo   |    1549    |
| greedy-ish |    1548    |
|   random   |    1318    |
+------------+------------+
```