### PR TITLE
Naf/enable gpu for alphazero training

### DIFF
--- a/deep_quoridor/src/osaz/alphazero_quoridor.py
+++ b/deep_quoridor/src/osaz/alphazero_quoridor.py
@@ -7,22 +7,22 @@ import collections
 import datetime
 import getpass
 import json
-import os
-import sys
 import multiprocessing
+import os
 
 # Set TF environment variables for GPU memory management and device visibility.
 # This must be done BEFORE TensorFlow is imported.
-os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
-os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"
 
 # Set the start method to 'spawn' for CUDA compatibility and monkey-patch
 # to prevent OpenSpiel from overriding it.
 try:
     multiprocessing.set_start_method("spawn", force=True)
+
     # Monkey-patch to prevent OpenSpiel from changing the start method.
     def _do_nothing_set_start_method(method, force=False):
         pass
+
     multiprocessing.set_start_method = _do_nothing_set_start_method
 except RuntimeError:
     # This may be raised in child processes where the context is already set.
@@ -43,7 +43,6 @@ from osaz.wandb_logger import AlphaZeroWandbLogger
 import wandb
 
 # Import wandb for logging and visualization is at the top
-
 
 
 # Add a custom JSON encoder to handle NumPy types

--- a/deep_quoridor/src/osaz/alphazero_quoridor.py
+++ b/deep_quoridor/src/osaz/alphazero_quoridor.py
@@ -38,6 +38,7 @@ from open_spiel.python.algorithms.alpha_zero import evaluator as az_evaluator
 from open_spiel.python.algorithms.alpha_zero import model as az_model
 from open_spiel.python.bots import uniform_random
 from open_spiel.python.utils import spawn
+from osaz.wandb_logger import AlphaZeroWandbLogger
 
 import wandb
 
@@ -96,7 +97,7 @@ flags.DEFINE_integer("evaluators", 2, "Number of evaluation processes to run in 
 # Evaluation parameters
 flags.DEFINE_integer("eval_games", 10, "Number of games for evaluation.")
 flags.DEFINE_boolean("eval_only", False, "Skip training and only evaluate an existing model.")
-flags.DEFINE_bool("verbose", True, "Be verbose.")
+flags.DEFINE_bool("verbose", False, "Be verbose.")
 
 # Weights & Biases parameters
 flags.DEFINE_string("wandb_project", "deep_quoridor", "Name of the wandb project.")
@@ -202,10 +203,24 @@ def main(_):
 
     # Train the model if not in eval_only mode
     if not FLAGS.eval_only:
+        # Initialize the wandb logger thread if wandb is enabled
+        wandb_logger = None
+        if FLAGS.use_wandb and wandb_run is not None:
+            # Create and start the logger thread
+            wandb_logger = AlphaZeroWandbLogger(
+                experiment_dir=checkpoint_dir,
+                wandb_run=wandb_run,
+                watch_interval_seconds=30,
+            )
+            wandb_logger.start()
+            print(f"Started wandb metrics logger thread for {checkpoint_dir}/learner.jsonl")
         # Run Alpha Zero with the given configuration
         with spawn.main_handler():
             alpha_zero.alpha_zero(config)
 
+        # Stop the logger thread if it was started
+        if wandb_logger is not None:
+            wandb_logger.stop()
         final_checkpoint = f"{checkpoint_dir}/checkpoint--1"
         # Log model as artifact if wandb is enabled
         if FLAGS.use_wandb and FLAGS.upload_model and not FLAGS.eval_only:

--- a/deep_quoridor/src/osaz/alphazero_quoridor.py
+++ b/deep_quoridor/src/osaz/alphazero_quoridor.py
@@ -8,6 +8,25 @@ import datetime
 import getpass
 import json
 import os
+import sys
+import multiprocessing
+
+# Set TF environment variables for GPU memory management and device visibility.
+# This must be done BEFORE TensorFlow is imported.
+os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+
+# Set the start method to 'spawn' for CUDA compatibility and monkey-patch
+# to prevent OpenSpiel from overriding it.
+try:
+    multiprocessing.set_start_method("spawn", force=True)
+    # Monkey-patch to prevent OpenSpiel from changing the start method.
+    def _do_nothing_set_start_method(method, force=False):
+        pass
+    multiprocessing.set_start_method = _do_nothing_set_start_method
+except RuntimeError:
+    # This may be raised in child processes where the context is already set.
+    pass
 
 import numpy as np
 import pyspiel
@@ -19,14 +38,11 @@ from open_spiel.python.algorithms.alpha_zero import evaluator as az_evaluator
 from open_spiel.python.algorithms.alpha_zero import model as az_model
 from open_spiel.python.bots import uniform_random
 from open_spiel.python.utils import spawn
-from osaz.wandb_logger import AlphaZeroWandbLogger
 
 import wandb
 
 # Import wandb for logging and visualization is at the top
 
-# Force TensorFlow to use CPU only to avoid CUDA errors
-os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
 
 # Add a custom JSON encoder to handle NumPy types
@@ -80,7 +96,7 @@ flags.DEFINE_integer("evaluators", 2, "Number of evaluation processes to run in 
 # Evaluation parameters
 flags.DEFINE_integer("eval_games", 10, "Number of games for evaluation.")
 flags.DEFINE_boolean("eval_only", False, "Skip training and only evaluate an existing model.")
-flags.DEFINE_bool("verbose", False, "Be verbose.")
+flags.DEFINE_bool("verbose", True, "Be verbose.")
 
 # Weights & Biases parameters
 flags.DEFINE_string("wandb_project", "deep_quoridor", "Name of the wandb project.")
@@ -186,24 +202,10 @@ def main(_):
 
     # Train the model if not in eval_only mode
     if not FLAGS.eval_only:
-        # Initialize the wandb logger thread if wandb is enabled
-        wandb_logger = None
-        if FLAGS.use_wandb and wandb_run is not None:
-            # Create and start the logger thread
-            wandb_logger = AlphaZeroWandbLogger(
-                experiment_dir=checkpoint_dir,
-                wandb_run=wandb_run,
-                watch_interval_seconds=30,
-            )
-            wandb_logger.start()
-            print(f"Started wandb metrics logger thread for {checkpoint_dir}/learner.jsonl")
         # Run Alpha Zero with the given configuration
         with spawn.main_handler():
             alpha_zero.alpha_zero(config)
 
-        # Stop the logger thread if it was started
-        if wandb_logger is not None:
-            wandb_logger.stop()
         final_checkpoint = f"{checkpoint_dir}/checkpoint--1"
         # Log model as artifact if wandb is enabled
         if FLAGS.use_wandb and FLAGS.upload_model and not FLAGS.eval_only:


### PR DESCRIPTION
I used Windsurf with gemini 2.5 to generate the code for this PR so I will let Gemini 2.5 explain what it does ;)

### Code Breakdown
`os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true': `This line tells TensorFlow to be flexible with its GPU memory allocation. Instead of grabbing all available GPU memory at once, it will start with a small amount and only request more as needed during the training process. This is a good practice to avoid memory fragmentation and allow other processes to use the GPU simultaneously.

`os.environ['CUDA_VISIBLE_DEVICES'] = '0': `This environment variable specifies which GPU (or GPUs) the script is allowed to see and use. In this case, it's restricted to the GPU with the index '0'. This is useful for managing multiple GPUs on a single machine, ensuring that the training job only runs on the intended device.

`multiprocessing.set_start_method("spawn", force=True):` This is crucial for compatibility between multiprocessing and CUDA (the platform that allows software to use NVIDIA GPUs). When a new process is needed (as is common in complex training pipelines like AlphaZero for self-play), the "spawn" method starts a fresh Python interpreter process. This is a clean way to start new processes and is required for CUDA to work correctly in a multiprocessing context. The force=True flag ensures this method is set, even if it has been set before.

Monkey-Patching multiprocessing.set_start_method: The subsequent block of code, which defines a do-nothing function and assigns it to multiprocessing.set_start_method, is a clever workaround. It's included because the OpenSpiel library might internally try to set the multiprocessing start method to something different (like "fork"), which would conflict with the "spawn" method required for GPU usage with CUDA. By replacing the function with one that does nothing, the script prevents OpenSpiel from overriding the necessary "spawn" configuration.

### Why It Enables GPU Training
In short, this code sets up the ideal environment for GPU-accelerated training with AlphaZero in OpenSpiel:

Selects the GPU: It explicitly tells the script which GPU to use.
Manages GPU Memory: It configures TensorFlow to use GPU memory efficiently, preventing crashes due to memory allocation issues.
Ensures CUDA Compatibility: It forces the use of the "spawn" start method for new processes, which is a prerequisite for using CUDA in a multiprocessing application.
Prevents Library Conflicts: It cleverly stops OpenSpiel from undoing the critical multiprocessing configuration.
Without these settings, you would likely encounter errors related to CUDA initialization, illegal memory access, or conflicts between TensorFlow and OpenSpiel's process management, preventing the AlphaZero agent from being trained on the GPU.