### PR TITLE
Performance improvements for bfs

### DIFF
--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -33,7 +33,7 @@ class SimpleParams(SubargsBase):
     discount_factor: float = 0.99
 
 
-def adjust_wall_position(position: tuple[int, int]) -> tuple[int, int]:
+def adjust_wall_position(position: tuple[int, int]) -> tuple[float, float]:
     """
     Compute a wall position that reflects where its center is relative to player positions.
     """


### PR DESCRIPTION
Fixing some low hanging fruit that made Simple run 4x faster.  Thanks Jon for the plug in, was also nice to see the speed improvement shown there.

Initially from main I ran this to have a baseline:
```
(.venv) (base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py -p simple greedy -t 10 -r progressbar computationtimes
Progress: [==================================================] 100.0% (10/10)
+---------+-------------------+---------------+---------------+
|  Player | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+---------+-------------------+---------------+---------------+
| simple  |      229.824      |     18.878    |    522.378    |
|  greedy |       1.915       |     0.754     |     3.641     |
+---------+-------------------+---------------+---------------+
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python  -p simple greedy -t 10   69.28s user 0.76s system 98% cpu 1:11.18 total
```

If I run it with -O to not use the asserts I get a significant speed bost:
```
(.venv) (base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python -O /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py -p simple greedy -t 10 -r progressbar computationtimes
Progress: [==================================================] 100.0% (10/10)
+---------+-------------------+---------------+---------------+
|  Player | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+---------+-------------------+---------------+---------------+
| simple  |       87.507      |     8.287     |    182.370    |
|  greedy |       0.823       |     0.384     |     1.414     |
+---------+-------------------+---------------+---------------+
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python -O  -p simple greedy -t   26.50s user 0.54s system 97% cpu 27.837 total
```

But I didn't want to just remove all the asserts, so first instead of doing `assert np.sum(np.abs(np.subtract(position1, position2))) == 1, "Positions must be adjacent"` that seems to be the main culprit, I created the `_are_adjacent`, which is much more efficient (but of course as not good as not using the asserts).

```
(.venv) (base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py -p simple greedy -t 10 -r progressbar computationtimes
Progress: [==================================================] 100.0% (10/10)
+---------+-------------------+---------------+---------------+
|  Player | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+---------+-------------------+---------------+---------------+
| simple  |       98.961      |     9.204     |    209.603    |
|  greedy |       0.903       |     0.437     |     1.588     |
+---------+-------------------+---------------+---------------+
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python  -p simple greedy -t 10   29.83s user 0.46s system 98% cpu 30.844 total
```

I moved the `and not visited[new_row, new_col]` in _bfs condition before the `is_wall_between` check, and that gave it another nice boost:

```
  (.venv) (base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py -p simple greedy -t 10 -r progressbar computationtimes
Progress: [==================================================] 100.0% (10/10)
+---------+-------------------+---------------+---------------+
|  Player | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+---------+-------------------+---------------+---------------+
| simple  |       75.949      |     8.157     |    137.911    |
|  greedy |       0.899       |     0.412     |     1.555     |
+---------+-------------------+---------------+---------------+
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python  -p simple greedy -t 10   22.29s user 0.36s system 99% cpu 22.752 total
```

I did the same in `_dfs` but things didn't change much.
Then, the top lines of the profiling were like this:
```
   128866    6.893    0.000   17.542    0.000 quoridor.py:273(_bfs)
 33864658    5.179    0.000    5.179    0.000 quoridor.py:231(is_position_on_board)
  7713616    4.852    0.000    8.773    0.000 quoridor.py:209(is_wall_between)
   461234    3.743    0.000    5.303    0.000 quoridor.py:262(_is_wall_potential_block)
  2084548    1.590    0.000    1.590    0.000 {method 'reduce' of 'numpy.ufunc' objects}
  7713616    1.552    0.000    1.552    0.000 quoridor.py:195(_are_adjacent)
   360930    1.077    0.000    2.938    0.000 simple.py:43(compute_wall_weight)
```

So I tried re-writing _bfs to make things manual and avoid extra checks, function overheads, etc, etc, now the ocde is longer but got another significant boost:
```
(.venv) (base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py -p simple greedy -t 10 -r progressbar computationtimes
Progress: [==================================================] 100.0% (10/10)
+---------+-------------------+---------------+---------------+
|  Player | Average Time (ms) | Min Time (ms) | Max Time (ms) |
+---------+-------------------+---------------+---------------+
| simple  |       52.728      |     6.341     |     91.073    |
|  greedy |       0.873       |     0.407     |     1.627     |
+---------+-------------------+---------------+---------------+
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python  -p simple greedy -t 10   15.81s user 0.32s system 97% cpu 16.548 total
```

So, the average time for simple went from initially 229ms to 52ms (4.4x) and the total running time from 71s to 16.5s (4.3x).


This is what we have now in the profile if we want to keep optimizing:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   128866    5.306    0.000    6.081    0.000 quoridor.py:255(_bfs)
   461234    3.680    0.000    5.179    0.000 quoridor.py:244(_is_wall_potential_block)
  2084548    1.502    0.000    1.502    0.000 {method 'reduce' of 'numpy.ufunc' objects}
   360930    1.071    0.000    2.922    0.000 simple.py:43(compute_wall_weight)
   721860    0.814    0.000    1.424    0.000 _linalg.py:2575(norm)
762842/82459    0.797    0.000    1.803    0.000 quoridor.py:316(_dfs)
   668733    0.785    0.000   10.035    0.000 quoridor.py:399(is_action_valid)
  1122060    0.719    0.000    0.933    0.000 quoridor.py:200(is_wall_between)
   623277    0.661    0.000    1.582    0.000 quoridor.py:184(can_place_wall)
```
