### PR TITLE
Renderer plugin for showing agent computation times

### DIFF
--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from agents import Agent, AgentRegistry, ReplayAgent
 from agents.core import AbstractTrainableAgent
-from arena_utils import ArenaPlugin, CompositeArenaPlugin, GameResult
+from arena_utils import ArenaPlugin, CompositeArenaPlugin, GameResult, MoveInfo
 from quoridor_env import env
 from renderers import PygameRenderer
 
@@ -50,6 +50,7 @@ class Arena:
         self.plugins.start_game(self.game, agent1, agent2)
         start_time = time.time()
         step = 0
+        move = []
         for agent_id in self.game.agent_iter():
             observation_before_action, _, termination, truncation, _ = self.game.last()
             agent = agents[agent_id]
@@ -71,9 +72,12 @@ class Arena:
 
             assert (observation_before_action["action_mask"] == self.game.last_action_mask[agent_id]).all()
 
+            get_action_start_time = time.time()
             action = int(
                 agent.get_action(observation_before_action["observation"], observation_before_action["action_mask"])
             )
+            get_action_finish_time = time.time()
+            move.append(MoveInfo(agent.name(), action, get_action_finish_time - get_action_start_time))
 
             self.plugins.before_action(self.game, agent)
             self.game.step(action)
@@ -114,6 +118,7 @@ class Arena:
             steps=step,
             time_ms=int((end_time - start_time) * 1000),
             game_id=game_id,
+            moves=move,
         )
         for p, a in agents.items():
             a.end_game(self.game)

--- a/deep_quoridor/src/arena_utils.py
+++ b/deep_quoridor/src/arena_utils.py
@@ -4,6 +4,13 @@ from agents import Agent
 
 
 @dataclass
+class MoveInfo:
+    player: str
+    action: int
+    computation_time: float  # in seconds
+
+
+@dataclass
 class GameResult:
     player1: str
     player2: str
@@ -11,6 +18,7 @@ class GameResult:
     steps: int
     time_ms: int
     game_id: str
+    moves: list[MoveInfo]
 
 
 class ArenaPlugin:

--- a/deep_quoridor/src/renderers/__init__.py
+++ b/deep_quoridor/src/renderers/__init__.py
@@ -24,6 +24,7 @@ class Renderer(ArenaPlugin):
 __all__ = [
     "ArenaResults2Renderer",
     "ArenaResultsRenderer",
+    "ComputationTimesRenderer",
     "CursesBoardRenderer",
     "EloResultsRenderer",
     "MatchResultsRenderer",
@@ -38,6 +39,7 @@ __all__ = [
 
 from renderers.arena_results import ArenaResultsRenderer  # noqa: E402, F401
 from renderers.arena_results2 import ArenaResults2Renderer  # noqa: E402, F401
+from renderers.computation_times import ComputationTimesRenderer  # noqa: E402, F401
 from renderers.curses_board import CursesBoardRenderer  # noqa: E402, F401
 from renderers.elo_results import EloResultsRenderer  # noqa: E402, F401
 from renderers.match_results import MatchResultsRenderer  # noqa: E402, F401

--- a/deep_quoridor/src/renderers/computation_times.py
+++ b/deep_quoridor/src/renderers/computation_times.py
@@ -1,0 +1,32 @@
+from arena import GameResult
+from prettytable import PrettyTable
+
+from renderers import Renderer
+
+
+class ComputationTimesRenderer(Renderer):
+    def end_arena(self, game, results: list[GameResult]):
+        player_moves = {}
+        for result in results:
+            for player in [result.player1, result.player2]:
+                if player not in player_moves:
+                    player_moves[player] = []
+
+                player_moves[player] = [move for move in result.moves if move.player == player]
+
+        table = PrettyTable()
+        table.field_names = ["Player", "Average Time (ms)", "Min Time (ms)", "Max Time (ms)"]
+
+        for player, moves in player_moves.items():
+            num_moves = len(moves)
+            computation_times_ms = [m.computation_time * 1000.0 for m in moves]
+            table.add_row(
+                [
+                    player,
+                    f"{sum(computation_times_ms) / num_moves:.3f}",
+                    f"{min(computation_times_ms):.3f}",
+                    f"{max(computation_times_ms):.3f}",
+                ]
+            )
+
+        print(table)

--- a/yargs/play/agent_benchmark.yaml
+++ b/yargs/play/agent_benchmark.yaml
@@ -1,8 +1,8 @@
 benchmark_B3W0:
-  args: -t 100 -N 3 -W 0 --players greedy greedy:p_random=0.1,nick=greedy-ish random sb3ppo:wandb_alias=best -r progressbar arenaresults eloresults
+  args: -t 100 -N 3 -W 0 --players greedy greedy:p_random=0.1,nick=greedy-ish random sb3ppo:wandb_alias=best -r progressbar arenaresults eloresults computationtimes
 
 benchmark_B5W3:
-  args: -t 100 -N 5 -W 3 --players random greedy greedy:p_random=0.1,nick=greedy-01 greedy:p_random=0.3,nick=greedy-03 dexp:wandb_alias=best simple sb3ppo:wandb_alias=best -r progressbar arenaresults eloresults
+  args: -t 100 -N 5 -W 3 --players random greedy greedy:p_random=0.1,nick=greedy-01 greedy:p_random=0.3,nick=greedy-03 dexp:wandb_alias=best simple sb3ppo:wandb_alias=best -r progressbar arenaresults eloresults computationtimes
 
 benchmark_B9W10:
-  args: -t 100 --players greedy greedy:p_random=0.1,nick=greedy-ish dexp:wandb_alias=latest -r progressbar arenaresults eloresults
+  args: -t 100 --players greedy greedy:p_random=0.1,nick=greedy-ish dexp:wandb_alias=latest -r progressbar arenaresults eloresults computationtimes


### PR DESCRIPTION
Keeps track of how long each agent takes to choose an action, and prints out stats at the end. I've added it to the default benchmarks. Example output:
```
+-------------+-------------------+---------------+---------------+
|    Player   | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+-------------+-------------------+---------------+---------------+
|    sb3ppo   |       2.577       |     1.453     |     6.769     |
|   simple    |       63.338      |     0.923     |    196.253    |
|    greedy   |       1.042       |     0.743     |     1.307     |
|  greedy-03  |       0.886       |     0.288     |     1.801     |
| dexp (1011) |       0.360       |     0.327     |     0.446     |
|  greedy-01  |       1.258       |     0.871     |     1.580     |
|    random   |       0.039       |     0.038     |     0.041     |
+-------------+-------------------+---------------+---------------+
```