### PR TITLE
Update masking method to make it safer to calculate cross entropy loss

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mlp_network.py
+++ b/deep_quoridor/src/agents/alphazero/mlp_network.py
@@ -24,7 +24,6 @@ class MLPNetwork(nn.Module):
         # TODO: Is it correct to include the Softmax at the end? Some implementations of alphazero
         # appear to leave it out, or apply it outside the network.
         self.policy_head = nn.Sequential(
-            # nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size), nn.Softmax(dim=-1)
             nn.Linear(256, 128),
             nn.ReLU(),
             nn.Linear(128, action_size),

--- a/deep_quoridor/src/agents/alphazero/mlp_network.py
+++ b/deep_quoridor/src/agents/alphazero/mlp_network.py
@@ -24,7 +24,10 @@ class MLPNetwork(nn.Module):
         # TODO: Is it correct to include the Softmax at the end? Some implementations of alphazero
         # appear to leave it out, or apply it outside the network.
         self.policy_head = nn.Sequential(
-            nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size), nn.Softmax(dim=-1)
+            # nn.Linear(256, 128), nn.ReLU(), nn.Linear(128, action_size), nn.Softmax(dim=-1)
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, action_size),
         )
 
         # value head - outputs position evaluation (-1 to 1)

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -9,6 +9,8 @@ from quoridor import ActionEncoder, Board, Player, Quoridor
 from agents.alphazero.mlp_network import MLPNetwork
 from agents.core.rotation import create_rotation_mapping
 
+INVALID_ACTION_VALUE = -1e32
+
 
 class NNEvaluator:
     def __init__(
@@ -47,7 +49,8 @@ class NNEvaluator:
         with torch.no_grad():
             input_array = self.game_to_input_array(game)
             policy_logits, value = self.network(torch.from_numpy(input_array).float().to(self.device))
-            policy_logits[invalid_mask] = -1e32
+            assert torch.isfinite(policy_logits).all(), "Policy logits contains non-finite values"
+            policy_logits[invalid_mask] = INVALID_ACTION_VALUE
             policy_masked = F.softmax(policy_logits, dim=-1).cpu().numpy()
             value = value.item()
 

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -38,7 +38,8 @@ class NNEvaluator:
 
         with torch.no_grad():
             input_array = self.game_to_input_array(game)
-            unmasked_policy, value = self.network(torch.from_numpy(input_array).float().to(self.device))
+            unmasked_policy_logits, value = self.network(torch.from_numpy(input_array).float().to(self.device))
+            unmasked_policy = F.softmax(unmasked_policy_logits, dim=-1)
             unmasked_policy = unmasked_policy.cpu().numpy()
             value = value.item()
 
@@ -159,10 +160,10 @@ class NNEvaluator:
                 raise ValueError("NaN in training data")
 
             # Forward pass
-            pred_policies, pred_values = self.network(inputs)
+            pred_logits, pred_values = self.network(inputs)
 
             # Compute losses
-            policy_loss = F.cross_entropy(pred_policies, target_policies, reduction="mean")
+            policy_loss = F.cross_entropy(pred_logits, target_policies, reduction="mean")
             value_loss = F.mse_loss(pred_values.squeeze(), target_values.squeeze(), reduction="mean")
             total_loss = policy_loss + value_loss
             # print(f"{total_loss.item():3.3f} {policy_loss.item():3.3f} {value_loss.item():3.3f}")


### PR DESCRIPTION
Apparently -1e32 is better for masking than -np.inf

```
>>> import torch
>>> import torch.nn.functional as F
>>> x = torch.Tensor([0,1])
>>> y = torch.log(x)
>>> F.cross_entropy(y,x)
tensor(nan)
>>> y
tensor([-inf, 0.])
>>> y[0] = -1e32
>>> F.cross_entropy(y,x)
tensor(-0.)
```