### PR TITLE
Remove call to .item() for performance

### DIFF
--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -223,11 +223,11 @@ class AbstractTrainableAgent(Agent):
             if self.episodes_rewards
             else 0.0
         )
-        avg_loss = (
-            sum(self.train_call_losses[-length:]) / min(length, len(self.train_call_losses))
-            if self.train_call_losses
-            else 0.0
-        )
+        if self.train_call_losses:
+            losses = torch.stack(self.train_call_losses[-length:])
+            avg_loss = losses.mean().item()
+        else:
+            avg_loss = 0.0
 
         return avg_loss, avg_reward
 
@@ -416,7 +416,7 @@ class AbstractTrainableAgent(Agent):
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-        return loss.item()
+        return loss
 
     def _update_epsilon(self):
         """Update epsilon value for exploration."""


### PR DESCRIPTION
cProfile was showing that a significant amount of time was spent on calls to item().
I think it takes long because when the agent calls _update_network() we compute the loss and do a step, but this actually runs async in the gpu.  If we call `.item()` right away, the cpu is just waiting for the gpu to finish the computation, and that's why it takes some time to complete. 
In this PR, instead of calling it right away, since this is used only to compute the average loss, I remove the call to `.item()` so that the elements accumulated in `self.train_call_losses` are now tensors of 1 element instead of floats.  That way, the CPU thread can keep running and for example compute the move for the other agent before calling it again.
When the function `compute_loss_and_reward` is called, then we compute the mean that will require to sync, but this call happens less often and we gave it a bit more time to complete.

The saving is not huge, but I think it's worth for this simple change (and was interesting for me to potentially understand what's going on).  For faster GPUs the saving is going to be probably less.

I run this training with and without the optimization:
```
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py  -N 7 -W 7 -e 100 -i 43 -p dexp:rotate=true,split=true,turn=false,epsilon=1,epsilon_decay=0.9985,epsilon_min=0.1,final_reward_multiplier=20,training_mode=true,use_opponents_actions=true,update_target_every=100,gamma=0.95,target_as_source_for_opponent=true,use_negative_qvalue_function=true,batch_size=128,mask_targetq=true,nick=dexp_train greedy:p_random=0.3 greedy:p_random=0.1 simple -rp cucu-no-item -s
```

Without the optimization ([link](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/cucu-main-20250424-153452/overview)] it completed in 4m43s, and with the optimization ([link](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/cucu-no-item-20250424-154112/overview)) it took 4m14s