### PR TITLE
Improvements for using wandb in training

### DIFF
--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -23,6 +23,8 @@ class TrainableAgentParams(SubargsBase):
     nick: Optional[str] = None
     # If wandb_alias is provided, the model will be fetched from wandb using the model_id and the alias
     wandb_alias: Optional[str] = None
+    # When loading from wandb, the project name to be used
+    wandb_project: str = "deep_quoridor"
     # If a filename is provided, the model will be loaded from disc
     model_filename: Optional[str] = None
     # Directory where wandb models are stored
@@ -83,6 +85,7 @@ class TrainableAgentParams(SubargsBase):
             "update_target_every",
             "use_negative_qvalue_function",
             "wandb_alias",
+            "wandb_project",
             "wandb_dir",
             "learning_rate",
         }
@@ -520,8 +523,9 @@ class AbstractTrainableAgent(Agent):
             return
 
         api = wandb.Api()
-        print(f"Fetching model from wandb: the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}")
-        artifact = api.artifact(f"the-lazy-learning-lair/deep_quoridor/{self.model_id()}:{alias}", type="model")
+        path = f"the-lazy-learning-lair/{self.params.wandb_project}/{self.model_id()}:{alias}"
+        print(f"Fetching model from wandb: {path}")
+        artifact = api.artifact(path, type="model")
         local_filename = resolve_path(self.params.wandb_dir, self.wandb_local_filename(artifact))
 
         all_params = self.params_class()(**artifact.metadata)

--- a/deep_quoridor/src/plugins/__init__.py
+++ b/deep_quoridor/src/plugins/__init__.py
@@ -1,3 +1,3 @@
 from plugins.arena_yaml_recorder import ArenaYAMLRecorder  # noqa: E402, F401
 from plugins.save_model import SaveModelEveryNEpisodesPlugin  # noqa: E402, F401
-from plugins.wandb_train import WandbTrainPlugin  # noqa: E402, F401
+from plugins.wandb_train import WandbParams, WandbTrainPlugin  # noqa: E402, F401

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -1,21 +1,47 @@
+import datetime
+import getpass
 import os
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 
 from agents.core.trainable_agent import AbstractTrainableAgent
 from arena_utils import ArenaPlugin
 from metrics import Metrics
 from utils import resolve_path
+from utils.subargs import SubargsBase
 
 import wandb
 
 
+@dataclass
+class WandbParams(SubargsBase):
+    # Prefix for this run. This is used to create a unique run id for naming, and tagging artifacts and files
+    prefix: str = getpass.getuser()
+
+    # Suffix for this run. This is used to create a unique run id for naming, and tagging artifacts and files
+    suffix: str = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+
+    # Name of the project in wandb
+    project: str = "deep_quoridor"
+
+    # Optional notes to store for the run
+    notes: str = ""
+
+    # Wether to upload the final model to wandb
+    upload_model: bool = True
+
+    # How often to log training metrics
+    log_every: int = 10
+
+    def run_id(self):
+        return f"{self.prefix}-{self.suffix}"
+
+
 class WandbTrainPlugin(ArenaPlugin):
-    def __init__(self, update_every: int, total_episodes: int, agent_encoded_name: str, run_id: str = ""):
-        self.update_every = update_every
+    def __init__(self, params: WandbParams, total_episodes: int, agent_encoded_name: str):
+        self.params = params
         self.total_episodes = total_episodes
         self.episode_count = 0
         self.agent = None
-        self.run_id = run_id
         self.agent_encoded_name = agent_encoded_name
 
     def _initialize(self, game):
@@ -31,12 +57,13 @@ class WandbTrainPlugin(ArenaPlugin):
         self.metrics = Metrics(game.board_size, game.max_walls)
 
         self.run = wandb.init(
-            project="deep_quoridor",
+            project=self.params.project,
             job_type="train",
             config=config,
-            tags=[self.agent.model_id(), f"-{self.run_id}"],
-            id=self.run_id,
-            name=f"{self.run_id}",
+            tags=[self.agent.model_id(), f"-{self.params.run_id()}"],
+            id=self.params.run_id(),
+            name=f"{self.params.run_id()}",
+            notes=self.params.notes,
         )
 
     def start_game(self, game, agent1, agent2):
@@ -54,8 +81,8 @@ class WandbTrainPlugin(ArenaPlugin):
 
     def end_game(self, game, result):
         assert self.agent
-        if self.episode_count % self.update_every == 0 or self.episode_count == (self.total_episodes - 1):
-            avg_loss, avg_reward = self.agent.compute_loss_and_reward(self.update_every)
+        if self.episode_count % self.params.log_every == 0 or self.episode_count == (self.total_episodes - 1):
+            avg_loss, avg_reward = self.agent.compute_loss_and_reward(self.params.log_every)
 
             self.run.log(
                 {"loss": avg_loss, "reward": avg_reward, "epsilon": self.agent.epsilon},
@@ -66,6 +93,10 @@ class WandbTrainPlugin(ArenaPlugin):
 
     def end_arena(self, game, results):
         assert self.agent
+        if not self.params.upload_model:
+            print("Model NOT uploaded to wandb since using `upload_model=False`")
+            wandb.finish()
+            return
 
         # Save the model in the wandb directory with the suffix "temp".  The file will be renamed
         # once we upload it to wandb and have the digest.

--- a/deep_quoridor/src/utils/subargs.py
+++ b/deep_quoridor/src/utils/subargs.py
@@ -1,3 +1,4 @@
+import shlex
 from dataclasses import dataclass, fields
 from typing import Type, Union, get_args, get_origin
 
@@ -23,14 +24,21 @@ class ParseSubargsError(ValueError):
     pass
 
 
+def split_with_shlex(s: str, separator: str):
+    lexer = shlex.shlex(s, posix=True)
+    lexer.whitespace = separator
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
 def parse_subargs(s: str, cls: Type[SubargsBase], separator=",", assign="=", ignore_fields=set()):
     """Parses the string s and uses it to instantiate a class cls and return it."""
     if s == "":
         return cls()
-
     class_fields = cls.fields()
     args = {}
-    for part in s.split(separator):
+
+    for part in split_with_shlex(s, separator):
         if assign not in part:
             raise ParseSubargsError(f"The subargument '{part}' needs to have an assignment using '{assign}'")
 


### PR DESCRIPTION
This will give us more flexibility when using wandb when running train.py
- By default, wandb is not going to be used (as opposed to now that is used unless --no-wandb is passed)
- It can be turned on just by passing `-w`, and the user name in the os will be used as the prefix
- Multiple parameters can be passed to the plugin, e.g `-w prefix=cucu,project=testing_xyz,notes="this time using abc",upload_model=False`
  - You can now pass a different project (by default is deep_quoridor, the one we're using now), so you can use a new project (will be created automatically if it doesn't exist) to try out whatever, and avoid poluting the main one.  Additionally, it's very easy to just delete the whole project once you're done.
  - You can pass notes that will be visible in the overview of the run, so you can easily remember wtf you were trying to do
  - You can skip uploading the model, which is useful when you're debugging or trying out stuff
