### PR TITLE
Handle temperature==0

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -231,7 +231,13 @@ class AlphaZeroAgent(TrainableAgent):
             raise RuntimeError("No nodes visited during MCTS")
 
         visit_probs = visit_counts / visit_counts_sum
-        if self.temperature != 0.0:
+        self._log_action(visit_probs, root_children)
+
+        if self.temperature == 0.0:
+            max_value = np.max(visit_probs)
+            visit_probs = np.array([1.0 if v == max_value else 0.0 for v in visit_probs])
+            visit_probs /= np.sum(visit_probs)
+        else:
             visit_probs = visit_probs ** (1.0 / self.temperature)
             visit_probs = visit_probs / np.sum(visit_probs)
 
@@ -247,8 +253,6 @@ class AlphaZeroAgent(TrainableAgent):
                 action_index = self.action_encoder.action_to_index(child.action_taken)
                 policy_target[action_index] = child.visit_count / visit_counts_sum
             self.store_training_data(game, policy_target, player)
-
-        self._log_action(visit_probs, root_children)
 
         return self.action_encoder.action_to_index(action)
 


### PR DESCRIPTION
I noticed that when playing it would often pick a sub-optimal choice (e.g. probs were 0.4, 0.3 and 0.3 and it would pick 0.3).  That was because it's not correclty handling the temperature.  When playing, temperature is 0 which means choose the best option (randomly between them if there's more than 1 with the max value)