### PR TITLE
Option to compute metrics from play.py

### DIFF
--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -135,17 +135,7 @@ class Arena:
             if isinstance(p, Agent):
                 agents.append(p)
             else:
-                agents.append(
-                    AgentRegistry.create_from_encoded_name(
-                        p,
-                        board_size=self.board_size,
-                        max_walls=self.max_walls,
-                        observation_space=self.game.observation_space(None),
-                        action_space=self.game.action_space(
-                            None
-                        ),  # We might need to do something fancier with the action space if we add agent wrappers.
-                    )
-                )
+                agents.append(AgentRegistry.create_from_encoded_name(p, self.game))
 
         if mode == PlayMode.ALL_VS_ALL:
             total_games = len(agents) * (len(agents) - 1) * times // 2

--- a/deep_quoridor/src/metrics.py
+++ b/deep_quoridor/src/metrics.py
@@ -10,12 +10,10 @@ class Metrics:
     Computes metrics for an agent by making it play against other agents.
     """
 
-    def __init__(self, board_size: int, max_walls: int, observation_space, action_space):
+    def __init__(self, board_size: int, max_walls: int):
         self.board_size = board_size
         self.max_walls = max_walls
         self.stored_elos = {}
-        self.observation_space = observation_space
-        self.action_space = action_space
 
     def _win_perc(self, results: list[GameResult], agent_name: str):
         played = 0
@@ -38,7 +36,7 @@ class Metrics:
 
         return int(agent_rating - best_opponent)
 
-    def compute(self, agent_encoded_name: str) -> tuple[int, dict[str, float], int, float]:
+    def compute(self, agent_encoded_name: str) -> tuple[int, dict[str, float], int, float, int]:
         """
         Evaluates the performance of a given agent by running it against a set of predefined opponents and computing its Elo rating and win percentage.
 
@@ -67,18 +65,14 @@ class Metrics:
             "greedy:p_random=0.3,nick=greedy-03",
             "greedy:p_random=0.5,nick=greedy-05",
         ]
+        arena = Arena(self.board_size, self.max_walls)
 
         agent = AgentRegistry.create_from_encoded_name(
             agent_encoded_name,
-            board_size=self.board_size,
-            max_walls=self.max_walls,
-            observation_space=self.observation_space,
-            action_space=self.action_space,
+            arena.game,
             remove_training_args=True,
-            keep_args={"model_filename"},
+            keep_args={"model_filename", "wandb_alias"},
         )
-
-        arena = Arena(self.board_size, self.max_walls)
 
         # We store the elos of the opponents playing against each other so we don't have to play those matches
         # every time
@@ -94,4 +88,4 @@ class Metrics:
         win_perc = self._win_perc(results, agent.name())
         absolute_elo = elo_table[agent.name()]
 
-        return VERSION, elo_table, relative_elo, win_perc, absolute_elo
+        return VERSION, elo_table, relative_elo, win_perc, int(absolute_elo)

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -2,9 +2,7 @@ import argparse
 
 from agents import AgentRegistry
 from arena import Arena
-from metrics import Metrics
 from plugins.arena_yaml_recorder import ArenaYAMLRecorder
-from prettytable import PrettyTable
 from renderers import Renderer
 from utils import set_deterministic, yargs
 
@@ -78,27 +76,8 @@ if __name__ == "__main__":
         default=False,
         help="Use cProfile to profile the game.",
     )
-    parser.add_argument(
-        "--metrics",
-        action="store_true",
-        default=False,
-        help="Compute the metrics for the players passed to --players",
-    )
 
     args_dict = yargs(parser, "yargs/play")
-    if len(args_dict) == 1 and list(args_dict.values())[0].metrics:
-        args = list(args_dict.values())[0]
-        m = Metrics(args.board_size, args.max_walls)
-        table = PrettyTable()
-        table.field_names = ["Agent", "Elo", "Relative Elo", "Win %"]
-
-        for player in args.players:
-            print(f"Computing metrics for {player}")
-            _, _, relative_elo, win_perc, absolute_elo = m.compute(player)
-            table.add_row([player, absolute_elo, relative_elo, win_perc])
-
-        print(table)
-        exit(1)
 
     for id, args in args_dict.items():
         if id:

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -2,7 +2,9 @@ import argparse
 
 from agents import AgentRegistry
 from arena import Arena
+from metrics import Metrics
 from plugins.arena_yaml_recorder import ArenaYAMLRecorder
+from prettytable import PrettyTable
 from renderers import Renderer
 from utils import set_deterministic, yargs
 
@@ -76,8 +78,27 @@ if __name__ == "__main__":
         default=False,
         help="Use cProfile to profile the game.",
     )
+    parser.add_argument(
+        "--metrics",
+        action="store_true",
+        default=False,
+        help="Compute the metrics for the players passed to --players",
+    )
 
     args_dict = yargs(parser, "yargs/play")
+    if len(args_dict) == 1 and list(args_dict.values())[0].metrics:
+        args = list(args_dict.values())[0]
+        m = Metrics(args.board_size, args.max_walls)
+        table = PrettyTable()
+        table.field_names = ["Agent", "Elo", "Relative Elo", "Win %"]
+
+        for player in args.players:
+            print(f"Computing metrics for {player}")
+            _, _, relative_elo, win_perc, absolute_elo = m.compute(player)
+            table.add_row([player, absolute_elo, relative_elo, win_perc])
+
+        print(table)
+        exit(1)
 
     for id, args in args_dict.items():
         if id:

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -54,7 +54,7 @@ class WandbTrainPlugin(ArenaPlugin):
             "player_args": self.agent.params,
         }
         config.update(self.agent.model_hyperparameters())
-        self.metrics = Metrics(game.board_size, game.max_walls, game.observation_space(None), game.action_space(None))
+        self.metrics = Metrics(game.board_size, game.max_walls)
 
         self.run = wandb.init(
             project=self.params.project,

--- a/deep_quoridor/src/run_metrics.py
+++ b/deep_quoridor/src/run_metrics.py
@@ -1,0 +1,36 @@
+import argparse
+
+from agents import AgentRegistry
+from metrics import Metrics
+from prettytable import PrettyTable
+
+
+def player_with_params(arg):
+    if not AgentRegistry.is_valid_encoded_name(arg):
+        raise argparse.ArgumentTypeError(f"Invalid player name: {arg}")
+    return arg
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Deep Quoridor - Run Metrics")
+    parser.add_argument("-N", "--board_size", type=int, default=9, help="Board Size")
+    parser.add_argument("-W", "--max_walls", type=int, default=10, help="Max walls per player")
+    parser.add_argument(
+        "-p",
+        "--players",
+        nargs="+",
+        type=player_with_params,
+        required=True,
+        help="List of players to run the metrics.  The metrics for each player are computed independently",
+    )
+    args = parser.parse_args()
+    m = Metrics(args.board_size, args.max_walls)
+    table = PrettyTable()
+    table.field_names = ["Agent", "Elo", "Relative Elo", "Win %"]
+
+    for player in args.players:
+        print(f"Computing metrics for {player}")
+        _, _, relative_elo, win_perc, absolute_elo = m.compute(player)
+        table.add_row([player, absolute_elo, relative_elo, win_perc])
+
+    print(table)

--- a/deep_quoridor/src/train_sb3.py
+++ b/deep_quoridor/src/train_sb3.py
@@ -43,12 +43,11 @@ def mask_fn(env):
 
 
 class SwapPlayerCallback(BaseCallback):
-    def __init__(self, env, monitor, opponents_config, opponents_kwargs):
+    def __init__(self, env, monitor, opponents_config):
         super().__init__()
         self.env = env
         self.current_player = "player_0"
         self.opponents_config = opponents_config
-        self.oppponents_kwargs = opponents_kwargs
         self.current_opponent = None
         self.current_opponent_rollouts_left = 0
         self.monitor = monitor
@@ -62,7 +61,7 @@ class SwapPlayerCallback(BaseCallback):
                 next_opponent = self.opponents_config.pop(0)
                 self.current_opponent = next_opponent
                 self.current_opponent_rollouts_left = next_opponent["rollouts"]
-                self.opponent = AgentRegistry.create_from_encoded_name(next_opponent["agent"], **self.oppponents_kwargs)
+                self.opponent = AgentRegistry.create_from_encoded_name(next_opponent["agent"], self.env)
                 self.env.set_opponent(self.opponent)
                 self.env.set_player("player_0")
         print(
@@ -172,7 +171,7 @@ def train_action_mask(env_fn, steps=10_000, seed=0, upload_to_wandb=False, train
 
     total_timesteps = sum(opponent["rollouts"] for opponent in opponents_config) * steps_per_rollout
 
-    swap_player_callback = SwapPlayerCallback(env, masked_env, opponents_config, env_kwargs)
+    swap_player_callback = SwapPlayerCallback(env, masked_env, opponents_config)
 
     # Play as player 1
     model.learn(
@@ -350,7 +349,7 @@ if __name__ == "__main__":
 
     opponent = None
     if args.opponent is not None:
-        opponent = AgentRegistry.create_from_encoded_name(args.opponent, **env_kwargs)
+        opponent = AgentRegistry.create_from_encoded_name(args.opponent, temp_env)
 
     env_fn = make_env_fn(quoridor_env.env, opponent=opponent, rewards_multiplier=args.rewards_multiplier)
 


### PR DESCRIPTION
Passing `--metrics` to play will make it compute metrics for the players using the same function than in wandb training.
E.g.
```
(.venv) (base) amarcu@MacBookPro deep_rabbit_hole % /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py --players dexp:wandb_alias=best dexp:wandb_alias=v1  sb3ppo:wandb_alias=best -N 5 -W 3 --metrics 
Computing metrics for dexp:wandb_alias=best
Fetching model from wandb: the-lazy-learning-lair/deep_quoridor/dexp_B5W3_mv4:best
Loading pre-trained model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/dexp_B5W3_mv4_38f3e.pt
Computing metrics for dexp:wandb_alias=v1
Fetching model from wandb: the-lazy-learning-lair/deep_quoridor/dexp_B5W3_mv4:v1
Loading pre-trained model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/dexp_B5W3_mv4_f5aa4.pt
Computing metrics for sb3ppo:wandb_alias=best
Using wandb_alias: best
Fetching model from wandb: the-lazy-learning-lair/deep_quoridor/sb3ppo_B5W3_mv3:best
Loading pre-trained model from /Users/amarcu/code/deep_rabbit_hole/wandbmodels/sb3ppo_B5W3_mv3_bfeca.zip
/Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/agents/sb3_ppo.py:292: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  thobs = torch.cat((thobs, torch.tensor(v).flatten(start_dim=1)), dim=1)
+-------------------------+------+--------------+-------+
|          Agent          | Elo  | Relative Elo | Win % |
+-------------------------+------+--------------+-------+
|  dexp:wandb_alias=best  | 2025 |     544      |  98.0 |
|   dexp:wandb_alias=v1   | 1644 |     -18      |  67.0 |
| sb3ppo:wandb_alias=best | 1774 |     257      |  86.5 |
+-------------------------+------+--------------+-------+
```

Additionally, I changed `AgentRegistry.create_from_encoded_name` to take the env instead of board_size, max_walls, observation_space and action_space, since we can get those from the env, and I improved other parameter passing

# Update
With the new commit, there's a separate script to run it, e.g.
```
python run_metrics.py --players dexp:wandb_alias=best dexp:wandb_alias=v1 sb3ppo:wandb_alias=best -N 5 -W 3
```