### PR TITLE
AZ: remove training_mode in mini tournaments

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -67,7 +67,14 @@ class AlphaZeroParams(SubargsBase):
         Returns a set of parameters that are used only during training.
         These parameters should not be used during playing.
         """
-        return {"train_every", "learning_rate", "optimizer_iterations", "batch_size", "replay_buffer_size"}
+        return {
+            "training_mode",
+            "train_every",
+            "learning_rate",
+            "optimizer_iterations",
+            "batch_size",
+            "replay_buffer_size",
+        }
 
 
 class AlphaZeroAgent(TrainableAgent):
@@ -202,8 +209,6 @@ class AlphaZeroAgent(TrainableAgent):
             self.recent_losses = self.recent_losses[-100:]
 
         print(f"done in {time.time() - t0:.2f}s")
-        dumb_score = self.metrics.dumb_score(self)
-        print(f"Dumb score: {dumb_score}")
 
     def _log_action(
         self,


### PR DESCRIPTION
By adding `training_mode ` in `training_only_params`, this parameter is removed when re-instantiating the agent to play the mini tournament for metrics.  This way, the temperature is set to 0.

Additionally, I removed the dumb_score computation, since we would need to set the temperature to 0 (and maybe other changes), or re-instantiate the agent to make sure we don't interfere with training.  Not sure if it's very useful so just removing it for now.