### PR TITLE
Additional tiny performance improvements and dropping matches if truncated

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -172,8 +172,8 @@ class AlphaZeroAgent(TrainableAgent):
             position["value"] = env.rewards[agent]
             episode_positions.append(position)
 
-            # Add back the positions with assigned values
-            self.replay_buffer.extend(reversed(episode_positions))
+        # Add back the positions with assigned values
+        self.replay_buffer.extend(reversed(episode_positions))
 
         self.episode_count += 1
 

--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -162,19 +162,15 @@ class AlphaZeroAgent(TrainableAgent):
     def end_game(self, env):
         if not self.params.training_mode:
             return
-        if env.winner() is None:
-            # if the game ended in a draw, we drop the match
-            while self.replay_buffer and self.replay_buffer[-1]["value"] is None:
-                self.replay_buffer.pop()
-        else:
-            # Assign the final game outcome to all positions in this episode
-            # For Quoridor: reward = 1 for win, -1 for loss, 0 for draw
-            episode_positions = []
-            while self.replay_buffer and self.replay_buffer[-1]["value"] is None:
-                position = self.replay_buffer.pop()
-                agent = env.player_to_agent[position["player"]]
-                position["value"] = env.rewards[agent]
-                episode_positions.append(position)
+
+        # Assign the final game outcome to all positions in this episode
+        # For Quoridor: reward = 1 for win, -1 for loss, 0 for draw
+        episode_positions = []
+        while self.replay_buffer and self.replay_buffer[-1]["value"] is None:
+            position = self.replay_buffer.pop()
+            agent = env.player_to_agent[position["player"]]
+            position["value"] = env.rewards[agent]
+            episode_positions.append(position)
 
             # Add back the positions with assigned values
             self.replay_buffer.extend(reversed(episode_positions))

--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -22,7 +22,7 @@ class AlphaZeroParams(SubargsBase):
     training_mode: bool = False
 
     # After how many self play games we train the network
-    train_every: int = 1
+    train_every: int = 10
 
     # Learning rate to use for the optimizer
     learning_rate: float = 0.001

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -43,6 +43,7 @@ class NNEvaluator:
             assert torch.isfinite(policy_logits).all(), "Policy logits contains non-finite values"
             policy_logits = policy_logits * action_mask + INVALID_ACTION_VALUE * (1 - action_mask)
             policy_masked = F.softmax(policy_logits, dim=-1).cpu().numpy()
+            value = value.item()
 
         # Sanity checks
         assert np.all(policy_masked >= 0), "Policy contains negative probabilities"
@@ -54,7 +55,7 @@ class NNEvaluator:
         if is_board_rotated:
             policy_masked = policy_masked[self.action_mapping_rotated_to_original]
 
-        return value.item(), policy_masked
+        return value, policy_masked
 
     def rotate_policy_from_original(self, policy: np.ndarray):
         """

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -401,14 +401,16 @@ def compute_move_action_mask(
 
     assert action_mask.shape == (board_size**2,)
 
-    for k in range(len(action_mask)):
-        action_mask[k] = 0
+    # for k in range(len(action_mask)):
+    #    action_mask[k] = 0
 
+    max_row = min(player_positions[current_player][0] + 3, board_size)
+    col_range = range(
+        max(player_positions[current_player][1] - 2, 0), min(player_positions[current_player][1] + 3, board_size)
+    )
     # Check all possible moves
-    for delta_row in np.arange(-2, 3):
-        for delta_col in np.arange(-2, 3):
-            destination_row = player_positions[current_player][0] + delta_row
-            destination_col = player_positions[current_player][1] + delta_col
+    for destination_row in range(max(player_positions[current_player][0] - 2, 0), max_row):
+        for destination_col in col_range:
             if is_move_action_valid(grid, player_positions, current_player, destination_row, destination_col):
                 action_mask[destination_row * board_size + destination_col] = 1
 
@@ -430,9 +432,11 @@ def compute_wall_action_mask(
 
     assert action_mask.shape == (2 * wall_size**2,)
 
-    for k in range(len(action_mask)):
-        action_mask[k] = 0
+    # for k in range(len(action_mask)):
+    #    action_mask[k] = 0
 
+    if walls_remaining[current_player] <= 0:
+        return action_mask
     for wall_row in range(wall_size):
         for wall_col in range(wall_size):
             if is_wall_action_valid(

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -401,15 +401,13 @@ def compute_move_action_mask(
 
     assert action_mask.shape == (board_size**2,)
 
-    # for k in range(len(action_mask)):
-    #    action_mask[k] = 0
-
-    max_row = min(player_positions[current_player][0] + 3, board_size)
     col_range = range(
         max(player_positions[current_player][1] - 2, 0), min(player_positions[current_player][1] + 3, board_size)
     )
     # Check all possible moves
-    for destination_row in range(max(player_positions[current_player][0] - 2, 0), max_row):
+    for destination_row in range(
+        max(player_positions[current_player][0] - 2, 0), min(player_positions[current_player][0] + 3, board_size)
+    ):
         for destination_col in col_range:
             if is_move_action_valid(grid, player_positions, current_player, destination_row, destination_col):
                 action_mask[destination_row * board_size + destination_col] = 1

--- a/deep_quoridor/src/qgrid.py
+++ b/deep_quoridor/src/qgrid.py
@@ -430,9 +430,6 @@ def compute_wall_action_mask(
 
     assert action_mask.shape == (2 * wall_size**2,)
 
-    # for k in range(len(action_mask)):
-    #    action_mask[k] = 0
-
     if walls_remaining[current_player] <= 0:
         return action_mask
     for wall_row in range(wall_size):

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -67,7 +67,6 @@ class ActionEncoder:
     def __deepcopy__(self, memo):
         return self
 
-    @cache
     def action_to_index(self, action) -> int:
         """
         Converts an action object to an action index

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -356,14 +356,14 @@ class Quoridor:
         self._goal_rows = self._goal_rows[::-1]
         self._rotated = not self._rotated
 
-    def step(self, action: Action):
+    def step(self, action: Action, validate: bool = True):
         """
         Execute the given action and update the game state.
 
         Turning off validation can save some computation if you're sure the action is valid,
         and also makes it easier to teleport players around the board for testing purposes.
         """
-        assert self.is_action_valid(action), (
+        assert not validate or self.is_action_valid(action), (
             f"Invalid action: {action} for player {self.current_player}, in board {self.board}"
         )
 

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -356,15 +356,16 @@ class Quoridor:
         self._goal_rows = self._goal_rows[::-1]
         self._rotated = not self._rotated
 
-    def step(self, action: Action, validate: bool = False):
+    def step(self, action: Action):
         """
         Execute the given action and update the game state.
 
         Turning off validation can save some computation if you're sure the action is valid,
         and also makes it easier to teleport players around the board for testing purposes.
         """
-        if validate and not self.is_action_valid(action):
-            raise ValueError(f"Invalid action: {action} for player {self.current_player}, in board {self.board}")
+        assert self.is_action_valid(action), (
+            f"Invalid action: {action} for player {self.current_player}, in board {self.board}"
+        )
 
         if isinstance(action, MoveAction):
             self.board.move_player(self.current_player, action.destination)

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -67,6 +67,7 @@ class ActionEncoder:
     def __deepcopy__(self, memo):
         return self
 
+    @cache
     def action_to_index(self, action) -> int:
         """
         Converts an action object to an action index
@@ -356,7 +357,7 @@ class Quoridor:
         self._goal_rows = self._goal_rows[::-1]
         self._rotated = not self._rotated
 
-    def step(self, action: Action, validate: bool = True):
+    def step(self, action: Action, validate: bool = False):
         """
         Execute the given action and update the game state.
 
@@ -413,7 +414,7 @@ class Quoridor:
         """
         Get a mask of valid actions for the current player.
         """
-        action_mask = np.zeros(self.action_encoder.num_actions, dtype=bool)
+        action_mask = np.zeros(self.action_encoder.num_actions, dtype=np.float32)
         move_actions = self.get_valid_move_actions_vector(player)
         wall_actions = self.get_valid_wall_actions_vector(player)
         action_mask[: self.action_encoder.board_size**2] = move_actions

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -56,7 +56,7 @@ def train_dqn(
         renderers=[print_plugin] + renderers,
         plugins=plugins,
         swap_players=True,
-        max_steps=100,
+        max_steps=1000,
     )
 
     # Self play

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -56,7 +56,7 @@ def train_dqn(
         renderers=[print_plugin] + renderers,
         plugins=plugins,
         swap_players=True,
-        max_steps=1000,
+        max_steps=100,
     )
 
     # Self play

--- a/deep_quoridor/test/quoridor_test.py
+++ b/deep_quoridor/test/quoridor_test.py
@@ -1,7 +1,6 @@
 import copy
 
 import numpy as np
-import pytest
 from quoridor import (
     Action,
     ActionEncoder,
@@ -194,12 +193,12 @@ class TestQuoridor:
         applying the rotated version of the action, and rotating the board back.
         """
         g1 = copy.deepcopy(game)
-        g1.step(action, validate=False)
+        g1.step(action)
 
         g2 = copy.deepcopy(game)
         rotated_action = g2.rotate_action(action)
         g2.rotate_board()
-        g2.step(rotated_action, validate=False)
+        g2.step(rotated_action)
         g2.rotate_board()
 
         assert g2 == g1
@@ -449,8 +448,8 @@ class TestQuoridor:
     def test_move_action_rotation(self):
         game = Quoridor(Board(board_size=5, max_walls=10))
 
-        m1 = MoveAction((1, 3))
-        m1_rotated = MoveAction((3, 1))
+        m1 = MoveAction((1, 2))
+        m1_rotated = MoveAction((3, 2))
         assert game.rotate_action(m1) == m1_rotated
         self._test_board_and_action_rotation(game, m1)
 


### PR DESCRIPTION
This change also removes entries from the replay buffer when match ends in truncation (no winner)

Before
      99286038 function calls (89750416 primitive calls) in 183.904 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1327039   37.156    0.000   37.156    0.000 {built-in method torch._C._nn.linear}
   189557   11.699    0.000  144.874    0.001 nn_evaluator.py:34(evaluate)
   947885   11.320    0.000   11.320    0.000 {built-in method torch.relu}
   568745    9.061    0.000    9.077    0.000 {method 'to' of 'torch._C.TensorBase' objects}
3601963/189577    6.419    0.000   83.048    0.000 module.py:1743(_call_impl)
3601963/189577    5.810    0.000   83.518    0.000 module.py:1735(_wrapped_call_impl)
   568731    5.127    0.000   77.342    0.000 container.py:248(forward)
   189557    4.834    0.000    5.859    0.000 mcts.py:49(expand)
  6114317    4.300    0.000    4.300    0.000 mcts.py:66(get_child_ucb)
  1267151    3.617    0.000   10.330    0.000 mcts.py:60(select)
   189557    3.507    0.000    3.507    0.000 {method 'cpu' of 'torch._C.TensorBase' objects}
  1327039    3.095    0.000   41.186    0.000 linear.py:124(forward)

After
         72318037 function calls (63999809 primitive calls) in 159.883 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1327039   36.456    0.000   36.456    0.000 {built-in method torch._C._nn.linear}
   947885   11.407    0.000   11.407    0.000 {built-in method torch.relu}
   189557   10.816    0.000  132.330    0.001 nn_evaluator.py:34(evaluate)
   379188    7.978    0.000    7.993    0.000 {method 'to' of 'torch._C.TensorBase' objects}
3601963/189577    5.669    0.000   79.980    0.000 module.py:1743(_call_impl)
   568731    5.046    0.000   74.861    0.000 container.py:248(forward)
   189557    4.976    0.000    6.005    0.000 mcts.py:49(expand)
3601963/189577    4.431    0.000   80.410    0.000 module.py:1735(_wrapped_call_impl)
  6114317    4.052    0.000    4.052    0.000 mcts.py:66(get_child_ucb)
   189557    3.472    0.000    3.472    0.000 {method 'cpu' of 'torch._C.TensorBase' objects}
  1267151    3.347    0.000    9.497    0.000 mcts.py:60(select)