### PR TITLE
AlphaZero: perf improvements for deepcopy and .to()

### DIFF
--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -107,13 +107,13 @@ class NNEvaluator:
             target_values = []
 
             for data in batch_data:
-                inputs.append(torch.from_numpy(self.game_to_input_array(data["game"])[0]).to(self.device))
-                target_policies.append(torch.FloatTensor(data["mcts_policy"]).to(self.device))
-                target_values.append(torch.FloatTensor([data["value"]]).to(self.device))
+                inputs.append(torch.from_numpy(self.game_to_input_array(data["game"])[0]))
+                target_policies.append(torch.FloatTensor(data["mcts_policy"]))
+                target_values.append(torch.FloatTensor([data["value"]]))
 
-            inputs = torch.stack(inputs)
-            target_policies = torch.stack(target_policies)
-            target_values = torch.stack(target_values)
+            inputs = torch.stack(inputs).to(self.device)
+            target_policies = torch.stack(target_policies).to(self.device)
+            target_values = torch.stack(target_values).to(self.device)
 
             if inputs.isnan().any() or target_policies.isnan().any() or target_values.isnan().any():
                 raise ValueError("NaN in training data")


### PR DESCRIPTION
As discussed in the chat, we use deepcopy for the games in nodes that end up being leaves and therefore are never used.
In this PR, I changed it to not copy the game initially, and just encapsulate it using property, so when you call `node.game`, if `_game` is not set, then it will be computed by making a copy of the parent's node (which can recursively trigger the copy, not sure if it will ever happen), and applying the action.

The profiler before this PR showed:

```
         55245798 function calls (48830906 primitive calls) in 34.281 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    37732    7.640    0.000    7.640    0.000 {method 'to' of 'torch._C.TensorBase' objects}
5811919/200411    4.303    0.000   10.685    0.000 copy.py:118(deepcopy)
     7718    3.834    0.000    3.834    0.000 {method 'cpu' of 'torch._C.TensorBase' objects}
    54726    1.789    0.000    1.789    0.000 {built-in method torch._C._nn.linear}
    15636    1.618    0.000    1.618    0.000 {built-in method torch.dropout}
     9121    1.543    0.000    1.543    0.000 {method 'item' of 'torch._C.TensorBase' objects}
 12086582    1.099    0.000    1.100    0.000 {method 'get' of 'dict' objects}
  2004110    1.071    0.000    1.376    0.000 copy.py:231(_keep_alive)
```

And after making that change:

```
         10661801 function calls (9791011 primitive calls) in 24.775 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    40112    7.250    0.000    7.250    0.000 {method 'to' of 'torch._C.TensorBase' objects}
    10098    3.665    0.000    3.665    0.000 {method 'cpu' of 'torch._C.TensorBase' objects}
    71386    2.222    0.000    2.222    0.000 {built-in method torch._C._nn.linear}
    20396    2.013    0.000    2.013    0.000 {built-in method torch.dropout}
    11501    1.909    0.000    1.909    0.000 {method 'item' of 'torch._C.TensorBase' objects}
    50990    0.951    0.000    0.951    0.000 {built-in method torch.relu}
   111776    0.829    0.000    1.073    0.000 mcts.py:72(get_child_ucbs)
    10098    0.287    0.000    0.378    0.000 mcts.py:50(expand)
320769/11061    0.279    0.000    0.714    0.000 copy.py:118(deepcopy)

```

So it reduced the number of calls to deepcopy from 200k to 11k, and cumtime went from 10s to 0.7s.

Then I saw that `to` was taking too much time and I remember seeing it used in a loop, so I changed that to be used after it, since I remember in the past it made a big difference, and with that other change, the profiler shows:

```
         10631190 function calls (9760400 primitive calls) in 19.476 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    10098    3.643    0.000    3.643    0.000 {method 'cpu' of 'torch._C.TensorBase' objects}
    71386    2.235    0.000    2.235    0.000 {built-in method torch._C._nn.linear}
    10412    2.192    0.000    2.192    0.000 {method 'to' of 'torch._C.TensorBase' objects}
    20396    2.026    0.000    2.026    0.000 {built-in method torch.dropout}
    11501    1.911    0.000    1.911    0.000 {method 'item' of 'torch._C.TensorBase' objects}
    50990    0.949    0.000    0.949    0.000 {built-in method torch.relu}
   111776    0.842    0.000    1.088    0.000 mcts.py:72(get_child_ucbs)
    10098    0.290    0.000    0.379    0.000 mcts.py:50(expand)
320769/11061    0.277    0.000    0.711    0.000 copy.py:118(deepcopy)
```

There's probably a lot more to improve, but just wanted to do those that I saw and will make experimenting a little faster.