### PR TITLE
Self play for training

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -191,7 +191,7 @@ class AlphaZeroAgent(TrainableAgent):
             self.recent_losses = self.recent_losses[-100:]
 
     def get_action(self, observation) -> int:
-        game, _, _ = construct_game_from_observation(observation["observation"], self.player_id)
+        game, _, _ = construct_game_from_observation(observation["observation"])
 
         # Run MCTS to get action visit counts
         root_children = self.mcts.search(game)

--- a/deep_quoridor/src/agents/greedy.py
+++ b/deep_quoridor/src/agents/greedy.py
@@ -174,7 +174,7 @@ class GreedyAgent(Agent):
         action_mask = observation["action_mask"]
         observation = observation["observation"]
         # Reconstruct the game from the observation.
-        game, player, opponent = construct_game_from_observation(observation, self.player_id)
+        game, player, opponent = construct_game_from_observation(observation)
 
         if random.random() < self.params.p_random:
             if self.action_log.is_enabled():

--- a/deep_quoridor/src/agents/mcts.py
+++ b/deep_quoridor/src/agents/mcts.py
@@ -201,7 +201,7 @@ class MCTSAgent(Agent):
     def get_action(self, observation):
         observation = observation["observation"]
 
-        game, _, _ = construct_game_from_observation(observation, self.player_id)
+        game, _, _ = construct_game_from_observation(observation)
         mcts = MCTS(game, self.params)
         children = mcts.search(game)
 

--- a/deep_quoridor/src/agents/simple.py
+++ b/deep_quoridor/src/agents/simple.py
@@ -4,7 +4,12 @@ from typing import Optional
 import numpy as np
 import qgrid
 from numba import njit, prange
-from quoridor import ActionEncoder, Player, array_to_action, construct_game_from_observation
+from quoridor import (
+    ActionEncoder,
+    Player,
+    array_to_action,
+    construct_game_from_observation,
+)
 from utils import SubargsBase
 
 from agents.core import Agent
@@ -316,7 +321,7 @@ class SimpleAgent(Agent):
     def get_action(self, observation):
         action_mask = observation["action_mask"]
         observation = observation["observation"]
-        game, _, _ = construct_game_from_observation(observation, self.player_id)
+        game, _, _ = construct_game_from_observation(observation)
 
         # Convert the game state to arrays that can be used by Numba
         grid = game.board._grid

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -114,10 +114,18 @@ class Arena:
         end_time = time.time()
         # print(self.game.render())
         winner = self.game.winner()
+
+        if agent1.name() == agent2.name():
+            agent1_name = f"{agent1.name()}-P1"
+            agent2_name = f"{agent2.name()}-P2"
+        else:
+            agent1_name = agent1.name()
+            agent2_name = agent2.name()
+
         result = GameResult(
-            player1=agent1.name(),
-            player2=agent2.name(),
-            winner=[agent1, agent2][winner].name() if winner is not None else "None",
+            player1=agent1_name,
+            player2=agent2_name,
+            winner=[agent1_name, agent2_name][winner] if winner is not None else "None",
             steps=step,
             time_ms=int((end_time - start_time) * 1000),
             game_id=game_id,

--- a/deep_quoridor/src/plugins/save_model.py
+++ b/deep_quoridor/src/plugins/save_model.py
@@ -37,7 +37,7 @@ class SaveModelEveryNEpisodesPlugin(ArenaPlugin):
         if isinstance(agent1, TrainableAgent) and agent1.is_training():
             self.agent = agent1
 
-        if isinstance(agent2, TrainableAgent) and agent2.is_training():
+        if agent1 != agent2 and isinstance(agent2, TrainableAgent) and agent2.is_training():
             if self.agent:
                 raise ValueError(
                     "SaveModelEveryNEpisodesPlugin can only be used with 1 training agent, but 2 are present."

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -474,7 +474,8 @@ class Quoridor:
         return str(self.board)
 
 
-def construct_game_from_observation(observation: dict, player_id: str) -> tuple[Quoridor, Player, Player]:
+def construct_game_from_observation(observation: dict) -> tuple[Quoridor, Player, Player]:
+    player_id = observation["player_turn"]
     if player_id == "player_0":
         player = Player.ONE
         opponent = Player.TWO

--- a/deep_quoridor/src/quoridor_env.py
+++ b/deep_quoridor/src/quoridor_env.py
@@ -184,6 +184,7 @@ class QuoridorEnv(AECEnv):
 
         return {
             "my_turn": self.agent_selection == agent_id,
+            "player_turn": agent_id,
             "board": board,
             "walls": walls,
             "my_walls_remaining": self.game.board.get_walls_remaining(player),

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -56,10 +56,10 @@ def train_dqn(
         max_steps=1000,
     )
 
+    # Self play
     if len(players) == 1:
-        agent1 = AgentRegistry.create_from_encoded_name(players[0], arena.game, training_mode=True)
-        agent2 = AgentRegistry.create_from_encoded_name(players[0], arena.game, training_instance=agent1)
-        players = [agent1, agent2]
+        agent = AgentRegistry.create_from_encoded_name(players[0], arena.game)
+        players = [agent, agent]
 
     arena.play_games(players=players, times=episodes, mode=PlayMode.FIRST_VS_RANDOM)
     return


### PR DESCRIPTION
If you only pass one player to the train script, it will use the same instance twice for training, to allow for self play.  I added the current player in the observation so the agents can know as which player is playing in each turn.