### PR TITLE
Quick fixes for network and training

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mlp_network.py
+++ b/deep_quoridor/src/agents/alphazero/mlp_network.py
@@ -23,7 +23,9 @@ class MLPNetwork(nn.Module):
         # Policy head - outputs action probabilities
         # TODO: Is it correct to include the Softmax at the end? Some implementations of alphazero
         # appear to leave it out, or apply it outside the network.
-        self.policy_head = nn.Sequential(nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size), nn.Softmax(dim=0))
+        self.policy_head = nn.Sequential(
+            nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size), nn.Softmax(dim=-1)
+        )
 
         # value head - outputs position evaluation (-1 to 1)
         self.value_head = nn.Sequential(nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, 1), nn.Tanh())

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -119,14 +119,13 @@ class NNEvaluator:
     def train_prepare(self, learning_rate, batch_size, batches_per_iteration, weight_decay: float = 0):
         assert not hasattr(self, "optimizer") or self.optimizer is None, "train_prepare should be called only once"
 
-        self.network.train()  # Make sure we aren't in eval mode, which disables dropout
-
         self.batch_size = batch_size
         self.batches_per_iteration = batches_per_iteration
         self.optimizer = torch.optim.Adam(self.network.parameters(), lr=learning_rate, weight_decay=weight_decay)
 
     def train_iteration(self, replay_buffer):
         assert self.optimizer is not None, "Call train_prepare before training"
+        self.network.train()  # Make sure we aren't in eval mode, which disables dropout
 
         for _ in range(self.batches_per_iteration):
             # Sample random batch from replay buffer


### PR DESCRIPTION
Run softmax on the correct dimension and use `train()` mode on every iteration.