### PR TITLE
Fix UCB computation

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -77,7 +77,7 @@ class Node:
         # value_sum is in between -1 and 1, so doing (avg + 1) / 2 would make it in the range [0, 1]
         q_values = (np.divide(value_sums, visit_counts, where=visit_counts != 0) + 1) / 2
 
-        return q_values + self.ucb_c * priors * np.sqrt(visit_counts) / (visit_counts + 1)
+        return q_values + self.ucb_c * priors * np.sqrt(self.visit_count) / (visit_counts + 1)
 
     def backpropagate(self, value: float):
         """


### PR DESCRIPTION
For computing UCB, we should be using in the numerator the sum of the visits (i.e. the number of visits of the parent), rather than the visits in the node (`U(s, a) = c(s) * P(s, a) * sqrt(N(s)) / (1 + N(s, a))`)
I think this is what caused one of the players to have probability of 1 for certain moves, because this computation was increasing the total value in that case and therefore making it more likely to be visited