### PR TITLE
Show the state value in pygame

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -7,14 +7,14 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
-from agents.alphazero.mcts import MCTS
-from agents.alphazero.nn_evaluator import NNEvaluator
-from agents.core import TrainableAgent
+import wandb
 from quoridor import ActionEncoder, MoveAction, construct_game_from_observation
 from utils import my_device
 from utils.subargs import SubargsBase
 
-import wandb
+from agents.alphazero.mcts import MCTS
+from agents.alphazero.nn_evaluator import NNEvaluator
+from agents.core import TrainableAgent
 
 
 @dataclass

--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -7,14 +7,14 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
-import wandb
-from quoridor import ActionEncoder, construct_game_from_observation
-from utils import my_device
-from utils.subargs import SubargsBase
-
 from agents.alphazero.mcts import MCTS
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import TrainableAgent
+from quoridor import ActionEncoder, MoveAction, construct_game_from_observation
+from utils import my_device
+from utils.subargs import SubargsBase
+
+import wandb
 
 
 @dataclass
@@ -233,6 +233,8 @@ class AlphaZeroAgent(TrainableAgent):
         self,
         visit_probs,
         root_children,
+        root_value,
+        root_action,
     ):
         if not self.action_log.is_enabled():
             return
@@ -243,19 +245,21 @@ class AlphaZeroAgent(TrainableAgent):
 
         scores = {root_children[i].action_taken: visit_probs[i] for i in top_indices}
         self.action_log.action_score_ranking(scores)
+        self.action_log.action_text(root_action, f"{root_value:0.2f}")
 
     def get_action(self, observation) -> int:
         game, player, _ = construct_game_from_observation(observation["observation"])
-
         # Run MCTS to get action visit counts
-        root_children = self.mcts.search(game)
+        root_children, root_value = self.mcts.search(game)
         visit_counts = np.array([child.visit_count for child in root_children])
         visit_counts_sum = np.sum(visit_counts)
         if visit_counts_sum == 0:
             raise RuntimeError("No nodes visited during MCTS")
 
         visit_probs = visit_counts / visit_counts_sum
-        self._log_action(visit_probs, root_children)
+        self._log_action(
+            visit_probs, root_children, float(root_value), MoveAction(game.board.get_player_position(player))
+        )
 
         if self.temperature == 0.0:
             max_value = np.max(visit_probs)

--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy as np
-from quoridor import Action, Quoridor
+from quoridor import Action, Player, Quoridor
 
 
 class Node:
@@ -131,5 +131,7 @@ class MCTS:
                 self.new_nodes.extend(node.children)
 
             node.backpropagate(value)
-
-        return root.children
+        # Negate the value because the value is actually the value that the opponent
+        # got for getting to that state.
+        root_value = -(root.value_sum / root.visit_count)
+        return root.children, root_value

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -65,9 +65,9 @@ class NNEvaluator:
             # If the game was originally rotated, rotate the resulting back to player 2's perspective
             if g.get_current_player() == Player.TWO:
                 policy_masked[i] = policy_masked[i][self.action_mapping_rotated_to_original]
-            self.cache[all_hashes[i]] = (values[i], policy_masked[i])
+            self.cache[all_hashes[i]] = (values[i][0], policy_masked[i])
 
-        return values[0], policy_masked[0]
+        return values[0][0], policy_masked[0]
 
     def rotate_policy_from_original(self, policy: np.ndarray):
         """


### PR DESCRIPTION
I thought it would be useful to display the state value to better understand what's going on, i.e. how likely MCTS thinks that the player will win.  We can see that at the beginning the values are close to 0, because we end up evaluating mid-game states and the network is untrained.  Later in the game, MCTS is able to reach winning states and we can see that the values are higher and seem reasonable (e.g. getting closer to 1 when it has a good chance of winning)

```
/Users/amarcu/code/deep_rabbit_hole/.venv/bin/python /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 1000 -i 43 -p alphazero:training_mode=true,mcts_n=1000,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=2,optimizer_iterations=50 -r arenaresults2 computationtimes -f 20 -r pygame
```

https://github.com/user-attachments/assets/fa5b235b-a716-4e58-b162-baa6d990ce2f

