### PR TITLE
Optimize get_player_position

### DIFF
--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -108,7 +108,8 @@ class Board:
         """
         Get the position of the player's pawn.
         """
-        return tuple(self._player_positions[player])
+        pos = self._player_positions[player]
+        return (pos[0], pos[1])
 
     def move_player(self, player: Player, new_position: tuple[int, int]):
         """


### PR DESCRIPTION
chatgpt says that the conversion from np.array to list is relatively slow because it iterates over the array, and the fastest is to just use a tuple (but it would require multiple changes), or an easier but not as efficient solution is to do as I do in this PR.
I just tried it and in the profiling it's taking now half of the time for get_player_position, and the running time for Simple came down from 6.4ms to 6ms approx, so not a huge gain of course but worth for such trivial change.

Profiling before:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
819598/2703    2.011    0.000   21.882    0.008 simple.py:83(choose_action)
  3339726    1.876    0.000    1.876    0.000 quoridor.py:107(get_player_position)
  1555662    1.779    0.000    1.779    0.000 quoridor.py:363(distance_to_target)
    47089    1.776    0.000    4.821    0.000 quoridor.py:321(get_valid_wall_actions)
    41606    1.637    0.000    7.454    0.000 simple.py:48(sample_actions)
   827018    1.100    0.000    2.288    0.000 quoridor.py:274(is_action_valid)
```

Profiling after:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
819598/2703    1.993    0.000   20.467    0.008 simple.py:83(choose_action)
  1555662    1.771    0.000    1.771    0.000 quoridor.py:364(distance_to_target)
    47089    1.757    0.000    4.835    0.000 quoridor.py:322(get_valid_wall_actions)
    41606    1.611    0.000    7.323    0.000 simple.py:48(sample_actions)
   827018    1.090    0.000    2.087    0.000 quoridor.py:275(is_action_valid)
    98808    1.036    0.000    1.036    0.000 {built-in method numpy.array}
  1256134    0.820    0.000    1.081    0.000 quoridor.py:184(is_wall_between)
   340951    0.802    0.000    2.242    0.000 greedy.py:49(_next_moves)
  3339726    0.750    0.000    0.750    0.000 quoridor.py:107(get_player_position)
   738808    0.748    0.000    1.669    0.000 quoridor.py:149(add_wall)
```

Just to make sure it's not just something off with profiling (since the overhead added may be significant for small functions), runnig this:
```
 time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/play.py  -p simple greedy -t 100 -r progressbar computationtimes
```
before this PR took 20.3s and with this PR came down to 19.3s
