### PR TITLE
Tests to make sure evaluator rotates board

### DIFF
--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -34,6 +34,8 @@ class NNEvaluator:
         # Rotate the board if player 2 is playing so that we always work with player 1's perspective.
         game, is_board_rotated = self.rotate_if_needed_to_point_downwards(game)
 
+        self.network.eval()  # Disables dropout
+
         with torch.no_grad():
             input_array = self.game_to_input_array(game)
             unmasked_policy, value = self.network(torch.from_numpy(input_array).float().to(self.device))
@@ -115,6 +117,8 @@ class NNEvaluator:
         return input_array
 
     def train_network(self, replay_buffer, learning_rate, batch_size, optimizer_iterations):
+        self.network.train()  # Make sure we aren't in eval mode, which disables dropout
+
         optimizer = torch.optim.Adam(self.network.parameters(), lr=learning_rate)
 
         for _ in range(optimizer_iterations):

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -341,6 +341,9 @@ class Quoridor:
     def create_new(self):
         return Quoridor(self.board.create_new(), self.current_player, self.action_encoder, self._goal_rows)
 
+    def copy(self):
+        return copy.deepcopy(self)
+
     def rotate_board(self):
         """
         Rotates the board, but leaves the current player the same.

--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -1,26 +1,38 @@
-import copy
-
 import numpy as np
 from agents.alphazero.nn_evaluator import NNEvaluator
-from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor, WallAction, WallOrientation
+from agents.core import rotation
+from quoridor import ActionEncoder, Board, Quoridor
 from utils import my_device
 
 
-def test_evaluator_game_rotation():
+def _assert_policy_and_rotated_policy_equivalent(
+    action_encoder: ActionEncoder, policy: np.ndarray, rotated_policy: np.ndarray
+) -> None:
+    assert policy.shape == (action_encoder.num_actions,)
+    assert rotated_policy.shape == (action_encoder.num_actions,)
+
+    for action_index in range(len((policy))):
+        roated_action_index = rotation.convert_original_action_index_to_rotated(action_encoder.board_size, action_index)
+        assert policy[action_index] == rotated_policy[roated_action_index]
+
+
+def _rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNEvaluator, Quoridor]:
     board_size = 3
     max_walls = 1
 
     action_encoder = ActionEncoder(board_size)
     evaluator = NNEvaluator(action_encoder, my_device())
+    game = Quoridor(Board(board_size, max_walls))
 
-    # Initial game evaluation should be the same, regardless of whose turn it is.
-    g1 = Quoridor(Board(board_size, max_walls))
-    g2 = Quoridor(Board(board_size, max_walls))
-    g2.go_to_next_player()
-    v1, p1 = evaluator.evaluate(g1)
-    v2, p2 = evaluator.evaluate(g2)
-    assert v1 == v2
-    assert p1 == p2
+    return action_encoder, evaluator, game
 
 
-test_evaluator_game_rotation()
+def test_evaluator_game_rotation():
+    action_encoder, evaluator, game_1 = _rotation_test_setup(board_size=3, max_walls=1)
+
+    game_2 = game_1.copy()
+    game_2.go_to_next_player()
+    value_1, policy_1 = evaluator.evaluate(game_1)
+    value_2, policy_2 = evaluator.evaluate(game_2)
+    assert value_1 == value_2
+    _assert_policy_and_rotated_policy_equivalent(action_encoder, policy_1, policy_2)

--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -1,0 +1,26 @@
+import copy
+
+import numpy as np
+from agents.alphazero.nn_evaluator import NNEvaluator
+from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor, WallAction, WallOrientation
+from utils import my_device
+
+
+def test_evaluator_game_rotation():
+    board_size = 3
+    max_walls = 1
+
+    action_encoder = ActionEncoder(board_size)
+    evaluator = NNEvaluator(action_encoder, my_device())
+
+    # Initial game evaluation should be the same, regardless of whose turn it is.
+    g1 = Quoridor(Board(board_size, max_walls))
+    g2 = Quoridor(Board(board_size, max_walls))
+    g2.go_to_next_player()
+    v1, p1 = evaluator.evaluate(g1)
+    v2, p2 = evaluator.evaluate(g2)
+    assert v1 == v2
+    assert p1 == p2
+
+
+test_evaluator_game_rotation()

--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import rotation
-from quoridor import ActionEncoder, Board, Quoridor
+from quoridor import ActionEncoder, Board, MoveAction, Quoridor, WallAction, WallOrientation
 from utils import my_device
 
 
@@ -16,10 +16,7 @@ def _assert_policy_and_rotated_policy_equivalent(
         assert policy[action_index] == rotated_policy[roated_action_index]
 
 
-def _rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNEvaluator, Quoridor]:
-    board_size = 3
-    max_walls = 1
-
+def _evaluator_rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNEvaluator, Quoridor]:
     action_encoder = ActionEncoder(board_size)
     evaluator = NNEvaluator(action_encoder, my_device())
     game = Quoridor(Board(board_size, max_walls))
@@ -27,8 +24,40 @@ def _rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNE
     return action_encoder, evaluator, game
 
 
-def test_evaluator_game_rotation():
-    action_encoder, evaluator, game_1 = _rotation_test_setup(board_size=3, max_walls=1)
+def test_evaluator_rotation_on_initial_game():
+    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=3, max_walls=0)
+
+    game_2 = game_1.copy()
+    game_2.go_to_next_player()
+    value_1, policy_1 = evaluator.evaluate(game_1)
+    value_2, policy_2 = evaluator.evaluate(game_2)
+    assert value_1 == value_2
+    _assert_policy_and_rotated_policy_equivalent(action_encoder, policy_1, policy_2)
+
+
+def test_evaluator_rotation_with_players_in_symmetrical_positions():
+    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=5, max_walls=0)
+
+    game_1.step(MoveAction((1, 0)), validate=False)
+    game_1.step(MoveAction((3, 4)), validate=False)
+
+    game_2 = game_1.copy()
+    game_2.go_to_next_player()
+    value_1, policy_1 = evaluator.evaluate(game_1)
+    value_2, policy_2 = evaluator.evaluate(game_2)
+    assert value_1 == value_2
+    _assert_policy_and_rotated_policy_equivalent(action_encoder, policy_1, policy_2)
+
+
+def test_evaluator_rotation_with_players_and_walls_in_symmetrical_positions():
+    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=5, max_walls=2)
+
+    game_1.step(MoveAction((1, 0)), validate=False)
+    game_1.step(MoveAction((3, 4)), validate=False)
+    game_1.step(WallAction((0, 1), WallOrientation.HORIZONTAL))
+    game_1.step(WallAction((3, 2), WallOrientation.HORIZONTAL))
+    game_1.step(WallAction((2, 0), WallOrientation.VERTICAL))
+    game_1.step(WallAction((1, 3), WallOrientation.VERTICAL))
 
     game_2 = game_1.copy()
     game_2.go_to_next_player()


### PR DESCRIPTION
If the evaluator rotates the board properly for player two, then rotationally symmetric games should give the same policy and value, regardless of whose turn it is.  These tests failed at first, and I realized that it's conventional to call `model.eval()` to put the model in "evaluation" mode before running inference. That disables the dropout, which otherwise would introduce randomness to the results. Then before training, we call `model.train()` to put the model back into training mode.