### PR TITLE
Early version of multiprocess training script

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -7,11 +7,11 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
+import wandb
 from quoridor import ActionEncoder, construct_game_from_observation
 from utils import my_device
 from utils.subargs import SubargsBase
 
-import wandb
 from agents.alphazero.mcts import MCTS
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import TrainableAgent

--- a/deep_quoridor/src/renderers/pygame.py
+++ b/deep_quoridor/src/renderers/pygame.py
@@ -1,4 +1,3 @@
-import re
 import time
 import warnings
 
@@ -423,7 +422,6 @@ class PygameQuoridor:
             # if the user wants a verticar or horizontal wall
             return
 
-        type_action = 0
         if v_wall:
             action = WallAction((row, col), WallOrientation.VERTICAL)
         elif h_wall:

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a DQN agent for Quoridor")
     parser.add_argument("-N", "--board_size", type=int, default=9, help="Board Size")
     parser.add_argument("-W", "--max_walls", type=int, default=10, help="Max walls per player")
-    parser.add_argument("--max_steps", type=int, default=10, help="Max number of turns before game is called a tie")
+    parser.add_argument("--max_steps", type=int, default=200, help="Max number of turns before game is called a tie")
     parser.add_argument("-e", "--episodes", type=int, default=1000, help="Number of episodes to train for")
     parser.add_argument("-s", "--step_rewards", action="store_true", default=False, help="Enable step rewards")
     parser.add_argument("-sp", "--save_path", type=str, default="models", help="Directory to save models")

--- a/deep_quoridor/src/train.py
+++ b/deep_quoridor/src/train.py
@@ -16,6 +16,7 @@ def train_dqn(
     episodes: int,
     board_size: int,
     max_walls: int,
+    max_steps: int,
     save_frequency: int,
     step_rewards: bool = True,
     wandb_params: Optional[WandbParams] = None,
@@ -56,7 +57,7 @@ def train_dqn(
         renderers=[print_plugin] + renderers,
         plugins=plugins,
         swap_players=True,
-        max_steps=1000,
+        max_steps=max_steps,
     )
 
     # Self play
@@ -72,6 +73,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train a DQN agent for Quoridor")
     parser.add_argument("-N", "--board_size", type=int, default=9, help="Board Size")
     parser.add_argument("-W", "--max_walls", type=int, default=10, help="Max walls per player")
+    parser.add_argument("--max_steps", type=int, default=10, help="Max number of turns before game is called a tie")
     parser.add_argument("-e", "--episodes", type=int, default=1000, help="Number of episodes to train for")
     parser.add_argument("-s", "--step_rewards", action="store_true", default=False, help="Enable step rewards")
     parser.add_argument("-sp", "--save_path", type=str, default="models", help="Directory to save models")
@@ -154,6 +156,7 @@ if __name__ == "__main__":
             episodes=args.episodes,
             board_size=args.board_size,
             max_walls=args.max_walls,
+            max_steps=args.max_steps,
             save_frequency=args.save_frequency,
             step_rewards=args.step_rewards,
             players=args.players,

--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -180,8 +180,8 @@ def main(args):
 
     print(f"Worker startup time: {t1 - t0}")
     print(f"Total processing time {t2 - t0}")
-    print(f"Time per game: {(t2 - t0) / args.games_per_epoch}")
-    print(f"Throughput = {args.games_per_epoch / (t2 - t0)}")
+    print(f"Time per game: {(t2 - t0) / (args.games_per_epoch * args.epochs)}")
+    print(f"Throughput = {(args.games_per_epoch * args.epochs) / (t2 - t0)}")
 
 
 if __name__ == "__main__":

--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -1,0 +1,158 @@
+import argparse
+import multiprocessing as mp
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import quoridor as q
+import quoridor_env
+from agents.alphazero.alphazero import AlphaZeroAgent, AlphaZeroParams
+
+
+@dataclass
+class Worker:
+    worker_id: int
+    process: mp.Process
+    job_queue: mp.SimpleQueue
+    result_queue: mp.SimpleQueue
+
+
+@dataclass
+class RunGamesJob:
+    num_games: int  # If -1, worker shuts itself down.
+    model_path: str
+
+
+@dataclass
+class RunGamesResult:
+    replay_buffer: list[dict]
+
+
+def self_play_worker(
+    board_size: int,
+    max_walls: int,
+    max_game_length: int,
+    worker_id: int,
+    job_queue: mp.SimpleQueue,
+    result_queue: mp.SimpleQueue,
+):
+    alphazero_params = AlphaZeroParams()
+    alphazero_params.training_mode = True
+    alphazero_params.train_every = None
+    alphazero_agent = AlphaZeroAgent(board_size, max_walls, params=alphazero_params)
+
+    environment = quoridor_env.env(board_size=board_size, max_walls=max_walls, step_rewards=False)
+
+    print(f"Worker {worker_id} ready for jobs")
+    while True:
+        job = job_queue.get()
+        if job.num_games == -1:
+            break
+
+        # TODO: make all workers use the same random weights for the NN on startup,
+        # then the same loaded model in each epoch afterwards
+        # AlphaZeroAgent.load_model(job.model_path)
+
+        for _ in range(job.num_games):
+            environment.reset()
+            num_turns = 0
+
+            for _ in environment.agent_iter():
+                # TODO: Use environment class to properly set the agent_id arg to make_observation
+                observation, _, termination, truncation, _ = environment.last()
+                if termination or truncation:
+                    break
+
+                action_index = alphazero_agent.get_action(observation)
+                environment.step(action_index)
+                num_turns += 1
+
+                # TODO: Move max steps with proper truncation to the environment
+                if num_turns >= max_game_length:
+                    print("Truncating game")
+                    print(environment.render())
+                    break
+
+            print(f"Game ended after {num_turns} turns")
+            alphazero_agent.end_game(environment)
+
+    print(f"Worker {worker_id} exiting")
+
+
+def train_alphazero(num_games, workers):
+    games_per_worker = int(np.ceil(num_games / len(workers)))
+
+    games_remaining_to_allocate = num_games
+    for worker_i in range(len(workers)):
+        this_worker_num_games = min(games_per_worker, games_remaining_to_allocate)
+
+        # TODO: Pass model
+        workers[worker_i].job_queue.put(RunGamesJob(this_worker_num_games, ""))
+
+
+def create_workers(board_size: int, max_walls: int, max_game_length: int, num_workers: int) -> list[Worker]:
+    workers = []
+    for worker_id in range(num_workers):
+        job_queue = mp.SimpleQueue()
+        result_queue = mp.SimpleQueue()
+        process = mp.Process(
+            target=self_play_worker,
+            args=(
+                board_size,
+                max_walls,
+                max_game_length,
+                worker_id,
+                job_queue,
+                result_queue,
+            ),
+        )
+        workers.append(Worker(worker_id, process, job_queue, result_queue))
+
+    for worker in workers:
+        worker.process.start()
+
+    return workers
+
+
+def stop_workers(workers: list[Worker]):
+    # Tell workers to stop
+    for worker in workers:
+        worker.job_queue.put(RunGamesJob(-1, ""))
+
+    for worker in workers:
+        worker.process.join()
+
+
+def main(args):
+    # Set multiprocessing start method to avoid tensor sharing issues and Mac bugs
+    mp.set_start_method("spawn", force=True)
+
+    t0 = time.time()
+
+    workers = create_workers(args.board_size, args.max_walls, args.max_game_length, args.num_workers)
+
+    t1 = time.time()
+
+    train_alphazero(num_games=args.episodes, workers=workers)
+    stop_workers(workers)
+
+    t2 = time.time()
+
+    print(f"Worker startup time: {t1 - t0}")
+    print(f"Total processing time {t2 - t0}")
+    print(f"Time per game: {(t2 - t0) / args.episodes}")
+    print(f"Throughput = {args.episodes / (t2 - t0)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train a DQN agent for Quoridor")
+    parser.add_argument("-N", "--board-size", type=int, default=5, help="Board Size")
+    parser.add_argument("-W", "--max-walls", type=int, default=3, help="Max walls per player")
+    parser.add_argument("-e", "--episodes", type=int, default=1000, help="Number of episodes to train for")
+    parser.add_argument("--num-workers", type=int, default=2, help="Number of worker processes")
+    parser.add_argument(
+        "--max-game-length", type=int, default=200, help="Max number of turns before game is called a tie"
+    )
+    args = parser.parse_args()
+
+    main(args)

--- a/ruff.toml
+++ b/ruff.toml
@@ -50,6 +50,12 @@ unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
+[lint.isort]
+# Ruff sometimes mistakenly thinks the wandb python module is "first-party"
+# and puts it in that section  of the imports if the wandb cache directory
+# exists. See https://github.com/astral-sh/ruff/issues/10519
+known-third-party = ["wandb"]
+
 [format]
 # Like Black, use double quotes for strings.
 quote-style = "double"


### PR DESCRIPTION
There's a lot more to do on this, but I think getting this reviewed and merged at this point will be good - both to get feedback and avoid a huge PR later.

#### Summary
New "train_alphazero.py" script that trains alphazero via self play
using the main process for NN training and coordination, and worker
subprocesses to run multipled games in parallel.

#### Example command
This will run 40 self-play games, then train the NN, then run 40 more games, then train again. It will use 2 worker subprocesses. The `-p` is for setting the subargs parameters of the alphazero agent (but you omit the agent name since it is always alphazero).

```python -O deep_quoridor/src/train_alphazero.py --games-per-epoch 40 --epochs 2 --num-workers=2 -p mcts_n=1000```

On my laptop (which runs the NN on CPU) 2 threads is more than enough to overwhelm all the cores, since the torch NN inference runs in many system threads. On my desktop, which has an nvidia card, I can use up to 20 workers and stil have spare cores.

#### Things that still need to be done
- saving models to disk at checkpoints
- wandb integration
- better stats on what is taking the most computation time, and some optional GPU profiling
- adding noise for the policy used by the mcts search in early moves of each game, as the Alphago Zero paper does

