### PR TITLE
Use numba to speedup simple agent

### DIFF
--- a/deep_quoridor/requirements.txt
+++ b/deep_quoridor/requirements.txt
@@ -1,4 +1,5 @@
 gymnasium
+numba
 numpy
 pettingzoo
 prettytable

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -113,8 +113,6 @@ def choose_action(
 
         # Recursively call this function to choose the next player's action.
         _, value = choose_action(game, player, opponent, max_depth - 1, branching_factor, wall_sigma, discount_factor)
-        if isinstance(action, WallAction):
-            value -= 1.0  # HACK
         value = discount_factor * value
         values.append(value)
 

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -99,7 +99,9 @@ def choose_action(
     elif game.check_win(opponent):
         return None, -WINNING_REWARD
     elif max_depth == 0:
-        return None, game.player_distance_to_target(opponent) - game.player_distance_to_target(player)
+        distance_reward = game.player_distance_to_target(opponent) - game.player_distance_to_target(player)
+        wall_reward = game.board.get_walls_remaining(player) - game.board.get_walls_remaining(opponent)
+        return None, distance_reward + wall_reward / 100
 
     actions = sample_actions(game, branching_factor, wall_sigma)
     assert len(actions) > 0, "There are no valid actions for the current player."

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -134,8 +134,7 @@ def choose_action(
 
     best_action_indices = np.flatnonzero(values == best_value)
     # There may be multiple actions with the same value, so we randomly choose one of them.
-    # chosen_action_index = np.random.choice(best_action_indices)
-    chosen_action_index = best_action_indices[-1]
+    chosen_action_index = np.random.choice(best_action_indices)
 
     return actions[chosen_action_index], values[chosen_action_index]
 

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -106,7 +106,17 @@ if __name__ == "__main__":
 
         if args.profile:
             import cProfile
+            import pstats
+            from io import StringIO
 
-            cProfile.run("arena.play_games(players, args.times)", sort="tottime")
+            pr = cProfile.Profile()
+            pr.enable()
+            arena.play_games(players, args.times)
+            pr.disable()
+
+            s = StringIO()
+            ps = pstats.Stats(pr, stream=s).sort_stats("tottime")
+            ps.print_stats(12)
+            print(s.getvalue())
         else:
             arena.play_games(players, args.times)

--- a/deep_quoridor/src/play.py
+++ b/deep_quoridor/src/play.py
@@ -106,17 +106,7 @@ if __name__ == "__main__":
 
         if args.profile:
             import cProfile
-            import pstats
-            from io import StringIO
 
-            pr = cProfile.Profile()
-            pr.enable()
-            arena.play_games(players, args.times)
-            pr.disable()
-
-            s = StringIO()
-            ps = pstats.Stats(pr, stream=s).sort_stats("tottime")
-            ps.print_stats(12)
-            print(s.getvalue())
+            cProfile.run("arena.play_games(players, args.times)", sort="tottime")
         else:
             arena.play_games(players, args.times)

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -102,7 +102,7 @@ def are_wall_cells_free(grid: np.ndarray, start_row: int, start_col: int, orient
     else:
         start_i = start_row * 2 + 3
         start_j = start_col * 2 + 2
-        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 3 < grid_width
+        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
         return (
             grid[start_i, start_j] == CELL_FREE
@@ -152,7 +152,7 @@ def is_wall_potential_block(grid, start_row, start_col, orientation):
     else:  # HORIZONTAL
         start_i = start_row * 2 + 3
         start_j = start_col * 2 + 2
-        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 3 < grid_width
+        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
         touches = 0
         if (

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -361,10 +361,12 @@ def compute_move_action_mask(
         action_mask[k] = 0
 
     # Check all possible moves
-    for row in np.arange(-2, 3):
-        for col in np.arange(-2, 3):
-            if is_move_action_valid(grid, player_positions, current_player, row, col):
-                action_mask[col * board_size + row] = 1
+    for delta_row in np.arange(-2, 3):
+        for delta_col in np.arange(-2, 3):
+            destination_row = player_positions[current_player][0] + delta_row
+            destination_col = player_positions[current_player][1] + delta_col
+            if is_move_action_valid(grid, player_positions, current_player, destination_row, destination_col):
+                action_mask[destination_row * board_size + destination_col] = 1
 
     return action_mask
 
@@ -399,7 +401,8 @@ def compute_wall_action_mask(
                 wall_col,
                 WALL_ORIENTATION_VERTICAL,
             ):
-                action_mask[wall_row * wall_size + wall_row] = 1
+                action_mask[wall_row * wall_size + wall_col] = 1
+
             if is_wall_action_valid(
                 grid,
                 player_positions,
@@ -410,6 +413,6 @@ def compute_wall_action_mask(
                 wall_col,
                 WALL_ORIENTATION_HORIZONTAL,
             ):
-                action_mask[wall_row * wall_size + wall_col] = 1
+                action_mask[wall_size**2 + wall_row * wall_size + wall_col] = 1
 
     return action_mask

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -86,13 +86,13 @@ def distance_to_row(grid: np.ndarray, start_row: int, start_col: int, target_row
 
 
 @njit
-def are_wall_cells_free(grid: np.ndarray, start_row: int, start_col: int, orientation: int) -> bool:
+def are_wall_cells_free(grid: np.ndarray, wall_row: int, wall_col: int, wall_orientation: int) -> bool:
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
 
-    if orientation == WALL_ORIENTATION_VERTICAL:
-        start_i = start_row * 2 + 2
-        start_j = start_col * 2 + 3
+    if wall_orientation == WALL_ORIENTATION_VERTICAL:
+        start_i = wall_row * 2 + 2
+        start_j = wall_col * 2 + 3
         assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
 
         return (
@@ -101,8 +101,8 @@ def are_wall_cells_free(grid: np.ndarray, start_row: int, start_col: int, orient
             and grid[start_i + 2, start_j] == CELL_FREE
         )
     else:
-        start_i = start_row * 2 + 3
-        start_j = start_col * 2 + 2
+        start_i = wall_row * 2 + 3
+        start_j = wall_col * 2 + 2
         assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
         return (
@@ -113,13 +113,13 @@ def are_wall_cells_free(grid: np.ndarray, start_row: int, start_col: int, orient
 
 
 @njit
-def is_wall_potential_block(grid, start_row, start_col, orientation):
+def is_wall_potential_block(grid, wall_row, wall_col, wall_orientation):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
 
-    if orientation == WALL_ORIENTATION_VERTICAL:
-        start_i = start_row * 2 + 2
-        start_j = start_col * 2 + 3
+    if wall_orientation == WALL_ORIENTATION_VERTICAL:
+        start_i = wall_row * 2 + 2
+        start_j = wall_col * 2 + 3
         assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
 
         touches = 0
@@ -140,8 +140,8 @@ def is_wall_potential_block(grid, start_row, start_col, orientation):
         return touches >= 2
 
     else:  # HORIZONTAL
-        start_i = start_row * 2 + 3
-        start_j = start_col * 2 + 2
+        start_i = wall_row * 2 + 3
+        start_j = wall_col * 2 + 2
         assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
         touches = 0
@@ -163,30 +163,30 @@ def is_wall_potential_block(grid, start_row, start_col, orientation):
 
 
 @njit
-def set_wall_cells(grid, start_row, start_col, orientation, value):
+def set_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
 
-    if orientation == WALL_ORIENTATION_VERTICAL:
-        start_i = start_row * 2 + 2
-        start_j = start_col * 2 + 3
+    if wall_orientation == WALL_ORIENTATION_VERTICAL:
+        start_i = wall_row * 2 + 2
+        start_j = wall_col * 2 + 3
         assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
 
-        grid[start_i, start_j] = value
-        grid[start_i + 1, start_j] = value
-        grid[start_i + 2, start_j] = value
+        grid[start_i, start_j] = cell_value
+        grid[start_i + 1, start_j] = cell_value
+        grid[start_i + 2, start_j] = cell_value
     else:
-        start_i = start_row * 2 + 3
-        start_j = start_col * 2 + 2
+        start_i = wall_row * 2 + 3
+        start_j = wall_col * 2 + 2
         assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
-        grid[start_i, start_j] = value
-        grid[start_i, start_j + 1] = value
-        grid[start_i, start_j + 2] = value
+        grid[start_i, start_j] = cell_value
+        grid[start_i, start_j + 1] = cell_value
+        grid[start_i, start_j + 2] = cell_value
 
 
 @njit
-def check_wall_cells(grid, wall_position, wall_orientation, cell_value):
+def check_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
     """
     Return True iff all the grid cells for the wall equal the given value.
     """
@@ -194,8 +194,8 @@ def check_wall_cells(grid, wall_position, wall_orientation, cell_value):
     grid_width = grid.shape[1]
 
     if wall_orientation == WALL_ORIENTATION_VERTICAL:
-        start_i = wall_position[0] * 2 + 2
-        start_j = wall_position[1] * 2 + 3
+        start_i = wall_row * 2 + 2
+        start_j = wall_col * 2 + 3
         assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
         return (
             grid[start_i, start_j] == cell_value
@@ -203,8 +203,8 @@ def check_wall_cells(grid, wall_position, wall_orientation, cell_value):
             and grid[start_i + 2, start_j] == cell_value
         )
     else:
-        start_i = wall_position[0] * 2 + 3
-        start_j = wall_position[1] * 2 + 2
+        start_i = wall_row * 2 + 3
+        start_j = wall_col * 2 + 2
         assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 2 < grid_width
 
         return (
@@ -215,14 +215,14 @@ def check_wall_cells(grid, wall_position, wall_orientation, cell_value):
 
 
 @njit
-def is_move_action_valid(grid, player_positions, current_player, destination):
+def is_move_action_valid(grid, player_positions, current_player, destination_row, destination_col):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
 
     player_i = player_positions[current_player][0] * 2 + 2
     player_j = player_positions[current_player][1] * 2 + 2
-    destination_i = destination[0] * 2 + 2
-    destination_j = destination[1] * 2 + 2
+    destination_i = destination_row * 2 + 2
+    destination_j = destination_col * 2 + 2
     opponent = 1 - current_player
 
     # This suffices for bounds cheking, since the grid cells we check for a move are always between the player its destination.
@@ -322,16 +322,16 @@ def is_move_action_valid(grid, player_positions, current_player, destination):
 
 @njit
 def is_wall_action_valid(
-    grid, player_positions, walls_remaining, goal_rows, current_player, wall_position, wall_orientation
+    grid, player_positions, walls_remaining, goal_rows, current_player, wall_row, wall_col, wall_orientation
 ):
     is_valid = True
     if walls_remaining[current_player] <= 0:
         is_valid = False
-    elif not check_wall_cells(grid, wall_position, wall_orientation, CELL_FREE):
+    elif not check_wall_cells(grid, wall_row, wall_col, wall_orientation, CELL_FREE):
         is_valid = False
-    elif is_wall_potential_block(grid, wall_position[0], wall_position[1], wall_orientation):
+    elif is_wall_potential_block(grid, wall_row, wall_col, wall_orientation):
         # Temprorarily add the wall.
-        set_wall_cells(grid, wall_position[0], wall_position[1], wall_orientation, CELL_WALL)
+        set_wall_cells(grid, wall_row, wall_col, wall_orientation, CELL_WALL)
 
         # Make sure all players still have some path to their goal row.
         for i in range(len(player_positions)):
@@ -340,6 +340,76 @@ def is_wall_action_valid(
                 break
 
         # Restore the grid to its previous state.
-        set_wall_cells(grid, wall_position[0], wall_position[1], wall_orientation, CELL_FREE)
+        set_wall_cells(grid, wall_row, wall_col, wall_orientation, CELL_FREE)
 
     return is_valid
+
+
+@njit
+def compute_move_action_mask(
+    grid: np.ndarray,
+    player_positions: np.ndarray,
+    current_player: int,
+    action_mask: np.ndarray,
+) -> np.ndarray:
+    grid_width = grid.shape[1]
+    board_size = (grid_width - 4) // 2 + 1
+
+    assert action_mask.shape == (board_size**2,)
+
+    for k in range(len(action_mask)):
+        action_mask[k] = 0
+
+    # Check all possible moves
+    for row in np.arange(-2, 3):
+        for col in np.arange(-2, 3):
+            if is_move_action_valid(grid, player_positions, current_player, row, col):
+                action_mask[col * board_size + row] = 1
+
+    return action_mask
+
+
+@njit
+def compute_wall_action_mask(
+    grid: np.ndarray,
+    player_positions: np.ndarray,
+    walls_remaining: np.ndarray,
+    goal_rows: np.ndarray,
+    current_player: int,
+    action_mask: np.ndarray,
+) -> np.ndarray:
+    grid_width = grid.shape[1]
+    board_size = (grid_width - 4) // 2 + 1
+    wall_size = board_size - 1
+
+    assert action_mask.shape == (2 * wall_size**2,)
+
+    for k in range(len(action_mask)):
+        action_mask[k] = 0
+
+    for wall_row in range(wall_size):
+        for wall_col in range(wall_size):
+            if is_wall_action_valid(
+                grid,
+                player_positions,
+                walls_remaining,
+                goal_rows,
+                current_player,
+                wall_row,
+                wall_col,
+                WALL_ORIENTATION_VERTICAL,
+            ):
+                action_mask[wall_row * wall_size + wall_row] = 1
+            if is_wall_action_valid(
+                grid,
+                player_positions,
+                walls_remaining,
+                goal_rows,
+                current_player,
+                wall_row,
+                wall_col,
+                WALL_ORIENTATION_HORIZONTAL,
+            ):
+                action_mask[wall_row * wall_size + wall_col] = 1
+
+    return action_mask

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -1,3 +1,43 @@
+"""
+Fast implementation of quoridor functions using Numba.
+
+The core data structure in this implemtation is a 2D grid that represents both the quoridor board and walls. Here is
+an ASCII representation of a 5x5 grid in an example game state:
+
+#####################
+#####################
+##.   .   .   .   .##
+##                 ##
+##.   .   .   . # .##
+##        # # # #  ##
+##.   . # .   . # 2##
+##      #          ##
+##.   . # .   .   .##
+##        # # #    ##
+##.   .   1   .   .##
+##    # # #   # # ###
+##.   .   .   .   .##
+#####################
+#####################
+
+The hashes represent walls, the dots represent positions that players can be in, and the numbers represent the players.
+Note that we add a border of two wall cells around the grid. This reduces the number of special cases we need to handle
+when checking for valid moves and wall placements.  The cells in the grid (other than the boarder) alternate between
+player cells and wall cells. Because of the border and the alternating wall and player cells, for an NxN Quoridor
+board, the corresponding grid will be (2N+2)x(2N+2) in size.
+
+Terminology:
+- row or col - the row or column on the quoridor board (each between 0 and 8 on a normal board)
+- i or j - the indices into the combined grid used to represent the board and walls (more info below)
+- cell - an element in the combined grid.
+
+In addition to the grid, there are a few arrays used to represent the game state:
+- player_positions (np.ndarray): 2D array of containing [[p1_row, p1_col], [p2_row, p2_col]]
+- walls_remaining (np.ndarray): 1D array of containing [p1_walls_remaining, p2_walls_remaining]
+- goal_rows (np.ndarray): 1D array of containing [p1_goal_row, p2_goal_row]
+- current_player (scalar): 0 or 1
+"""
+
 import numpy as np
 from numba import njit
 

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -1,0 +1,172 @@
+import numpy as np
+from numba import njit
+
+WALL_ORIENTATION_VERTICAL = 0
+WALL_ORIENTATION_HORIZONTAL = 1
+
+# Possible values for each cell in the grid.
+CELL_FREE = -1
+# The player numbers start at 0 so that they can also be used as indices into the player positions array.
+CELL_PLAYER1 = 0
+CELL_PLAYER2 = 1
+CELL_WALL = 10
+
+
+@njit
+def distance_to_row(grid: np.ndarray, start_row: int, start_col: int, target_row: int) -> int:
+    """
+    Args:
+        row (int): The current row of the pawn
+        col (int): The current column of the pawn
+        target_row (int): The target row to reach
+        visited (numpy.array): A 2D boolean array with the same shape as the board,
+            indicating which positions have been visited
+
+    Returns:
+        int: Number of steps to reach the target or -1 if it's unreachable
+    """
+    grid_width = grid.shape[0]
+    grid_height = grid.shape[1]
+    start_i = start_row * 2 + 2
+    start_j = start_col * 2 + 2
+    target_i = target_row * 2 + 2
+
+    if target_i == start_i:
+        return 0
+
+    visited = np.zeros(grid.shape, dtype="bool")
+    visited[start_i, start_j] = True
+
+    queue = [(start_i, start_j, 0)]
+
+    while queue:
+        i, j, steps = queue.pop(0)
+        # Iterate in the 4 directions, and if we can move to that position and we haven't already visited it, add it to the queue.
+        # This was done in a for loop before, but making everything explicit makes it significantly faster, and this method is called
+        # very often.
+
+        # Down
+        new_i = i + 2
+        wall_i = i + 1
+        if new_i < grid_width and not visited[new_i, j] and grid[wall_i, j] != CELL_WALL:
+            visited[new_i, j] = True
+            if target_i == new_i:
+                return steps + 1
+            queue.append((new_i, j, steps + 1))
+
+        # Up
+        new_i = i - 2
+        wall_i = i - 1
+        if new_i >= 0 and not visited[new_i, j] and grid[wall_i, j] != CELL_WALL:
+            visited[new_i, j] = True
+            if target_i == new_i:
+                return steps + 1
+            queue.append((new_i, j, steps + 1))
+
+        # Right
+        new_j = j + 2
+        wall_j = j + 1
+        if new_j < grid_height and not visited[i, new_j] and grid[i, wall_j] != CELL_WALL:
+            visited[i, new_j] = True
+            if target_i == i:
+                return steps + 1
+            queue.append((i, new_j, steps + 1))
+
+        # Left
+        new_j = j - 2
+        wall_j = j - 1
+        if new_j >= 0 and not visited[i, new_j] and grid[i, wall_j] != CELL_WALL:
+            visited[i, new_j] = True
+            if target_i == i:
+                return steps + 1
+            queue.append((i, new_j, steps + 1))
+
+    return -1
+
+
+@njit
+def are_wall_cells_free(grid: np.ndarray, start_row: int, start_col: int, orientation: int) -> bool:
+    grid_width = grid.shape[0]
+    grid_height = grid.shape[1]
+
+    if orientation == WALL_ORIENTATION_VERTICAL:
+        start_i = start_row * 2 + 2
+        start_j = start_col * 2 + 3
+        assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
+
+        return (
+            grid[start_i, start_j] == CELL_FREE
+            and grid[start_i + 1, start_j] == CELL_FREE
+            and grid[start_i + 2, start_j] == CELL_FREE
+        )
+    else:
+        start_i = start_row * 2 + 3
+        start_j = start_col * 2 + 2
+        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 3 < grid_width
+
+        return (
+            grid[start_i, start_j] == CELL_FREE
+            and grid[start_i, start_j + 1] == CELL_FREE
+            and grid[start_i, start_j + 2] == CELL_FREE
+        )
+
+
+def is_wall_potential_block(grid, start_row, start_col, orientation):
+    grid_width = grid.shape[0]
+    grid_height = grid.shape[1]
+
+    # potential_wall_neighbors = {
+    #   WallOrientation.VERTICAL: [
+    #       np.array([(-1, -1), (-2, 0), (-1, 1)]),
+    #       np.array([(1, -1), (1, 1)]),
+    #       np.array([(3, -1), (4, 0), (3, 1)]),
+    #   ],
+    #   WallOrientation.HORIZONTAL: [
+    #       np.array([(-1, -1), (0, -2), (1, -1)]),
+    #       np.array([(-1, 1), (1, 1)]),
+    #       np.array([(-1, 3), (0, 4), (1, 3)]),
+    #   ],
+
+    if orientation == WALL_ORIENTATION_VERTICAL:
+        start_i = start_row * 2 + 2
+        start_j = start_col * 2 + 3
+        assert start_i >= 0 and start_i + 2 < grid_height and start_j >= 0 and start_j < grid_width
+
+        touches = 0
+        if (
+            grid[start_i - 1, start_j - 1] == CELL_WALL
+            or grid[start_i - 2, start_j] == CELL_WALL
+            or grid[start_i - 1, start_j + 1] == CELL_WALL
+        ):
+            touches += 1
+        if grid[start_i + 1, start_j - 1] == CELL_WALL or grid[start_i + 1, start_j + 1] == CELL_WALL:
+            touches += 1
+        if (
+            grid[start_i + 3, start_j - 1] == CELL_WALL
+            or grid[start_i + 4, start_j] == CELL_WALL
+            or grid[start_i + 3, start_j + 1] == CELL_WALL
+        ):
+            touches += 1
+        return touches >= 2
+
+    else:  # HORIZONTAL
+        start_i = start_row * 2 + 3
+        start_j = start_col * 2 + 2
+        assert start_i >= 0 and start_i < grid_height and start_j >= 0 and start_j + 3 < grid_width
+
+        touches = 0
+        if (
+            grid[start_i - 1, start_j - 1] == CELL_WALL
+            or grid[start_i, start_j - 2] == CELL_WALL
+            or grid[start_i + 1, start_j - 1] == CELL_WALL
+        ):
+            touches += 1
+        if grid[start_i - 1, start_j + 1] == CELL_WALL or grid[start_i + 1, start_j + 1] == CELL_WALL:
+            touches += 1
+        if (
+            grid[start_i - 1, start_j + 3] == CELL_WALL
+            or grid[start_i, start_j + 4] == CELL_WALL
+            or grid[start_i + 1, start_j + 3] == CELL_WALL
+        ):
+            touches += 1
+        return touches >= 2

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -1,6 +1,7 @@
 import copy
 from dataclasses import dataclass
 from enum import IntEnum, unique
+from functools import cache
 from typing import Optional, Sequence
 
 import numpy as np
@@ -52,6 +53,7 @@ class ActionEncoder:
         else:
             raise ValueError(f"Invalid action type: {action}")
 
+    @cache
     def index_to_action(self, idx) -> Action:
         """
         Converts an action index to an action object.

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -305,7 +305,8 @@ class Quoridor:
                 self.board._grid,
                 self.board._player_positions,
                 int(for_player),
-                np.array(action.destination),
+                action.destination[0],
+                action.destination[1],
             )
 
         elif isinstance(action, WallAction):
@@ -315,7 +316,8 @@ class Quoridor:
                 self.board._walls_remaining,
                 self._goal_rows,
                 int(for_player),
-                np.array(action.position),
+                action.position[0],
+                action.position[1],
                 int(action.orientation),
             )
         else:

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -297,45 +297,16 @@ class Quoridor:
         Check whether the given action is valid given the current game state.
         """
         if for_player is None:
-            player = self.get_current_player()
-        else:
-            player = for_player
-        opponent = Player(1 - player)
+            for_player = self.get_current_player()
 
         is_valid = True
         if isinstance(action, MoveAction):
-            current_position = self.board.get_player_position(player)
-            opponent_position = self.board.get_player_position(opponent)
-            opponent_offset = (opponent_position[0] - current_position[0], opponent_position[1] - current_position[1])
-            position_delta = (action.destination[0] - current_position[0], action.destination[1] - current_position[1])
-
-            # Destination cell must be free
-            if self.board.get_player_cell(action.destination) != Board.FREE:
-                is_valid = False
-
-            elif np.sum(np.abs(position_delta)) == 1:
-                # Moving to an adjacent cell, just make sure no wall is in the way.
-                if self.board.is_wall_between(current_position, action.destination):
-                    is_valid = False
-
-            elif (opponent_offset, position_delta) in self._jump_checks:
-                jump_checks = self._jump_checks[(opponent_offset, position_delta)]
-
-                for check_delta_1, check_delta_2 in jump_checks["wall"]:
-                    if not self.board.is_wall_between(
-                        (current_position[0] + check_delta_1[0], current_position[1] + check_delta_1[1]),
-                        (current_position[0] + check_delta_2[0], current_position[1] + check_delta_2[1]),
-                    ):
-                        is_valid = False
-                for check_delta_1, check_delta_2 in jump_checks["nowall"]:
-                    if self.board.is_wall_between(
-                        (current_position[0] + check_delta_1[0], current_position[1] + check_delta_1[1]),
-                        (current_position[0] + check_delta_2[0], current_position[1] + check_delta_2[1]),
-                    ):
-                        is_valid = False
-            else:
-                # This isn't a move by 1, and it isn't a jump, so it's invalid.
-                is_valid = False
+            return qgrid.is_move_action_valid(
+                self.board._grid,
+                self.board._player_positions,
+                int(for_player),
+                np.array(action.destination),
+            )
 
         elif isinstance(action, WallAction):
             is_valid = qgrid.is_wall_action_valid(
@@ -343,7 +314,7 @@ class Quoridor:
                 self.board._player_positions,
                 self.board._walls_remaining,
                 self._goal_rows,
-                int(self.current_player),
+                int(for_player),
                 np.array(action.position),
                 int(action.orientation),
             )

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -429,7 +429,3 @@ if __name__ == "__main__":
     game.step(WallAction((0, 4), WallOrientation.HORIZONTAL))
     game.step(WallAction((4, 2), WallOrientation.VERTICAL))
     print(str(game))
-
-    jump_checks = create_jump_checks()
-    for key, value in jump_checks.items():
-        print(f"{key}: {value}")


### PR DESCRIPTION
The Quoridor game logic that was taking up the most computation time is re-implemented using numba, which just-in-time compiles it.

Good stuff:
- On my computer, the average running time of the Simple agent with default parameters goes from 24 ms to about 5 ms
- More speedup is possible. I think another 10x or so if the minimax implementation in the simple agent itself is numba-fied, and parallel processing is enabled

Meh stuff:
- To get much benefit from numba, we now do more batch processing in free functions. This blurs some of the abstraction provided by the Quoridor class (for example the numba grid functions in `qgrid.py` do action encoding/decoding themselves instead of using the ActionEncoder class)
- Compilation by numba takes a couple seconds each time `play.py` is run. This doesn't seem to get cached on disk and reused the next time the python interpreter is restarted.
- Numba works well for what it does, but has a lot of magic, doesn't feel particularly actively used or developed, and has limitations that would make we not want to use it in a more "serious" project.

A couple more notes:
- I've added tie-breaking of the minimax reward function using the number of walls remaining (suggested by @alejandromarcu when reviewing that last PR). This gives a nice bump to the results of the simple agent without slowing it down.
- We'd probably be better off removing the `Board` class and just calling `qgrid.py` functions directly from the Quoridor class. Three levels of abstraction feels like too much, but I didn't want to change too much in this PR so I left it for now.
- For the moment I'm using numba-fied BFS for both shortest path and for "does this wall block a player's path to goal". For blocking checks, we can use DFS instead, but it wasn't a bottleneck so I didn't do that yet.