### PR TITLE
Fixing issues after new implementation

### DIFF
--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -161,6 +161,7 @@ class AbstractTrainableAgent(Agent):
         return "player_1" if player_id == "player_0" else "player_0"
 
     def handle_opponent_step_outcome(
+        self,
         opponent_observation_before_action,
         my_observation_after_opponent_action,
         opponent_observation_after_action,

--- a/deep_quoridor/src/agents/dexp.py
+++ b/deep_quoridor/src/agents/dexp.py
@@ -30,15 +30,13 @@ class DExpNetwork(nn.Module):
 
         # Define network architecture
         self.model = nn.Sequential(
-            nn.Linear(flat_input_size, 2048),
+            nn.Linear(flat_input_size, 1024),
             nn.ReLU(),
-            nn.Linear(2048, 4096),
+            nn.Linear(1024, 2048),
             nn.ReLU(),
-            nn.Linear(4096, 4096),
+            nn.Linear(2048, 1024),
             nn.ReLU(),
-            nn.Linear(4096, 2048),
-            nn.ReLU(),
-            nn.Linear(2048, action_size),
+            nn.Linear(1024, action_size),
         )
         self.model.to(my_device())
 
@@ -115,7 +113,7 @@ class DExpAgent(AbstractTrainableAgent):
 
     def version(self):
         """Bump this version when compatibility with saved models is broken"""
-        return 2
+        return 3
 
     def resolve_filename(self, suffix):
         return f"{self.model_id()}_C{self.params}_{suffix}.pt"

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -93,7 +93,7 @@ class Arena:
                     opponent_observation_before_action=observation_before_action,
                     my_observation_after_opponent_action=self.game.observe(opponent_agent_id),
                     opponent_observation_after_action=self.game.observe(agent_id),
-                    opponent_reward=self.game.rewards[opponent_agent_id],
+                    opponent_reward=self.game.rewards[agent_id],
                     opponent_action=action,
                     done=self.game.is_done(),
                 )

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -587,6 +587,10 @@ def construct_game_from_observation(observation: dict, player_id: str) -> tuple[
         player_on_board = Player(
             observation["board"][row, col] - 1
         )  # Players are 1 and 2 on the board, but we use 0 and 1.
+        if player_on_board == Player.ONE:
+            player_on_board = player
+        elif player_on_board == Player.TWO:
+            player_on_board = opponent
         board.move_player(player_on_board, (row, col))
 
     for row, col, orientation in np.argwhere(observation["walls"] == 1):

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -174,10 +174,10 @@ class QuoridorEnv(AECEnv):
 
         # Calculate board from self.positions
         board = np.zeros((self.game.board.board_size, self.game.board.board_size), dtype=np.int8)
-        player_one_position = self.game.board.get_player_position(Player.ONE)
-        player_two_position = self.game.board.get_player_position(Player.TWO)
-        board[player_one_position] = 1
-        board[player_two_position] = 2
+        player_position = self.game.board.get_player_position(player)
+        opponent_position = self.game.board.get_player_position(opponent)
+        board[player_position] = 1
+        board[opponent_position] = 2
 
         # Make a copy of walls
         walls = self.game.board.get_old_style_walls()

--- a/deep_quoridor/src/renderers/text_board.py
+++ b/deep_quoridor/src/renderers/text_board.py
@@ -7,6 +7,7 @@ from renderers import Renderer
 class TextBoardRenderer(Renderer):
     def start_game(self, game, agent1: Agent, agent2: Agent):
         self.match = f"{agent1.name()} vs {agent2.name()}"
+        print(f"Match {self.match}")
         print("Initial Board State:")
         print(game.render())
 


### PR DESCRIPTION
Fix two issues in the new quoridor impl:
- Making env.observe compatible with past environment. New env was using 1 and 2 on the board for player 1 and player 2 but previous observation was using 1 for the player being observed, and 2 for the opponent
-- Fix construction of board based on observation to match fixed observation
- Reward passed for the handle opponent was using the agent reward instead of the opponent. 
Some other changes included here: 
- Smaller NN -  to ensure I could reproduce 100% win rate against greedy 
- Making LR configurable as parameter 
- Adding agents for text board renderer to know which player is which
- Nits