### PR TITLE
Cache compiled numba code

### DIFF
--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -34,7 +34,7 @@ class SimpleParams(SubargsBase):
     discount_factor: float = 0.99
 
 
-@njit
+@njit(cache=True)
 def gaussian_wall_weights(wall_actions, p1_pos, p2_pos, sigma):
     """
     Calculate Gaussian weights for wall actions based on distance to players (Numba-optimized).
@@ -64,7 +64,7 @@ def gaussian_wall_weights(wall_actions, p1_pos, p2_pos, sigma):
     return weights
 
 
-@njit
+@njit(cache=True)
 def sample_actions(
     grid, player_positions, walls_remaining, goal_rows, current_player, branching_factor, wall_sigma=0.5
 ):
@@ -127,7 +127,7 @@ def sample_actions(
         return combined_actions
 
 
-@njit
+@njit(cache=True)
 def compute_heuristic_for_game_state(grid, player_positions, walls_remaining, goal_rows, agent_player):
     """
     Evaluate a board position (Numba-optimized).
@@ -150,7 +150,7 @@ def compute_heuristic_for_game_state(grid, player_positions, walls_remaining, go
     return distance_reward + wall_reward
 
 
-@njit
+@njit(cache=True)
 def minimax(
     action,
     grid,
@@ -235,7 +235,7 @@ def minimax(
     return best_value
 
 
-@njit(parallel=True)
+@njit(cache=True, parallel=True)
 def evaluate_actions(
     grid,
     player_positions,

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -56,7 +56,7 @@ CELL_PLAYER2 = 1
 CELL_WALL = 10
 
 
-@njit
+@njit(cache=True)
 def distance_to_row(grid: np.ndarray, start_row: int, start_col: int, target_row: int) -> int:
     """
     Args:
@@ -129,7 +129,7 @@ def distance_to_row(grid: np.ndarray, start_row: int, start_col: int, target_row
     return -1
 
 
-@njit
+@njit(cache=True)
 def are_wall_cells_free(grid: np.ndarray, wall_row: int, wall_col: int, wall_orientation: int) -> bool:
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
@@ -156,7 +156,7 @@ def are_wall_cells_free(grid: np.ndarray, wall_row: int, wall_col: int, wall_ori
         )
 
 
-@njit
+@njit(cache=True)
 def is_wall_potential_block(grid, wall_row, wall_col, wall_orientation):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
@@ -206,7 +206,7 @@ def is_wall_potential_block(grid, wall_row, wall_col, wall_orientation):
         return touches >= 2
 
 
-@njit
+@njit(cache=True)
 def set_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
@@ -229,7 +229,7 @@ def set_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
         grid[start_i, start_j + 2] = cell_value
 
 
-@njit
+@njit(cache=True)
 def check_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
     """
     Return True iff all the grid cells for the wall equal the given value.
@@ -258,7 +258,7 @@ def check_wall_cells(grid, wall_row, wall_col, wall_orientation, cell_value):
         )
 
 
-@njit
+@njit(cache=True)
 def is_move_action_valid(grid, player_positions, current_player, destination_row, destination_col):
     grid_height = grid.shape[0]
     grid_width = grid.shape[1]
@@ -364,7 +364,7 @@ def is_move_action_valid(grid, player_positions, current_player, destination_row
         return False
 
 
-@njit
+@njit(cache=True)
 def is_wall_action_valid(
     grid, player_positions, walls_remaining, goal_rows, current_player, wall_row, wall_col, wall_orientation
 ):
@@ -389,7 +389,7 @@ def is_wall_action_valid(
     return is_valid
 
 
-@njit
+@njit(cache=True)
 def compute_move_action_mask(
     grid: np.ndarray,
     player_positions: np.ndarray,
@@ -415,7 +415,7 @@ def compute_move_action_mask(
     return action_mask
 
 
-@njit
+@njit(cache=True)
 def compute_wall_action_mask(
     grid: np.ndarray,
     player_positions: np.ndarray,
@@ -462,7 +462,7 @@ def compute_wall_action_mask(
     return action_mask
 
 
-@njit
+@njit(cache=True)
 def check_win(player_positions, goal_rows, player):
     """
     Check if a player has won (Numba-optimized).
@@ -470,7 +470,7 @@ def check_win(player_positions, goal_rows, player):
     return player_positions[player, 0] == goal_rows[player]
 
 
-@njit
+@njit(cache=True)
 def apply_action(grid, player_positions, walls_remaining, current_player, action):
     """
     Apply an action to the game state (Numba-optimized).
@@ -507,7 +507,7 @@ def apply_action(grid, player_positions, walls_remaining, current_player, action
         walls_remaining[current_player] -= 1
 
 
-@njit
+@njit(cache=True)
 def undo_action(grid, player_positions, walls_remaining, player_that_took_action, action, previous_position):
     action_type = action[2]
 
@@ -543,7 +543,7 @@ def undo_action(grid, player_positions, walls_remaining, player_that_took_action
         walls_remaining[player_that_took_action] += 1
 
 
-@njit
+@njit(cache=True)
 def get_valid_move_actions(grid, player_positions, current_player):
     """
     Get all valid move actions (Numba-optimized).
@@ -566,7 +566,7 @@ def get_valid_move_actions(grid, player_positions, current_player):
     return actions[:count]  # Return only valid actions
 
 
-@njit
+@njit(cache=True)
 def get_valid_wall_actions(grid, player_positions, walls_remaining, goal_rows, current_player):
     """
     Get all valid wall actions (Numba-optimized).

--- a/deep_quoridor/src/renderers/computation_times.py
+++ b/deep_quoridor/src/renderers/computation_times.py
@@ -12,7 +12,7 @@ class ComputationTimesRenderer(Renderer):
                 if player not in player_moves:
                     player_moves[player] = []
 
-                player_moves[player] = [move for move in result.moves if move.player == player]
+                player_moves[player].extend([move for move in result.moves if move.player == player])
 
         table = PrettyTable()
         table.field_names = ["Player", "Average Time (ms)", "Min Time (ms)", "Max Time (ms)"]


### PR DESCRIPTION
This saves about 8 seconds of compilation time each time I run `play.py` with the simple agent. I also fixed a stupid bug where the computation times renderer only used the last game played in the arena for each agent.

The compiled functions get cached as `.nbc` files in the `__pycache__` directory, e.g.:
```
deep_quoridor/src/__pycache__/qgrid.set_wall_cells-209.py312.9.nbc
deep_quoridor/src/__pycache__/qgrid.undo_action-510.py312.1.nbc
deep_quoridor/src/__pycache__/qgrid.get_valid_move_actions-546.py312.1.nbc
deep_quoridor/src/__pycache__/qgrid.set_wall_cells-209.py312.6.nbc
deep_quoridor/src/__pycache__/qgrid.is_wall_potential_block-159.py312.1.nbc
deep_quoridor/src/agents/__pycache__/simple.evaluate_actions-238.py312.1.nbc
deep_quoridor/src/agents/__pycache__/simple.compute_heuristic_for_game_state-130.py312.1.nbc
```