### PR TITLE
AlphaZero: assign rewards for the acting player in the replay buffer

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -160,8 +160,8 @@ class AlphaZeroAgent(TrainableAgent):
         episode_positions = []
         while self.replay_buffer and self.replay_buffer[-1]["value"] is None:
             position = self.replay_buffer.pop()
-            player = env.player_to_agent[position["player"]]
-            position["value"] = env.rewards[player]
+            agent = env.player_to_agent[position["player"]]
+            position["value"] = env.rewards[agent]
             episode_positions.append(position)
 
         # Add back the positions with assigned values

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -46,7 +46,14 @@ class Arena:
             "player_0": agent1,
             "player_1": agent2,
         }
-        for p, a in agents.items():
+        # If it's self play, we only have one agent, and we use this to make sure that some calls like
+        # start_game and end_game are called only once.
+        if agent1 == agent2:
+            unique_agents = {"both_players": agent1}
+        else:
+            unique_agents = agents
+
+        for p, a in unique_agents.items():
             a.start_game(self.game, p)
         self.plugins.start_game(self.game, agent1, agent2)
         start_time = time.time()
@@ -132,7 +139,7 @@ class Arena:
             game_id=game_id,
             moves=moves,
         )
-        for p, a in agents.items():
+        for p, a in unique_agents.items():
             a.end_game(self.game)
         self.plugins.end_game(self.game, result)
 


### PR DESCRIPTION
The main change in this PR is the following: in the replay buffer we're storing the moves from both players (because the agent is playing as both), but then we were assigning the same reward for all the moves, but we should assign the reward corresponding to the player that made the move.  So, I addded the player to the replay buffer, and then when the rewards are assigned, I assign it based on the player.
Also, I piggy-backed a few small tangentially related things:
- Since the same agent is playing both sides, we were calling start_game and end_game twice per game, so in end_game we were counting each episode as 2, plus doing some other processing that probably needs to be done only once.  I changed the arena so that for self-play, those methods are called only once.
- I removed the recent_rewards metric, I think they don't make much sense in self-play (which reward would we add?)
- Printed a message when the network is training and compute and print the dumb score after it, e.g.:
```
alphazero P2 Episode     9/100 [ ], Steps:  56, Time:  7795ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
Training the network (buffer size: 393, batch size: 100)...done in 1.80s
Dumb score: 83
```
- Removed some unused code

Something else that I want to do in a separate PR, is that the `TrainingStatusRenderer` plug in is not very good for self play (appears twice per game, shows things that we don't make sense), so I'd like to either create a separate plug in for AZ or just render it in the Agent