### PR TITLE
wandb: save best model, trigger metrics, ctrl-c

### DIFF
--- a/deep_quoridor/src/plugins/save_model.py
+++ b/deep_quoridor/src/plugins/save_model.py
@@ -1,4 +1,5 @@
-from typing import Callable, Optional
+from collections import deque
+from typing import Any, Callable, Optional
 
 from agents.core.trainable_agent import TrainableAgent
 from arena_utils import ArenaPlugin
@@ -13,7 +14,8 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
         max_walls: int,
         save_final: bool = True,
         run_id: str = "",
-        after_save: Optional[Callable[[str], None]] = None,
+        after_save: Optional[Callable[[str], Any]] = None,
+        trigger_metrics: Optional[tuple[int, int]] = None,  # wins, last_episodes
     ):
         self.update_every = update_every
         self.episode_count = 0
@@ -23,11 +25,45 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
         self.run_id = run_id
         self.after_save = after_save
 
+        if trigger_metrics:
+            self.trigger_metrics_n_wins = trigger_metrics[0]
+            self.win_history = deque(maxlen=trigger_metrics[1])
+        else:
+            self.trigger_metrics_n_wins = 0
+            self.win_history = None
+
     def start_game(self, game, agent1, agent2):
-        self.agents = [agent1, agent2]
+        self.agent = None
+        if isinstance(agent1, TrainableAgent) and agent1.is_training():
+            self.agent = agent1
+
+        if isinstance(agent2, TrainableAgent) and agent2.is_training():
+            if self.agent:
+                raise ValueError(
+                    "SaveModelEveryNEpisodesPlugin can only be used with 1 training agent, but 2 are present."
+                )
+            self.agent = agent2
+
+        if self.agent is None:
+            raise ValueError("SaveModelEveryNEpisodesPlugin requires an agent being trained to be used")
 
     def end_game(self, game, result):
-        if self.episode_count % self.update_every == 0 and self.episode_count > 0:
+        assert self.agent
+
+        trigger_save = False
+        if self.win_history is not None:
+            won = 1 if result.winner == self.agent.name() else 0
+            self.win_history.append(won)
+            n_won = sum(list(self.win_history))
+
+            if n_won >= self.trigger_metrics_n_wins:
+                print(
+                    f"Won {n_won} out of {len(self.win_history)} games.  Saving model for episode {self.episode_count}"
+                )
+                self.win_history.clear()
+                trigger_save = True
+
+        if trigger_save or (self.episode_count % self.update_every == 0 and self.episode_count > 0):
             self._save_models(f"{self.run_id}_episode_{self.episode_count}")
         self.episode_count += 1
 
@@ -36,13 +72,10 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
             self._save_models(f"{self.run_id}_final")
 
     def _save_models(self, suffix: str):
-        for agent in self.agents:
-            if not isinstance(agent, TrainableAgent) or not agent.is_training():
-                continue
-            agent_name = agent.name()
-            save_file = resolve_path(agent.params.model_dir, agent.resolve_filename(suffix))
-            agent.save_model(save_file)
-            print(f"{agent_name} Model saved to {save_file}")
+        assert self.agent
+        save_file = resolve_path(self.agent.params.model_dir, self.agent.resolve_filename(suffix))
+        self.agent.save_model(save_file)
+        print(f"{self.agent.name()} Model saved to {save_file}")
 
-            if self.after_save:
-                self.after_save(str(save_file))
+        if self.after_save:
+            self.after_save(str(save_file))

--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -43,6 +43,9 @@ class WandbTrainPlugin(ArenaPlugin):
         self.episode_count = 0
         self.agent = None
         self.agent_encoded_name = agent_encoded_name
+        self.best_model_filename = None
+        # Notice that the best model won't be uploaded if it's not better than the initialization.
+        self.best_model_relative_elo = -800
 
     def _initialize(self, game):
         assert self.agent
@@ -91,6 +94,24 @@ class WandbTrainPlugin(ArenaPlugin):
 
         self.episode_count += 1
 
+    def _upload_model(self, save_file: str, aliases: list[str] | None = None) -> str:
+        assert self.agent
+
+        artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
+        artifact.add_file(local_path=save_file)
+        artifact.save()
+        wandb.log_artifact(artifact, aliases=aliases).wait(60)
+        print(f"Done! Model uploaded with version {artifact.version} and aliases {artifact.aliases}")
+
+        wand_file = resolve_path(self.agent.params.wandb_dir, self.agent.wandb_local_filename(artifact))
+
+        # Now that we know the digest, rename the file to include it, so it takes the expected name and
+        # doesn't need to be re-downloaded from wandb.
+        # Source and target file are in the same path, just a different file name
+        os.rename(save_file, wand_file)
+        print(f"Model saved to {wand_file}")
+        return str(wand_file)
+
     def end_arena(self, game, results):
         assert self.agent
         if not self.params.upload_model:
@@ -98,32 +119,32 @@ class WandbTrainPlugin(ArenaPlugin):
             wandb.finish()
             return
 
-        # Save the model in the wandb directory with the suffix "temp".  The file will be renamed
+        # Save the model in the wandb directory with the suffix "final".  The file will be renamed
         # once we upload it to wandb and have the digest.
-        save_file = resolve_path(self.agent.params.wandb_dir, self.agent.resolve_filename("temp"))
+        save_file = resolve_path(self.agent.params.wandb_dir, self.agent.resolve_filename("final"))
         self.agent.save_model(save_file)
 
-        artifact = wandb.Artifact(f"{self.agent.model_id()}", type="model", metadata=asdict(self.agent.params))
-        artifact.add_file(local_path=str(save_file))
-        artifact.save()
-        print("Model being uploaded to wandb")
-        wandb.log_artifact(artifact).wait(60)
-        print(f"Model uploaded with version {artifact.version}")
+        print("Uploading the final model to wandb...")
+        wandb_file = self._upload_model(str(save_file))
+        relative_elo = self.compute_tournament_metrics(wandb_file)
 
-        wand_file = resolve_path(self.agent.params.wandb_dir, self.agent.wandb_local_filename(artifact))
+        if self.best_model_relative_elo > relative_elo and self.best_model_filename is not None:
+            print("Uploading the best model to wandb...")
+            self._upload_model(self.best_model_filename, aliases=[f"{self.run.id}-best"])
 
-        # Now that we know the digest, rename the file to include it.  Source and target file are in
-        # the same path, just a different file name
-        os.rename(save_file, wand_file)
-        print(f"Model saved to {wand_file}")
-        self.compute_tournament_metrics(str(wand_file))
         wandb.finish()
 
-    def compute_tournament_metrics(self, model_filename: str):
+    def compute_tournament_metrics(self, model_filename: str) -> int:
         _, elo_table, relative_elo, win_perc, absolute_elo = self.metrics.compute(
             self.agent_encoded_name + f",model_filename={model_filename}"
         )
+
         print(f"Tournament Metrics - Relative elo: {relative_elo}, win percentage: {win_perc}")
+        if relative_elo > self.best_model_relative_elo:
+            self.best_model_relative_elo = relative_elo
+            self.best_model_filename = model_filename
+            print("Best Relative Elo so far!")
+
         wandb_elo_table = wandb.Table(
             columns=["Player", "elo"], data=[[player, elo] for player, elo in elo_table.items()]
         )
@@ -131,3 +152,5 @@ class WandbTrainPlugin(ArenaPlugin):
             {"elo": wandb_elo_table, "relative_elo": relative_elo, "win_perc": win_perc, "absolute_elo": absolute_elo},
             step=self.episode_count,
         )
+
+        return relative_elo

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -22,6 +22,7 @@ def train_dqn(
     players: list = [],
     renderers: list[ArenaPlugin] = [],
     run_id: str = "",
+    trigger_metrics: Optional[tuple[int, int]] = None,
 ):
     plugins = []
     total_episodes = episodes * (len(players) - 1)
@@ -40,6 +41,7 @@ def train_dqn(
             save_final=wandb_params is None,
             run_id=run_id,
             after_save=after_save_method,
+            trigger_metrics=trigger_metrics,
         )
     )
 
@@ -91,7 +93,13 @@ if __name__ == "__main__":
         help="Render modes to be used. Note that TrainingStatusRenderer is always included",
     )
     parser.add_argument("-w", "--wandb", nargs="?", const="", default=None, type=str)
-
+    parser.add_argument(
+        "--trigger-metrics",
+        nargs=2,
+        type=int,
+        metavar=("wins", "last_episodes"),
+        help="Trigger tournament metrics computation and save the model if there were 'wins' wins in the last 'last_episodes'",
+    )
     args = parser.parse_args()
 
     renderers = [Renderer.create(r) for r in args.renderers]
@@ -124,6 +132,7 @@ if __name__ == "__main__":
         players=args.players,
         renderers=renderers,
         wandb_params=wandb_params,
+        trigger_metrics=args.trigger_metrics,
     )
 
     print("Training completed!")


### PR DESCRIPTION
From Diego's wishlist for wandb:
- When we save the model and compute the metrics, keep track of which one scored the highest in relative elo and (unless is the same as the final model) upload it to wandb
- When training, if you use for example: ` --trigger-metrics 95 100` , whenever 95 matches are won out of the last 100 during training, the model will be saved and the metrics computed.  Then, we clear the state so that we don't trigger it right after if there's another win, so you'll need at least 95 more matches to trigger another save.
- If you press ctrl-c or an exception is raised, it's caught and we still call end_arena, giving a chance to upload to wandb and other stuff.  An additional adavantage is that if you do ctrl-c during play it will show the results so far.

It's supposed to tag the best model with "{run_id}-best", but it's not working.  I think it may be related to the issue wandb is dealing with right now, so I don't think it's worth debugging more unless tags are not working after it's fixed.