### PR TITLE
MCTS: pre-compute evaluations and cache

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -86,10 +86,12 @@ class Node:
 
 
 class MCTS:
-    def __init__(self, n: int, ucb_c: float, evaluator):
+    def __init__(self, n: int, ucb_c: float, evaluator, pre_evaluate_nodes_total: int = 64):
         self.n = n
         self.ucb_c = ucb_c
         self.evaluator = evaluator
+        self.new_nodes = []
+        self.extra_eval = pre_evaluate_nodes_total - 1
 
     def select(self, node: Node) -> Node:
         """
@@ -113,8 +115,11 @@ class MCTS:
                 value = 1
             # TODO: Handle ties (these happen when arena decides game is taking too long)
             else:
-                value, priors = self.evaluator.evaluate(node.game)
+                games_to_evaluate = [n.game for n in self.new_nodes[: self.extra_eval]]
+                self.new_nodes = self.new_nodes[self.extra_eval :]
+                value, priors = self.evaluator.evaluate(node.game, games_to_evaluate)
                 node.expand(priors)
+                self.new_nodes.extend(node.children)
 
             node.backpropagate(value)
 


### PR DESCRIPTION
This does 3 things to speed up the training:

- Removed `assert torch.isfinite(policy_logits).all(), "Policy logits contains non-finite values"`.  I think it's redundant anyway, but it was making it much slower, I think it's not the computation itself, but that it needs to wait for the NN to complete.
- Instead of using the NN to evaluate just the current game, we evaluate up to `mcts_pre_evaluate_nodes_total` (default 64) games, to take advantage of GPU efficiency for batches.  The way it works is that when we expand, we store the new nodes in a list, and then when computing we do not only the current game but up to 63 from this list, and we store them in the cache.
- By using the cache, we don't need to re-evaluate the same states, even in different games (but we need to reset the cache when we train the NN), which also gives a nice speed up.

I tried using:
```
time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 20 -i 43 -p alphazero:training_mode=true,mcts_n=200,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=1.4,optimizer_iterations=50 -r arenaresults2 computationtimes -f 20
```
And from main it took 4 minutes, vs 40 seconds with this change, so it's a 6x speedup (YMMV).
Also, the number of steps and the loss is the same before and after, so most likely is producing the same results.

