### PR TITLE
Introduce mcts_k

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -7,11 +7,11 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
+import wandb
 from quoridor import ActionEncoder, construct_game_from_observation
 from utils import my_device
 from utils.subargs import SubargsBase
 
-import wandb
 from agents.alphazero.mcts import MCTS
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import TrainableAgent
@@ -45,6 +45,10 @@ class AlphaZeroParams(SubargsBase):
 
     # Number of MCTS selections
     mcts_n: int = 100
+
+    # If set, the number of MCTS selections is going to be mcts_k * n_actions, where n_actions
+    # is the number of actions available.
+    mcts_k: Optional[int] = None
 
     # A higher number favors exploration over exploitation
     mcts_ucb_c: float = 1.4
@@ -103,7 +107,9 @@ class AlphaZeroAgent(TrainableAgent):
 
         self.action_encoder = ActionEncoder(board_size)
         self.evaluator = NNEvaluator(self.action_encoder, self.device)
-        self.mcts = MCTS(params.mcts_n, params.mcts_ucb_c, self.evaluator, params.mcts_pre_evaluate_nodes_total)
+        self.mcts = MCTS(
+            params.mcts_n, params.mcts_k, params.mcts_ucb_c, self.evaluator, params.mcts_pre_evaluate_nodes_total
+        )
         if params.training_mode and params.train_every is not None:
             self.evaluator.train_prepare(params.learning_rate, params.batch_size, params.optimizer_iterations)
 

--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -86,8 +86,10 @@ class Node:
 
 
 class MCTS:
-    def __init__(self, n: int, ucb_c: float, evaluator, pre_evaluate_nodes_total: int = 64):
+    def __init__(self, n: Optional[int], k: Optional[int], ucb_c: float, evaluator, pre_evaluate_nodes_total: int = 64):
+        assert n is not None or k is not None, "Either n or k need to be specified"
         self.n = n
+        self.k = k
         self.ucb_c = ucb_c
         self.evaluator = evaluator
         self.new_nodes = []
@@ -106,7 +108,14 @@ class MCTS:
     def search(self, initial_game: Quoridor):
         root = Node(initial_game, ucb_c=self.ucb_c)
 
-        for _ in range(self.n):
+        if self.k is not None:
+            num_actions = np.sum(np.array(initial_game.get_action_mask()) == 1)
+            num_iterations = self.k * num_actions
+        else:
+            assert self.n is not None, "n must be specified if k is not"
+            num_iterations = self.n
+
+        for _ in range(num_iterations):
             # Traverse down the tree guided by maximum UCB until we find a node to expand
             node = self.select(root)
 


### PR DESCRIPTION
With this PR, if you specify mcts_k instead of mcts_n, the number of searches in MCTS will be mcts_k * number_of_actions. This way, we ensure we have enough searches to explore the space, but we don't waste time if there are just a few actions (usually when there are no walls)


E.g.:
```
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python  -N 5 -W 3 -e 1000 -i 43  32.76s user 3.69s system 78% cpu 46.212 total
(base) amarcu@MacBookPro deep_rabbit_hole % time /Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 1000 -i 43 -p alphazero:training_mode=true,mcts_k=20,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=2,optimizer_iterations=50 -r arenaresults2 computationtimes -f 20
Starting DQN training...
Board size: 5x5
Max walls: 3
Training for 1000 episodes
Using step rewards: False
Device: mps
Initializing random seed 43
alphazero P2 Episode     1/1000 [ ], Steps:  41, Time:  4751ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     1/1000 [ ], Steps:  41, Time:  4751ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     2/1000 [ ], Steps:  55, Time:  2517ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     2/1000 [ ], Steps:  55, Time:  2517ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     3/1000 [ ], Steps:  30, Time:  2267ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     3/1000 [ ], Steps:  30, Time:  2267ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     4/1000 [ ], Steps:  42, Time:  2434ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     4/1000 [ ], Steps:  42, Time:  2434ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     5/1000 [ ], Steps:  26, Time:  1973ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     5/1000 [ ], Steps:  26, Time:  1973ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     6/1000 [ ], Steps: 106, Time:  2780ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     6/1000 [ ], Steps: 106, Time:  2780ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     7/1000 [ ], Steps: 109, Time:  2795ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     7/1000 [ ], Steps: 109, Time:  2795ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     8/1000 [ ], Steps:  68, Time:  2766ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     8/1000 [ ], Steps:  68, Time:  2766ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     9/1000 [ ], Steps:  72, Time:  2645ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     9/1000 [ ], Steps:  72, Time:  2645ms,  Avg Reward:   0.00, Avg Loss:  0.0000, Epsilon: 0.0000 opponent: alphazero
Training the network (buffer size: 582, batch size: 64)...done in 0.74s
alphazero P2 Episode    10/1000 [ ], Steps:  33, Time:  3268ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    10/1000 [ ], Steps:  33, Time:  3268ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    11/1000 [ ], Steps:  42, Time:  3848ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    11/1000 [ ], Steps:  42, Time:  3848ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    12/1000 [ ], Steps:  17, Time:  3640ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    12/1000 [ ], Steps:  17, Time:  3640ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    13/1000 [ ], Steps:  49, Time:  2953ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    13/1000 [ ], Steps:  49, Time:  2953ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    14/1000 [ ], Steps:  38, Time:  2615ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    14/1000 [ ], Steps:  38, Time:  2615ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    15/1000 [ ], Steps:  43, Time:  2451ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    15/1000 [ ], Steps:  43, Time:  2451ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    16/1000 [ ], Steps:  67, Time:  3568ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    16/1000 [ ], Steps:  67, Time:  3568ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    17/1000 [ ], Steps:  43, Time:  3970ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    17/1000 [ ], Steps:  43, Time:  3970ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    18/1000 [ ], Steps: 117, Time:  4425ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    18/1000 [ ], Steps: 117, Time:  4425ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    19/1000 [ ], Steps:  69, Time:  3435ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode    19/1000 [ ], Steps:  69, Time:  3435ms,  Avg Reward:   0.00, Avg Loss:  4.7440, Epsilon: 0.0000 opponent: alphazero
Training the network (buffer size: 1151, batch size: 64)...done in 0.42s
```
