### PR TITLE
Supress warning on pygame import

### DIFF
--- a/deep_quoridor/src/renderers/pygame.py
+++ b/deep_quoridor/src/renderers/pygame.py
@@ -1,17 +1,28 @@
 import time
+import warnings
+
+# Suppress pygame setuptools warning
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Event
 from typing import List, Optional, Tuple
 
 import numpy as np
-import pygame
 from agents import ActionLog, Agent
 from agents.human import HumanAgent
 from arena import GameResult
 from quoridor import Action, MoveAction, Player, WallAction, WallOrientation
 
 from renderers import Renderer
+
+# Pygame import creates an annoying warning because of a deprecated use of pkgtools, so we
+# suppress the warning for now.
+#
+#   See https://github.com/pygame/pygame/issues/4313
+warnings.filterwarnings("ignore", category=UserWarning)
+import pygame  # noqa: E402
+
+warnings.filterwarnings("default", category=UserWarning)
 
 WALL_TO_CELL_RATIO = 5
 


### PR DESCRIPTION
Using python 3.12 in my virtualenv i get the following warning every 
time the pygame renderer gets imported, because pygame uses
setuptools in a deprecated way:
```
home/jbinney/ws/deep_rabbit_hole/.venv/lib/python3.12/site-
packages/pygame/pkgdata.py:25: UserWarning: pkg_resources is 
deprecated as an API. See https://setuptools.pypa.io/en/latest/
pkg_resources.html. The pkg_resources package is slated for removal 
as early as 2025-11-30. Refrain from using this package or pin to 
Setuptools<81.
  from pkg_resources import resource_stream, resource_exists
```
This suppresses that warning.