### PR TITLE
Show median value for computation times

### DIFF
--- a/deep_quoridor/src/renderers/computation_times.py
+++ b/deep_quoridor/src/renderers/computation_times.py
@@ -1,3 +1,5 @@
+import statistics
+
 from arena import GameResult
 from prettytable import PrettyTable
 
@@ -15,7 +17,7 @@ class ComputationTimesRenderer(Renderer):
                 player_moves[player].extend([move for move in result.moves if move.player == player])
 
         table = PrettyTable()
-        table.field_names = ["Player", "Average Time (ms)", "Min Time (ms)", "Max Time (ms)"]
+        table.field_names = ["Player", "Average Time (ms)", "Min Time (ms)", "Max Time (ms)", "Median Time (ms)"]
 
         for player, moves in player_moves.items():
             num_moves = len(moves)
@@ -26,6 +28,7 @@ class ComputationTimesRenderer(Renderer):
                     f"{sum(computation_times_ms) / num_moves:.3f}",
                     f"{min(computation_times_ms):.3f}",
                     f"{max(computation_times_ms):.3f}",
+                    f"{statistics.median(computation_times_ms):.3f}",
                 ]
             )
 

--- a/deep_quoridor/src/renderers/computation_times.py
+++ b/deep_quoridor/src/renderers/computation_times.py
@@ -17,7 +17,8 @@ class ComputationTimesRenderer(Renderer):
                 player_moves[player].extend([move for move in result.moves if move.player == player])
 
         table = PrettyTable()
-        table.field_names = ["Player", "Average Time (ms)", "Min Time (ms)", "Max Time (ms)", "Median Time (ms)"]
+        table.title = "Computation times (ms)"
+        table.field_names = ["Player", "Average", "Min", "Max", "Median"]
 
         for player, moves in player_moves.items():
             num_moves = len(moves)


### PR DESCRIPTION
And add a title to the table. Median computation time is useful for cases where an agent does caching or jit-ing, or does training inside get_action.