### PR TITLE
New metric: dumb score

### DIFF
--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -134,7 +134,7 @@ class WandbTrainPlugin(ArenaPlugin):
         wandb.finish()
 
     def compute_tournament_metrics(self, model_filename: str) -> int:
-        _, elo_table, relative_elo, win_perc, absolute_elo = self.metrics.compute(
+        _, elo_table, relative_elo, win_perc, absolute_elo, dumb_score = self.metrics.compute(
             self.agent_encoded_name + f",model_filename={model_filename}"
         )
 
@@ -148,7 +148,13 @@ class WandbTrainPlugin(ArenaPlugin):
             columns=["Player", "elo"], data=[[player, elo] for player, elo in elo_table.items()]
         )
         self.run.log(
-            {"elo": wandb_elo_table, "relative_elo": relative_elo, "win_perc": win_perc, "absolute_elo": absolute_elo},
+            {
+                "elo": wandb_elo_table,
+                "relative_elo": relative_elo,
+                "win_perc": win_perc,
+                "absolute_elo": absolute_elo,
+                "dumb_score": dumb_score,
+            },
             step=self.episode_count,
         )
 

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -252,6 +252,11 @@ class QuoridorEnv(AECEnv):
     def get_opponent(self, agent):
         return "player_1" if agent == "player_0" else "player_0"
 
+    def set_current_player(self, agent: str):
+        """Shouldn't be called during regular play, just for setting up scenarios for testing or metrics"""
+        self.agent_selection = agent
+        self.game.set_current_player(self.agent_to_player[agent])
+
 
 # Wrapping the environment for PettingZoo compatibility
 def env(**kwargs):

--- a/deep_quoridor/src/run_metrics.py
+++ b/deep_quoridor/src/run_metrics.py
@@ -26,11 +26,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
     m = Metrics(args.board_size, args.max_walls)
     table = PrettyTable()
-    table.field_names = ["Agent", "Elo", "Relative Elo", "Win %"]
+    table.field_names = ["Agent", "Elo", "Relative Elo", "Win %", "Dumb Score"]
 
     for player in args.players:
         print(f"Computing metrics for {player}")
-        _, _, relative_elo, win_perc, absolute_elo = m.compute(player)
-        table.add_row([player, absolute_elo, relative_elo, win_perc])
+        _, _, relative_elo, win_perc, absolute_elo, dumb_score = m.compute(player)
+        table.add_row([player, absolute_elo, relative_elo, win_perc, dumb_score])
 
     print(table)


### PR DESCRIPTION
This PR introduces a new metric: the "dumb score" (I could invert it to reasonable score or something like that if someone feels strongly).   The idea is to put the agent in some situations where the next action is "obvious": e.g. move to win or block the opponent that is about to win.  We could include more situations in the future.
The idea is to use it to figure out if a model is learning, which I think it's harder to evaluate in the initial phases of training, when it can barely win against random.  Any reasonable agent should have a dumb score of 0.
The score is logged during training or when running the metrics.

E.g. with a training of dexp:
<img width="680" alt="image" src="https://github.com/user-attachments/assets/0093b320-60dd-4cf7-9593-98233075041a" />

And running the metrics for some agents, we can see that MCTS needs some improvement: 
```
(base) amarcu@MacBookPro deep_rabbit_hole % /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python 
+-----------------------+------+--------------+-------+------------+
|         Agent         | Elo  | Relative Elo | Win % | Dumb Score |
+-----------------------+------+--------------+-------+------------+
|         greedy        | 2999 |     908      |  88.5 |     0      |
|         random        | 1067 |     -753     |  5.0  |     86     |
|         simple        | 2028 |     525      |  99.0 |     0      |
|          mcts         | 1214 |     -652     |  27.5 |     16     |
| dexp:wandb_alias=best | 1937 |     420      |  97.0 |     0      |
+-----------------------+------+--------------+-------+------------+
```