### PR TITLE
Make ActionEncoder a singleton-ish

### DIFF
--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -1,6 +1,7 @@
 import copy
 from dataclasses import dataclass
 from enum import IntEnum, unique
+from functools import cache
 from typing import Optional, Sequence
 
 import numpy as np
@@ -35,9 +36,29 @@ class WallAction(Action):
 
 
 class ActionEncoder:
+    _instances = {}
+
+    def __new__(cls, board_size: int):
+        """
+        We use a singleton pattern to avoid creating multiple instances of the ActionEncoder for the same board size.
+        """
+        if board_size not in cls._instances:
+            cls._instances[board_size] = super().__new__(cls)
+
+        return cls._instances[board_size]
+
     def __init__(self, board_size: int):
+        if hasattr(self, "board_size"):
+            return
+
         self.board_size = board_size
         self.wall_size = board_size - 1
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        return self
 
     def action_to_index(self, action) -> int:
         """
@@ -52,6 +73,7 @@ class ActionEncoder:
         else:
             raise ValueError(f"Invalid action type: {action}")
 
+    @cache
     def index_to_action(self, idx) -> Action:
         """
         Converts an action index to an action object.

--- a/deep_quoridor/test/quoridor_test.py
+++ b/deep_quoridor/test/quoridor_test.py
@@ -1,6 +1,14 @@
 import numpy as np
 import pytest
-from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor, WallAction, WallOrientation
+from quoridor import (
+    ActionEncoder,
+    Board,
+    MoveAction,
+    Player,
+    Quoridor,
+    WallAction,
+    WallOrientation,
+)
 from quoridor_env import env as quoridor_env
 
 
@@ -386,3 +394,20 @@ class TestQuoridor:
             . . . . . .
             . . 2 . . .
         """)
+
+
+class TestActionEncoder:
+    def test_action_encoder(self):
+        a5 = ActionEncoder(5)
+        a5_again = ActionEncoder(5)
+        assert a5 is a5_again
+
+        a9 = ActionEncoder(9)
+        assert a5 is not a9
+
+        action_a = a5.index_to_action(10)
+        action_b = a5_again.index_to_action(10)
+        assert action_a is action_b
+
+        action_c = a9.index_to_action(10)
+        assert action_a is not action_c


### PR DESCRIPTION
We call ActionEncoder.index_to_action a bazillion times, and returning a new object each time when there's a very limited set of possible objects takes a lot of memory and is slow.  
We had it cached before but when using deepcopy to copy the games, it was copying the ActionEncoder object and therefore we were losing the cache, making it use a lot of memory.
With this approach, we can only have 1 ActionEncoder instance per board size, even when using deepcopy.
Running benchmark_B5W3 with this change took 9:32, vs 11:43 before it