### PR TITLE
Adds metrics logging to AlphaZero OpenSpiel training

### DIFF
--- a/deep_quoridor/src/osaz/alphazero_quoridor.py
+++ b/deep_quoridor/src/osaz/alphazero_quoridor.py
@@ -19,6 +19,7 @@ from open_spiel.python.algorithms.alpha_zero import evaluator as az_evaluator
 from open_spiel.python.algorithms.alpha_zero import model as az_model
 from open_spiel.python.bots import uniform_random
 from open_spiel.python.utils import spawn
+from osaz.wandb_logger import AlphaZeroWandbLogger
 
 import wandb
 
@@ -185,10 +186,24 @@ def main(_):
 
     # Train the model if not in eval_only mode
     if not FLAGS.eval_only:
+        # Initialize the wandb logger thread if wandb is enabled
+        wandb_logger = None
+        if FLAGS.use_wandb and wandb_run is not None:
+            # Create and start the logger thread
+            wandb_logger = AlphaZeroWandbLogger(
+                experiment_dir=checkpoint_dir,
+                wandb_run=wandb_run,
+                watch_interval_seconds=30,
+            )
+            wandb_logger.start()
+            print(f"Started wandb metrics logger thread for {checkpoint_dir}/learner.jsonl")
         # Run Alpha Zero with the given configuration
         with spawn.main_handler():
             alpha_zero.alpha_zero(config)
 
+        # Stop the logger thread if it was started
+        if wandb_logger is not None:
+            wandb_logger.stop()
         final_checkpoint = f"{checkpoint_dir}/checkpoint--1"
         # Log model as artifact if wandb is enabled
         if FLAGS.use_wandb and FLAGS.upload_model and not FLAGS.eval_only:

--- a/deep_quoridor/src/osaz/alphazero_quoridor.py
+++ b/deep_quoridor/src/osaz/alphazero_quoridor.py
@@ -80,7 +80,7 @@ flags.DEFINE_integer("evaluators", 2, "Number of evaluation processes to run in 
 # Evaluation parameters
 flags.DEFINE_integer("eval_games", 10, "Number of games for evaluation.")
 flags.DEFINE_boolean("eval_only", False, "Skip training and only evaluate an existing model.")
-flags.DEFINE_bool("verbose", True, "Be verbose.")
+flags.DEFINE_bool("verbose", False, "Be verbose.")
 
 # Weights & Biases parameters
 flags.DEFINE_string("wandb_project", "deep_quoridor", "Name of the wandb project.")

--- a/deep_quoridor/src/osaz/wandb_logger.py
+++ b/deep_quoridor/src/osaz/wandb_logger.py
@@ -1,0 +1,149 @@
+"""
+AlphaZero wandb metrics logger.
+
+This module provides a threaded logger that reads AlphaZero's learner.jsonl file
+and sends the metrics to wandb.
+"""
+
+import json
+import os
+import threading
+import time
+from typing import Any, Dict, List
+
+
+class AlphaZeroWandbLogger:
+    """Logger that reads AlphaZero's learner.jsonl and uploads metrics to wandb.
+
+    This class is designed to be run in a separate thread to monitor the
+    learner.jsonl file and upload metrics to wandb as they become available.
+    """
+
+    def __init__(
+        self,
+        experiment_dir: str,
+        wandb_run: Any,
+        watch_interval_seconds: int = 30,
+    ):
+        """
+        Initialize the logger.
+
+        Args:
+            experiment_dir: Directory where learner.jsonl is located
+            wandb_run: Direct wandb run object to log metrics to
+            watch_interval_seconds: How often to check for updates when watching
+        """
+        self.experiment_dir = experiment_dir
+        self.jsonl_path = os.path.join(experiment_dir, "learner.jsonl")
+        self.wandb_run = wandb_run
+        self.watch_interval = watch_interval_seconds
+        self.last_position = 0
+        # wandb_run is already set in __init__
+        self.stop_event = threading.Event()
+        self.thread = None
+
+    def _read_config(self) -> Dict[str, Any]:
+        """Read the config.json file to get experiment configuration."""
+        config_path = os.path.join(self.experiment_dir, "config.json")
+        if not os.path.exists(config_path):
+            print(f"Warning: No config.json found at {config_path}")
+            return {}
+
+        try:
+            with open(config_path, "r") as f:
+                content = f.read().strip()
+                if not content:  # Empty file
+                    print(f"Warning: config.json at {config_path} is empty")
+                    return {}
+                return json.loads(content)
+        except json.JSONDecodeError as e:
+            print(f"Warning: Failed to parse config.json: {e}")
+            return {}
+        except Exception as e:
+            print(f"Warning: Error reading config.json: {e}")
+            return {}
+
+    def _parse_new_lines(self) -> List[Dict[str, Any]]:
+        """Read new lines from the jsonl file."""
+        if not os.path.exists(self.jsonl_path):
+            return []
+
+        entries = []
+        try:
+            with open(self.jsonl_path, "r") as f:
+                f.seek(self.last_position)
+                for line in f:
+                    if line.strip():
+                        try:
+                            entry = json.loads(line)
+                            entries.append(entry)
+                        except json.JSONDecodeError:
+                            print(f"Warning: Could not parse line: {line}")
+                self.last_position = f.tell()
+        except FileNotFoundError:
+            # File might not exist yet
+            pass
+        except Exception as e:
+            print(f"Error reading from {self.jsonl_path}: {e}")
+        return entries
+
+    def _log_entries(self, entries: List[Dict[str, Any]]):
+        """Log entries to wandb."""
+        if not entries:
+            return
+
+        for entry in entries:
+            # Extract step number
+            step = entry.get("step", 0)
+
+            # Convert all scalar values to a flattened dict
+            metrics = {}
+            for k, v in entry.items():
+                if k != "step" and isinstance(v, (int, float)):
+                    metrics[k] = v
+
+            # Log metrics to wandb
+            if metrics:
+                self.wandb_run.log(metrics, step=step)
+
+    def _watch_loop(self):
+        """Main watch loop that monitors the file and uploads metrics."""
+        # Read config but don't need to use it directly
+        self._read_config()
+
+        # Process existing data
+        entries = self._parse_new_lines()
+        if entries:
+            self._log_entries(entries)
+
+        # Watch for updates until stopped
+        while not self.stop_event.is_set():
+            time.sleep(self.watch_interval)
+
+            # Check if the file exists now (might have been created after init)
+            entries = self._parse_new_lines()
+            if entries:
+                self._log_entries(entries)
+
+    def start(self):
+        """Start the logger in a separate thread."""
+        if self.thread is not None and self.thread.is_alive():
+            print("Logger is already running")
+            return
+
+        self.stop_event.clear()
+        self.thread = threading.Thread(target=self._watch_loop, name="AlphaZeroWandbLogger", daemon=True)
+        self.thread.start()
+        print(f"Started wandb metrics logger for {self.jsonl_path}")
+
+    def stop(self):
+        """Stop the logger thread."""
+        if self.thread is not None and self.thread.is_alive():
+            self.stop_event.set()
+            self.thread.join(timeout=5.0)
+            if self.thread.is_alive():
+                print("Warning: Logger thread did not stop cleanly")
+            else:
+                print("Stopped wandb metrics logger")
+
+        self.thread = None

--- a/deep_quoridor/src/osaz/wandb_logger.py
+++ b/deep_quoridor/src/osaz/wandb_logger.py
@@ -99,8 +99,17 @@ class AlphaZeroWandbLogger:
             # Convert all scalar values to a flattened dict
             metrics = {}
             for k, v in entry.items():
-                if k != "step" and isinstance(v, (int, float)):
-                    metrics[k] = v
+                if k != "step":
+                    # Handle nested loss metrics
+                    if k == "loss" and isinstance(v, dict):
+                        for loss_key, loss_val in v.items():
+                            if isinstance(loss_val, (int, float)):
+                                metrics[f"loss_{loss_key}"] = loss_val
+                    if k == "game_length" and isinstance(v, dict):
+                        metrics["avg_game_length"] = v.get("avg", 0)
+                    # Handle regular scalar metrics
+                    elif isinstance(v, (int, float)):
+                        metrics[k] = v
 
             # Log metrics to wandb
             if metrics:


### PR DESCRIPTION
# Add Weights & Biases Metrics Logging to AlphaZero

This PR adds real-time metrics logging for AlphaZero training to Weights & Biases.

## Features

- **Non-invasive metrics logging**: Implemented a separate thread to monitor the AlphaZero `learner.jsonl` file and upload metrics to wandb in real-time without modifying the core OpenSpiel code
- **Robust JSON parsing**: Added comprehensive error handling for reading and parsing metrics from the log file
- **Threaded monitoring**: The logger runs in a separate daemon thread to avoid blocking the main training process
- **Clean integration**: Integrated with the existing wandb artifact management system for models

## Implementation Details

- Created a new `AlphaZeroWandbLogger` class in `wandb_logger.py` that:
  - Monitors the `learner.jsonl` file for new metrics entries
  - Parses metrics into a format suitable for wandb
  - Uploads metrics with appropriate step indexing

- Added thread management in `alphazero_quoridor.py`:
  - Initializes the logger thread when wandb is enabled
  - Properly starts/stops the thread to ensure clean operation

## Bug Fixes

- Fixed issue where the logger would crash when trying to fetch a newly created wandb run via the API
  - Solution: Pass the wandb run object directly to the logger instead of the run ID
  
- Fixed issue where the logger would crash if the config.json file was empty or malformed
  - Solution: Added robust error handling in the _read_config method

- Fixed various linting issues and improved code organization

## Testing

This has been manually tested to ensure:
- Metrics are uploaded to wandb in real-time during training
- Thread is properly started and stopped during the training lifecycle
- Error handling works correctly for edge cases

## Future Improvements

- Add support for visualizing learning curves and model performance metrics
- Implement more detailed configuration options for metric filtering
- Add support for logging evaluation metrics alongside training metrics


# Sample logging output

![image](https://github.com/user-attachments/assets/ad1d5179-4265-4902-a21a-b0388cd2038d)
