### PR TITLE
Fix board rotation for AlphaZero agent

### DIFF
--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -4,7 +4,7 @@ import random
 import numpy as np
 import torch
 import torch.nn.functional as F
-from quoridor import ActionEncoder, Board, Quoridor
+from quoridor import ActionEncoder, Board, Player, Quoridor
 
 from agents.alphazero.mlp_network import MLPNetwork
 
@@ -70,10 +70,10 @@ class NNEvaluator:
         player = game.get_current_player()
         opponent = int(1 - player)
 
-        rotate = True if (player == "player_2") else False
+        rotate = True if (player == Player.TWO) else False
         if rotate:
             game = copy.deepcopy(game)
-            game.rotate()
+            game.rotate_board()
 
         player_position = game.board.get_player_position(player)
         opponent_position = game.board.get_player_position(opponent)

--- a/deep_quoridor/src/agents/core/rotation.py
+++ b/deep_quoridor/src/agents/core/rotation.py
@@ -1,6 +1,26 @@
 import numpy as np
 
 
+def create_rotation_mapping(board_size):
+    """
+    Returns two action mapping arrays, one for converting from original to rotated and one for the other way around.
+    These arrays can then be used to convert policies by indexing into them.
+    """
+    num_actions = board_size * board_size + (board_size - 1) ** 2 * 2
+    action_mapping_original_to_rotated = np.zeros(num_actions, dtype=int)
+    action_mapping_rotated_to_original = np.zeros(num_actions, dtype=int)
+
+    for action_index in range(num_actions):
+        action_mapping_original_to_rotated[action_index] = convert_original_action_index_to_rotated(
+            board_size, action_index
+        )
+        action_mapping_rotated_to_original[action_index] = convert_rotated_action_index_to_original(
+            board_size, action_index
+        )
+
+    return action_mapping_original_to_rotated, action_mapping_rotated_to_original
+
+
 def rotate_action_vector(board_size, orig_vector):
     total_actions = board_size * board_size  # Movement actions
     wall_actions = (board_size - 1) ** 2  # Actions for each wall type

--- a/deep_quoridor/test/agents/core/rotation_test.py
+++ b/deep_quoridor/test/agents/core/rotation_test.py
@@ -2,6 +2,7 @@ import numpy as np
 from agents.core.rotation import (
     convert_original_action_index_to_rotated,
     convert_rotated_action_index_to_original,
+    create_rotation_mapping,
     rotate_action_vector,
     rotate_board,
     rotate_walls,
@@ -204,3 +205,17 @@ def test_convert_action_index_and_back():
         rotated_index = convert_original_action_index_to_rotated(board_size, original_index)
         final_index = convert_rotated_action_index_to_original(board_size, rotated_index)
         assert final_index == original_index
+
+
+def test_convert_policy_and_back():
+    """Test converting a policy to rotated and back to original."""
+    board_size = 4
+    num_actions = board_size * board_size + (board_size - 1) ** 2 * 2
+
+    action_mapping_original_to_rotated, action_mapping_rotated_to_original = create_rotation_mapping(board_size)
+
+    # Test a random policy
+    policy = np.random.random(0, 2, num_actions)
+    rotated_policy = policy[action_mapping_original_to_rotated]
+    final_policy = rotated_policy[action_mapping_rotated_to_original]
+    np.testing.assert_array_equal(final_policy, policy)

--- a/deep_quoridor/test/agents/core/rotation_test.py
+++ b/deep_quoridor/test/agents/core/rotation_test.py
@@ -215,7 +215,7 @@ def test_convert_policy_and_back():
     action_mapping_original_to_rotated, action_mapping_rotated_to_original = create_rotation_mapping(board_size)
 
     # Test a random policy
-    policy = np.random.random(0, 2, num_actions)
+    policy = np.random.random(num_actions)
     rotated_policy = policy[action_mapping_original_to_rotated]
     final_policy = rotated_policy[action_mapping_rotated_to_original]
     np.testing.assert_array_equal(final_policy, policy)


### PR DESCRIPTION
Fixes a bug in how the decision was made to rotate or not and also moves things around so that the network is always trained and evaluated using the perspective of Player 1