### PR TITLE
Simple tests for alphazero NN training

### DIFF
--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -1,7 +1,9 @@
 import numpy as np
+import torch
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import rotation
 from quoridor import ActionEncoder, Board, MoveAction, Quoridor, WallAction, WallOrientation
+from torch.distributions import Categorical
 from utils import my_device
 
 
@@ -16,7 +18,7 @@ def _assert_policy_and_rotated_policy_equivalent(
         assert policy[action_index] == rotated_policy[roated_action_index]
 
 
-def _evaluator_rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNEvaluator, Quoridor]:
+def _evaluator_test_setup(board_size: int, max_walls) -> tuple[ActionEncoder, NNEvaluator, Quoridor]:
     action_encoder = ActionEncoder(board_size)
     evaluator = NNEvaluator(action_encoder, my_device())
     game = Quoridor(Board(board_size, max_walls))
@@ -25,7 +27,7 @@ def _evaluator_rotation_test_setup(board_size: int, max_walls) -> tuple[ActionEn
 
 
 def test_evaluator_rotation_on_initial_game():
-    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=3, max_walls=0)
+    action_encoder, evaluator, game_1 = _evaluator_test_setup(board_size=3, max_walls=0)
 
     game_2 = game_1.copy()
     game_2.go_to_next_player()
@@ -36,7 +38,7 @@ def test_evaluator_rotation_on_initial_game():
 
 
 def test_evaluator_rotation_with_players_in_symmetrical_positions():
-    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=5, max_walls=0)
+    action_encoder, evaluator, game_1 = _evaluator_test_setup(board_size=5, max_walls=0)
 
     game_1.step(MoveAction((1, 0)), validate=False)
     game_1.step(MoveAction((3, 4)), validate=False)
@@ -50,7 +52,7 @@ def test_evaluator_rotation_with_players_in_symmetrical_positions():
 
 
 def test_evaluator_rotation_with_players_and_walls_in_symmetrical_positions():
-    action_encoder, evaluator, game_1 = _evaluator_rotation_test_setup(board_size=5, max_walls=2)
+    action_encoder, evaluator, game_1 = _evaluator_test_setup(board_size=5, max_walls=2)
 
     game_1.step(MoveAction((1, 0)), validate=False)
     game_1.step(MoveAction((3, 4)), validate=False)
@@ -67,23 +69,18 @@ def test_evaluator_rotation_with_players_and_walls_in_symmetrical_positions():
     _assert_policy_and_rotated_policy_equivalent(action_encoder, policy_1, policy_2)
 
 
-def test_evaluator_training_with_fake_data():
-    board_size = 3
-    max_walls = 0
+def test_evaluator_training_with_deterministic_policy():
+    action_encoder, evaluator, game = _evaluator_test_setup(board_size=3, max_walls=0)
     learning_rate = 0.001
     batch_size = 10
     optimizer_iterations = 20
     target_action = MoveAction((0, 0))
     target_value = 1.0
-
-    action_encoder = ActionEncoder(board_size)
-    evaluator = NNEvaluator(action_encoder, my_device())
-
-    game = Quoridor(Board(board_size, max_walls))
+    required_precision = 1e-3
 
     target_policy = np.zeros(action_encoder.num_actions, dtype=np.float32)
-    desired_action_index = action_encoder.action_to_index(target_action)
-    target_policy[desired_action_index] = 1.0
+    target_action_index = action_encoder.action_to_index(target_action)
+    target_policy[target_action_index] = 1.0
 
     replay_buffer = []
     for _ in range(100):
@@ -93,6 +90,39 @@ def test_evaluator_training_with_fake_data():
     training_stats = evaluator.train_iteration(replay_buffer)
 
     value, policy = evaluator.evaluate(game)
-    assert np.abs(value - target_value) < 1e-3
-    assert (np.abs(policy - target_policy) < 1e-3).all()
-    assert training_stats["total_loss"] < 1e-3
+    assert np.abs(value - target_value) < required_precision
+    assert (np.abs(policy - target_policy) < required_precision).all()
+    assert training_stats["total_loss"] < required_precision
+
+
+def test_evaluator_training_with_probabilistic_policy():
+    action_encoder, evaluator, game = _evaluator_test_setup(board_size=3, max_walls=0)
+    learning_rate = 0.001
+    batch_size = 10
+    # Note: the precision here is pretty loose and the number of optimizer iterations is quite
+    # large because it takes quite a while for the current MLP model to converge to the right
+    # policy in this case. Hopefully we can find a better NN that trains more efficiently.
+    optimizer_iterations = 500
+    required_precision = 1e-2
+    target_value = 1.0
+
+    # This policy chooses one of two actions with specific probabilities
+    target_policy = np.zeros(action_encoder.num_actions, dtype=np.float32)
+    target_policy[action_encoder.action_to_index(MoveAction((0, 0)))] = 0.2
+    target_policy[action_encoder.action_to_index(MoveAction((0, 2)))] = 0.8
+
+    replay_buffer = []
+    for _ in range(100):
+        replay_buffer.append({"game": game, "mcts_policy": target_policy, "value": 1.0})
+
+    evaluator.train_prepare(learning_rate, batch_size, optimizer_iterations)
+    training_stats = evaluator.train_iteration(replay_buffer)
+
+    value, policy = evaluator.evaluate(game)
+    assert np.abs(value - target_value) < required_precision
+    assert (np.abs(policy - target_policy) < required_precision).all()
+
+    # If the NN models the policy perfectly then the remaining policy loss should equal the
+    # entropy of the target policy.
+    target_policy_entropy = Categorical(torch.Tensor(target_policy)).entropy()
+    assert training_stats["total_loss"] - target_policy_entropy < required_precision

--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -65,3 +65,29 @@ def test_evaluator_rotation_with_players_and_walls_in_symmetrical_positions():
     value_2, policy_2 = evaluator.evaluate(game_2)
     assert value_1 == value_2
     _assert_policy_and_rotated_policy_equivalent(action_encoder, policy_1, policy_2)
+
+
+def test_evaluator_training_with_fake_data():
+    board_size = 3
+    max_walls = 0
+    learning_rate = 0.001
+    batch_size = 10
+    optimizer_iterations = 20
+    desired_action = MoveAction((0, 0))
+
+    action_encoder = ActionEncoder(board_size)
+    evaluator = NNEvaluator(action_encoder, my_device())
+
+    game = Quoridor(Board(board_size, max_walls))
+
+    target_policy = np.zeros(action_encoder.num_actions, dtype=np.float32)
+    desired_action_index = action_encoder.action_to_index(desired_action)
+    target_policy[desired_action_index] = 1.0
+
+    replay_buffer = []
+    for _ in range(100):
+        replay_buffer.append({"game": game, "mcts_policy": target_policy, "value": 1.0})
+
+    evaluator.train_network(replay_buffer, learning_rate, batch_size, optimizer_iterations)
+
+    evaluator.evaluate(game)


### PR DESCRIPTION
Been working on these tests for a while, but with the other changes made this past week, they pass now! For both tests, the game state used is always the initial game state. The tests are:

1. Fill the replay buffer with many instances of `(<game at start state>, <policy that chooses Move((0, 0)) 100% of the time>, value=1.0)`
2. 1. Fill the replay buffer with many instances of  `(<game at start state>, <policy that chooses Move((0, 0)) 20% of the time and Move((0, 2)) 80% of the time>, value=1.0)`

In both cases, it trains the evaluator network with the given replay buffer and makes sure that calling `Evaluator.evaluate(<game at start state>)` produces a policy that looks like the one we fed in.

Interestingly, it converges pretty quickly to the solution in test (1) but takes much longer for test (2). It will be interesting to see if this changes when we introduce other NN structures.