### PR TITLE
Use minimax algorithm in simple agent

### DIFF
--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -83,7 +83,7 @@ def choose_action(
     branching_factor: int,
     wall_sigma: float | None,
     discount_factor: float,
-) -> float:
+) -> tuple[Optional[Action], float]:
     """
     Minimax algorithm to choose the best action for the current player.
 

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -33,10 +33,17 @@ class SimpleParams(SubargsBase):
     discount_factor: float = 0.99
 
 
-def compute_wall_weight(wall: WallAction, position_1: np.ndarray, position_2: np.ndarray, sigma) -> float:
-    wall_position = np.array(wall.position)
-    d1 = np.linalg.norm(position_1 - wall_position)
-    d2 = np.linalg.norm(position_2 - wall_position)
+def adjust_wall_position(position: tuple[int, int]) -> tuple[int, int]:
+    """
+    Compute a wall position that reflects where its center is relative to player positions.
+    """
+    return position[0] + 0.5, position[1] + 0.5
+
+
+def compute_wall_weight(wall: WallAction, position_1: tuple[int, int], position_2: tuple[int, int], sigma) -> float:
+    wall_position = np.array(adjust_wall_position(wall.position))
+    d1 = np.linalg.norm(np.array(position_1) - wall_position)
+    d2 = np.linalg.norm(np.array(position_2) - wall_position)
     min_distance = min(d1, d2)
     weight = np.exp(-0.5 * (min_distance / sigma) ** 2)
     return weight
@@ -60,8 +67,8 @@ def sample_actions(game: Quoridor, n: int, wall_sigma: float | None = None) -> l
             if wall_sigma is None:
                 wall_actions = random.sample(wall_actions, num_wall_actions)
             else:
-                position_1 = np.array(game.board.get_player_position(Player.ONE))
-                position_2 = np.array(game.board.get_player_position(Player.TWO))
+                position_1 = game.board.get_player_position(Player.ONE)
+                position_2 = game.board.get_player_position(Player.TWO)
                 wall_weights = [compute_wall_weight(wall, position_1, position_2, wall_sigma) for wall in wall_actions]
                 wall_actions = np.random.choice(
                     wall_actions,

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -1,44 +1,72 @@
+import copy
 import random
 
 from quoridor import ActionEncoder, Player, Quoridor, construct_game_from_observation
-from quoridor_env import StepRewardCalculator
 
 from agents.core import Agent
 
 
-def sample_random_action_sequence(game: Quoridor, player: Player, opponent: Player, max_path_length: int):
+def sample_valid_actions(game: Quoridor, n: int):
     """
-    Sample a random sequence of actions for a given game. Stops early if the game terminates."""
-    action_sequence = []
-    total_reward = 0.0
-    reward_calculator = StepRewardCalculator(game, player, opponent)
-    while len(action_sequence) < max_path_length:
-        # For now, assume the other agent takes random actions.
-        valid_actions = game.get_valid_actions()
-        assert len(valid_actions) > 0, "No valid actions available... this shouldn't be possible."
+    Choose a random sample of valid actions for the current player.
 
-        action = random.choice(valid_actions)
+    Starts by including all valid move actions, then adds a random sample of valid wall actions. May return less than
+    n actions if there are not enough valid actions.
+    """
+    actions = game.get_valid_move_actions()
+    if len(actions) > n:
+        actions = random.sample(actions, n)
 
+    if len(actions) < n:
+        num_wall_actions = n - len(actions)
+        wall_actions = game.get_valid_wall_actions()
+        if len(wall_actions) > num_wall_actions:
+            wall_actions = random.sample(wall_actions, num_wall_actions)
+
+        actions += wall_actions
+
+    return actions
+
+
+def choose_action(game: Quoridor, player: Player, opponent: Player, max_depth: int, branching_factor: int) -> float:
+    """
+    Minimax algorithm to choose the best action for the current player.
+
+    The other agent tries to minimize the reward of the current player.
+    """
+    if game.check_win(player):
+        return None, float("inf")
+    elif game.check_win(opponent):
+        return None, -float("inf")
+    elif max_depth == 0:
+        return None, game.player_distance_to_target(opponent) - game.player_distance_to_target(player)
+
+    actions = sample_valid_actions(game, branching_factor)
+    assert len(actions) > 0, "There are no valid actions for the current player."
+
+    chosen_action = None
+    chosen_value = -float("inf") if game.get_current_player() == player else float("inf")
+    for action in actions:
+        game_after_action = copy.deepcopy(game)
+        game_after_action.step(action)
+        _, value = choose_action(game_after_action, player, opponent, max_depth - 1, branching_factor)
         if game.get_current_player() == player:
-            action_sequence.append(action)
-            reward_calculator.before_step()
+            if value >= chosen_value:
+                chosen_value = value
+                chosen_action = action
+        else:
+            if value <= chosen_value:
+                chosen_value = value
+                chosen_action = action
 
-        game.step(action)
-
-        if game.get_current_player() == player:
-            total_reward += reward_calculator.after_step()
-
-        if game.is_game_over():
-            break
-
-    return action_sequence, total_reward
+    return chosen_action, chosen_value
 
 
 class SimpleAgent(Agent):
-    def __init__(self, sequence_length=3, num_sequences=10, **kwargs):
+    def __init__(self, max_depth=3, branching_factor=8, **kwargs):
         super().__init__()
-        self.sequence_length = sequence_length
-        self.num_sequences = num_sequences
+        self.max_depth = max_depth
+        self.branching_factor = branching_factor
         self.board_size = kwargs["board_size"]
         self.action_encoder = ActionEncoder(self.board_size)
 
@@ -46,16 +74,12 @@ class SimpleAgent(Agent):
         self.player_id = player_id
 
     def get_action(self, observation, action_mask):
-        possible_action_sequences = []
-        for _ in range(self.num_sequences):
-            game, player, opponent = construct_game_from_observation(observation, self.player_id)
-            action_sequence, total_reward = sample_random_action_sequence(game, player, opponent, self.sequence_length)
-            possible_action_sequences.append((action_sequence, total_reward))
-
-        # Choose the action sequence with the highest reward.
-        best_sequence, _ = max(possible_action_sequences, key=lambda x: x[1])
         game, player, opponent = construct_game_from_observation(observation, self.player_id)
-        assert game.is_action_valid(best_sequence[0]), "The best action is not valid."
-        action_id = self.action_encoder.action_to_index(best_sequence[0])
+
+        chosen_action, chosen_value = choose_action(game, player, opponent, self.max_depth, self.branching_factor)
+
+        assert game.is_action_valid(chosen_action), "The chosen action is not valid."
+        action_id = self.action_encoder.action_to_index(chosen_action)
         assert action_mask[action_id] == 1, "The action is not valid according to the action mask."
+
         return action_id

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -483,6 +483,9 @@ class Quoridor:
     def get_current_player(self) -> int:
         return self.current_player
 
+    def set_current_player(self, player: Player):
+        self.current_player = player
+
     def get_goal_row(self, player: Player) -> int:
         return self._goal_rows[player]
 


### PR DESCRIPTION
By default it tries a max of 20 different actions at each step and looks 2 steps ahead (e.g. if I do X, then opponent could do Y). Beyond that horizon it maximizes the usual heuristic of `(opponent_distance_to_goal - my_distance_to_goal)`. I've tried having it look 3 steps ahead, but to keep computation time down, I had to reduce the number of actions considered per turn to 8, which resulted in worse results.

This agent takes longer than the others; a couple tenths of a second per turn instead of a couple milliseconds per turn. It can take much much longer if the branching factor or max depth are increased. Should give us some interesting options for training other agents - we could start with a dumb simple agent and then later in the training process crank up its intelligence as the trained agent gets better.

There are a few parameters for the agent:
```sh
    # How many moves to look ahead in the minimax algorithm.
    max_depth: int = 2

    # How many actions to consider at each minimax stage.
    branching_factor: int = 20

    # We use a Guassian distribution centered around each player's position to sample wall actions.
    # Sigma is the standard deviation of this distribution; a smaller sigma means the agent is more
    # likely to place walls near themselves or their opponent, rather than somewhere else on the board.
    wall_sigma: float = 0.5

    # Future rewards are worth less. This makes the agent try to win quickly. Without this,
    # once the agent knows it can win, it may oscillate between two moves instead of just winning.
    discount_factor: float = 0.99
```

I wasn't able to test against the trained agents because there's not a model with the "best" tag for the current version, but it does pretty well against greedy:
```
Board size:  5
Max walls:  3
Step rewards:  False
Total number of games:  100 

+-----------+--------+-----------+-----------+--------+---------+--------+
|  P1 \ P2  | greedy | greedy-01 | greedy-03 | random | simple  | Total  |
+-----------+--------+-----------+-----------+--------+---------+--------+
|   greedy  |   -    |    100%   |    100%   |  100%  |    0%   |  75%   |
| greedy-01 |  80%   |     -     |    100%   |  100%  |   20%   |  75%   |
| greedy-03 |  60%   |    40%    |     -     |  100%  |    0%   |  50%   |
|   random  |   0%   |     0%    |     0%    |   -    |    0%   |   0%   |
|  simple   |  100%  |    80%    |    100%   |  100%  |    -    |  95%   |
|   ======  | ====== |   ======  |   ======  | ====== |  ====== | ====== |
|   Total   |  60%   |    55%    |    75%    |  100%  |    5%   |  59%   |
+-----------+--------+-----------+-----------+--------+---------+--------+
+-----------+------------+
|   Player  | Elo Rating |
+-----------+------------+
|  simple   |    1766    |
| greedy-01 |    1603    |
|   greedy  |    1548    |
| greedy-03 |    1384    |
|   random  |    1196    |
```