### PR TITLE
Client/Server Evaluator for multiprocess training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ wandbmodels
 runs
 deep_quoridor/td.sh
 deep_quoridor/tn.sh
+
+# Claude code cache directory
+.claude

--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -7,11 +7,11 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
+import wandb
 from quoridor import ActionEncoder, construct_game_from_observation
 from utils import my_device
 from utils.subargs import SubargsBase
 
-import wandb
 from agents.alphazero.mcts import MCTS
 from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core import TrainableAgent
@@ -91,6 +91,7 @@ class AlphaZeroAgent(TrainableAgent):
         max_walls,
         observation_space=None,
         action_space=None,
+        evaluator=None,
         params=AlphaZeroParams(),
         **kwargs,
     ):
@@ -103,6 +104,10 @@ class AlphaZeroAgent(TrainableAgent):
 
         self.action_encoder = ActionEncoder(board_size)
         self.evaluator = NNEvaluator(self.action_encoder, self.device)
+        if evaluator is None:
+            self.evaluator = NNEvaluator(self.action_encoder, self.device)
+        else:
+            self.evaluator = evaluator
         self.mcts = MCTS(params.mcts_n, params.mcts_ucb_c, self.evaluator, params.mcts_pre_evaluate_nodes_total)
         if params.training_mode and params.train_every is not None:
             self.evaluator.train_prepare(params.learning_rate, params.batch_size, params.optimizer_iterations)

--- a/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
@@ -6,6 +6,8 @@ import queue
 import threading
 import time
 from collections import deque
+from dataclasses import dataclass
+from typing import Optional
 
 import numpy as np
 import torch
@@ -17,6 +19,55 @@ from agents.alphazero.nn_evaluator import NNEvaluator
 from agents.core.rotation import create_rotation_mapping
 
 
+@dataclass
+class EvaluationInfo:
+    """
+    Information about one call to the evaluator.
+    """
+
+    evaluation_start_time: float
+    evaluation_end_time: float
+    num_games_evaluated: int
+    used_cache: bool
+
+
+@dataclass
+class EvaluatorStatistics:
+    """
+    Statistics about all evaluations since this evaluator was created.
+    """
+
+    duty_cycle: float
+    average_evaluation_time: float
+    num_evaluations: int
+    num_cache_hits: int
+
+
+def compute_statistics(evaluation_log: list[EvaluationInfo]) -> Optional[EvaluatorStatistics]:
+    evaluation_time_sum = 0
+    num_evaluations = len(evaluation_log)
+    num_cache_hits = 0
+    first_evaluation_time = None
+    last_evaluation_time = None
+    for eval_info in evaluation_log:
+        if first_evaluation_time is None:
+            first_evaluation_time = eval_info.evaluation_start_time
+        last_evaluation_time = eval_info.evaluation_end_time
+        evaluation_time_sum += eval_info.evaluation_end_time - eval_info.evaluation_start_time
+        if eval_info.used_cache:
+            num_cache_hits += 1
+
+    if num_evaluations > 0:
+        if first_evaluation_time is None or last_evaluation_time is None:
+            duty_cycle = None
+        else:
+            duty_cycle = evaluation_time_sum / (last_evaluation_time - first_evaluation_time)
+
+        return EvaluatorStatistics(duty_cycle, evaluation_time_sum / num_evaluations, num_evaluations, num_cache_hits)
+    else:
+        return None
+
+
 class EvaluatorClient:
     def __init__(
         self,
@@ -24,6 +75,7 @@ class EvaluatorClient:
         client_id: int,
         request_queue: mp.Queue,
         result_queue: mp.Queue,
+        max_log_len=int(1e8),
     ):
         self._client_id = client_id
         self._request_queue = request_queue
@@ -31,39 +83,53 @@ class EvaluatorClient:
         (self._action_mapping_original_to_rotated, self._action_mapping_rotated_to_original) = create_rotation_mapping(
             board_size
         )
-        # byte_representation_of_game_state -> (, value, policy)
         self._cache = {}
+        self._evaluation_log = deque(maxlen=max_log_len)
 
     def evaluate(self, game: Quoridor, extra_games_to_evaluate: list[Quoridor] = []):
-        if game.get_byte_repr() in self._cache:
-            return self._cache[game.get_byte_repr()]
+        evaluation_start_time = time.time()
 
-        all_games = [game] + extra_games_to_evaluate
-        all_hashes = np.stack([g.get_byte_repr() for g in all_games])
-        all_games = [NNEvaluator.rotate_if_needed_to_point_downwards(g)[0] for g in all_games]
-        all_games_inputs_array = np.stack([NNEvaluator.game_to_input_array(g) for g in all_games])
+        game, _ = self.rotate_if_needed_to_point_downwards(game)
+        input_array = self.game_to_input_array(game)
+        cache_key = input_array.tobytes()
+        if cache_key in self._cache:
+            cached_value, cached_policy, _ = self._cache[cache_key]
+            if game.is_rotated():
+                cached_policy = cached_policy[self._action_mapping_rotated_to_original]
+            evaluation_end_time = time.time()
+            self._evaluation_log.append(EvaluationInfo(evaluation_start_time, evaluation_end_time, 1, True))
+            return cached_value, cached_policy
+
+        all_games = [game] + [self.rotate_if_needed_to_point_downwards(g)[0] for g in extra_games_to_evaluate]
+        all_games_inputs_array = np.stack([input_array] + [NNEvaluator.game_to_input_array(g) for g in all_games[1:]])
         all_games_action_masks = np.stack([g.get_action_mask() for g in all_games])
 
-        values, policies = self.evaluate_array(all_games_inputs_array, all_games_action_masks)
+        values_array, policies_array = self.evaluate_arrays(all_games_inputs_array, all_games_action_masks)
 
-        for game_i, game in enumerate(all_games):
+        for row_i in range(len(values_array)):
             # Sanity checks
-            assert np.all(policies[game_i] >= 0), "Policy contains negative probabilities"
-            assert np.abs(np.sum(policies[game_i]) - 1) < 1e-6, "Policy does not sum to 1"
-            assert np.isfinite(values[game_i]), "Policy or value is non-finite"
+            assert np.all(policies_array[row_i] >= 0), "Policy contains negative probabilities"
+            assert np.abs(np.sum(policies_array[row_i]) - 1) < 1e-6, "Policy does not sum to 1"
+            assert np.isfinite(values_array[row_i]), "Policy or value is non-finite"
 
-            # If the game was originally rotated, rotate the resulting back
-            if game.get_current_player() == Player.TWO:
-                policies[game_i] = policies[game_i][self._action_mapping_rotated_to_original]
+            # Update our local cache
+            cache_key = all_games_inputs_array[row_i].tobytes()
+            self._cache[cache_key] = (values_array[row_i], policies_array[row_i], game.copy())
 
-            self._cache[all_hashes[game_i]] = (values[game_i], policies[game_i])
+        evaluation_end_time = time.time()
+        self._evaluation_log.append(EvaluationInfo(evaluation_start_time, evaluation_end_time, 1, False))
 
-        return values[0], policies[0]
+        value = values_array[0]
+        policy = policies_array[0]
+        if game.is_rotated():
+            policy = policy[self._action_mapping_rotated_to_original]
 
-    def evaluate_array(self, input_arrays: np.ndarray, action_mask_arrays: np.ndarray):
-        self._request_queue.put((input_arrays, action_mask_arrays, self._client_id))
-        value, policy = self._result_queue.get(timeout=10)
         return value, policy
+
+    def evaluate_arrays(self, input_arrays: np.ndarray, action_mask_arrays: np.ndarray):
+        self._request_queue.put((input_arrays, action_mask_arrays, self._client_id))
+        values_array, policies_array = self._result_queue.get()
+        return values_array, policies_array
 
     def rotate_policy_from_original(self, policy: np.ndarray):
         return policy[self._action_mapping_original_to_rotated]
@@ -77,6 +143,9 @@ class EvaluatorClient:
     def clear_cache(self):
         self._cache.clear()
 
+    def get_statistics(self):
+        return compute_statistics(self._evaluation_log)
+
 
 class EvaluatorServer(threading.Thread):
     def __init__(
@@ -84,15 +153,15 @@ class EvaluatorServer(threading.Thread):
         evaluator: NNEvaluator,
         input_queue: mp.Queue,
         output_queues: list[mp.Queue],
-        statistics_window_size=1000000000,
+        max_log_len=int(1e8),
     ):
         super().__init__()
         self._evaluator = evaluator
         self._cache = {}
         self._input_queue = input_queue
         self._output_queues = output_queues
-        self._statistics_window_size = statistics_window_size
-        self._statistics = deque(maxlen=statistics_window_size)
+        self._max_l = max_log_len
+        self._evaluation_log = deque(maxlen=max_log_len)
         self._shutdown = False
 
     def run(self):
@@ -102,20 +171,43 @@ class EvaluatorServer(threading.Thread):
             except queue.Empty:
                 continue
 
+            values_array, policies_array = self._evaluate_arrays(inputs_array, action_masks_array)
+            self._send_result_to_client(client_id, values_array, policies_array)
+
+            # Update the cache
+            for row_i in range(len(values_array)):
+                self._cache[inputs_array[row_i].tobytes()] = (values_array[row_i], policies_array[row_i])
+
+    def _evaluate_arrays(self, inputs_array, action_masks_array):
+        evaluation_start_time = time.time()
+        used_cache = False
+
+        # If the first input array is in our cache, we return the cached value, policy for that
+        # one and don't evaluate the others.
+        cache_key = inputs_array[0].tobytes()
+        if cache_key in self._cache:
+            value, policy = self._cache.get(cache_key)
+            values_array = np.expand_dims(value, 0)
+            policies_array = np.expand_dims(policy, 0)
+            used_cache = True
+        else:
             inputs_tensor = torch.from_numpy(inputs_array).to(my_device())
             action_masks_tensor = torch.from_numpy(action_masks_array).to(my_device())
 
-            evaluation_start_time = time.time()
+            # Do the actual evalution
             values_tensor, policies_tensor = self._evaluator.evaluate_tensors(inputs_tensor, action_masks_tensor)
-            evaluation_end_time = time.time()
 
-            # Transfer policies and values back to CPU and turn them into arrays
-            policies_array = policies_tensor.cpu().numpy()
             values_array = values_tensor.cpu().flatten().numpy()
+            policies_array = policies_tensor.cpu().numpy()
 
-            self._output_queues[client_id].put((values_array, policies_array))
+        evaluation_end_time = time.time()
+        self._evaluation_log.append(
+            EvaluationInfo(evaluation_start_time, evaluation_end_time, len(inputs_array), used_cache)
+        )
+        return values_array, policies_array
 
-            self._statistics.append((evaluation_start_time, evaluation_end_time))
+    def _send_result_to_client(self, client_id, values_array, policies_array):
+        self._output_queues[client_id].put((values_array, policies_array))
 
     def train_prepare(self, *args, **kwargs):
         return self._evaluator.train_prepare(*args, **kwargs)
@@ -125,29 +217,7 @@ class EvaluatorServer(threading.Thread):
         return self._evaluator.train_iteration(*args, **kwargs)
 
     def get_statistics(self):
-        evaluation_time_sum = 0
-        num_evaluations = len(self._statistics)
-        first_evaluation_time = None
-        last_evaluation_time = None
-        for evaluation_start_time, evaluation_end_time in self._statistics:
-            if first_evaluation_time is None:
-                first_evaluation_time = evaluation_start_time
-            last_evaluation_time = evaluation_end_time
-            evaluation_time_sum += evaluation_end_time - evaluation_start_time
-
-        if num_evaluations > 0:
-            if first_evaluation_time is None or last_evaluation_time is None:
-                duty_cycle = None
-            else:
-                duty_cycle = evaluation_time_sum / (last_evaluation_time - first_evaluation_time)
-
-            return {
-                "duty_cycle": duty_cycle,
-                "average_evaluation_time": evaluation_time_sum / num_evaluations,
-                "num_evaluations": num_evaluations,
-            }
-        else:
-            return {}
+        return compute_statistics(self._evaluation_log)
 
     def shutdown(self):
         self._shutdown = True

--- a/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
@@ -21,7 +21,6 @@ class EvaluatorClient:
         self,
         board_size: int,
         client_id: int,
-        cache: dict,
         request_queue: mp.SimpleQueue,
         result_queue: mp.SimpleQueue,
     ):
@@ -32,7 +31,7 @@ class EvaluatorClient:
             board_size
         )
         # byte_representation_of_game_state -> (, value, policy)
-        self._cache = cache
+        self._cache = {}
 
     def evaluate(self, game: Quoridor, extra_games_to_evaluate: list[Quoridor] = []):
         if game.get_byte_repr() in self._cache:
@@ -74,19 +73,21 @@ class EvaluatorClient:
     def game_to_input_array(self, game):
         return NNEvaluator.game_to_input_array(game)
 
+    def clear_cache(self):
+        self._cache.clear()
+
 
 class EvaluatorServer(threading.Thread):
     def __init__(
         self,
         evaluator: NNEvaluator,
-        cache: dict,
         input_queue: mp.SimpleQueue,
         output_queues: list[mp.SimpleQueue],
         statistics_window_size=10000,
     ):
         super().__init__()
         self._evaluator = evaluator
-        self._cache = cache
+        self._cache = {}
         self._input_queue = input_queue
         self._output_queues = output_queues
         self._statistics_window_size = statistics_window_size

--- a/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
@@ -1,0 +1,126 @@
+"""
+Wraps an evaluator for use by multiple client processes via Queues.
+"""
+
+import threading
+import time
+from collections import deque
+
+import numpy as np
+import torch
+import torch.multiprocessing as mp
+from quoridor import Quoridor
+
+from agents.alphazero.nn_evaluator import NNEvaluator
+
+
+class EvaluatorClient:
+    def __init__(self, client_id: int, request_queue: mp.SimpleQueue, result_queue: mp.SimpleQueue):
+        self._client_id = client_id
+        self._request_queue = request_queue
+        self._result_queue = result_queue
+
+    def evaluate(self, game: Quoridor):
+        # Rotate the board if player 2 is playing so that we always work with player 1's perspective.
+        game, is_board_rotated = NNEvaluator.rotate_if_needed_to_point_downwards(game)
+        input_array = NNEvaluator.game_to_input_array(game)
+        action_mask_array = game.get_action_mask()
+
+        value, policy = self.evaluate_array(input_array, action_mask_array)
+
+        if is_board_rotated:
+            policy = self.rotate_policy_from_original(policy)
+
+        return value, policy
+
+    def evaluate_array(self, input_array: np.ndarray, action_mask_array: np.ndarray):
+        self._request_queue.put((input_array, action_mask_array, self._client_id))
+        value, policy = self._result_queue.get()
+        return value, policy
+
+
+class EvaluatorServer(threading.Thread):
+    def __init__(
+        self,
+        evaluator: NNEvaluator,
+        batch_size: int,
+        max_interbatch_time: float,
+        input_queue: mp.SimpleQueue,
+        output_queues: list[mp.SimpleQueue],
+        statistics_window_size=10000,
+    ):
+        super().__init__()
+        self._evaluator = evaluator
+        self._batch_size = batch_size
+        self._max_interbatch_time = max_interbatch_time
+        self._input_queue = input_queue
+        self._output_queues = output_queues
+        self._statistics_window_size = statistics_window_size
+        self._statistics = deque(maxlen=statistics_window_size)
+        self._shutdown = False
+
+    def run(self):
+        batch = []
+        last_batch_end_time = time.time()
+
+        while not self._shutdown:
+            while len(batch) < self._batch_size:
+                if self._shutdown:
+                    break
+
+                wait_until_time = last_batch_end_time + self._max_interbatch_time
+                while time.time() < wait_until_time and self._input_queue.empty():
+                    # If we used Queue instead of SimpleQueue, we could use a timeout in get(),
+                    # but that seems to cause deadlocks.
+                    time.sleep(0.001)
+
+                if self._input_queue.empty():
+                    break
+
+                # Grab any more available inputs up to batch size
+                while self._input_queue.empty() and len(batch) < self._batch_size:
+                    input_array, action_mask_array, client_id = self._input_queue.get()
+                    batch.append((input_array, action_mask_array, client_id))
+
+            if len(batch) > 0:
+                stacked_input_tensor = torch.from_numpy(np.stack([x[0] for x in batch]))
+                stacked_action_masks_tensor = torch.from_numpy(np.stack([x[1] for x in batch]))
+                client_ids = [x[2] for x in batch]
+
+                # Run the evaluator on all the inputs at once
+                evaluation_start_time = time.time()
+                stacked_values, stacked_policies = self._evaluator.batch_evaluate(
+                    stacked_input_tensor, stacked_action_masks_tensor
+                )
+                evaluation_end_time = time.time()
+
+                # Send the results back to the clients
+                for row, client_id in enumerate(client_ids):
+                    self._output_queues[client_id].put(stacked_values[row], stacked_policies[row])
+
+                # Clear out everything we just computed
+                batch = []
+
+                # Keep some statistics for tuning and debugging
+                self._statistics.append((len(batch), evaluation_start_time, evaluation_end_time))
+
+            last_batch_end_time = time.time()
+
+    def get_statistics(self):
+        batch_size_sum = 0
+        evaluation_time_sum = 0
+        num_batches = 0
+        for batch_size, evaluation_start_time, evaluation_end_time in self._statistics:
+            batch_size_sum += batch_size
+            evaluation_time_sum += evaluation_end_time - evaluation_start_time
+            num_batches += 1
+        if num_batches > 0:
+            return {
+                "average_batch_size": batch_size_sum / num_batches,
+                "average_evaluation_time": evaluation_time_sum / num_batches,
+            }
+        else:
+            return {}
+
+    def shutdown(self):
+        self._shutdown = True

--- a/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
@@ -10,20 +10,25 @@ import numpy as np
 import torch
 import torch.multiprocessing as mp
 from quoridor import Quoridor
+from utils import my_device
 
 from agents.alphazero.nn_evaluator import NNEvaluator
+from agents.core.rotation import create_rotation_mapping
 
 
 class EvaluatorClient:
-    def __init__(self, client_id: int, request_queue: mp.SimpleQueue, result_queue: mp.SimpleQueue):
+    def __init__(self, client_id: int, request_queue: mp.SimpleQueue, result_queue: mp.SimpleQueue, board_size: int):
         self._client_id = client_id
         self._request_queue = request_queue
         self._result_queue = result_queue
+        (self._action_mapping_original_to_rotated, self._action_mapping_rotated_to_original) = create_rotation_mapping(
+            board_size
+        )
 
     def evaluate(self, game: Quoridor):
         # Rotate the board if player 2 is playing so that we always work with player 1's perspective.
-        game, is_board_rotated = NNEvaluator.rotate_if_needed_to_point_downwards(game)
-        input_array = NNEvaluator.game_to_input_array(game)
+        game, is_board_rotated = self.rotate_if_needed_to_point_downwards(game)
+        input_array = self.game_to_input_array(game)
         action_mask_array = game.get_action_mask()
 
         value, policy = self.evaluate_array(input_array, action_mask_array)
@@ -37,6 +42,15 @@ class EvaluatorClient:
         self._request_queue.put((input_array, action_mask_array, self._client_id))
         value, policy = self._result_queue.get()
         return value, policy
+
+    def rotate_policy_from_original(self, policy: np.ndarray):
+        return policy[self._action_mapping_original_to_rotated]
+
+    def rotate_if_needed_to_point_downwards(self, game: Quoridor):
+        return NNEvaluator.rotate_if_needed_to_point_downwards(game)
+
+    def game_to_input_array(self, game):
+        return NNEvaluator.game_to_input_array(game)
 
 
 class EvaluatorServer(threading.Thread):
@@ -64,27 +78,28 @@ class EvaluatorServer(threading.Thread):
         last_batch_end_time = time.time()
 
         while not self._shutdown:
-            while len(batch) < self._batch_size:
+            while len(batch) == 0:
                 if self._shutdown:
                     break
 
+                # If we used Queue instead of SimpleQueue, we could use a timeout in get(),
+                # but that seems to cause deadlocks. Until we debug that, sticking to a
+                # busy wait here.
                 wait_until_time = last_batch_end_time + self._max_interbatch_time
                 while time.time() < wait_until_time and self._input_queue.empty():
-                    # If we used Queue instead of SimpleQueue, we could use a timeout in get(),
-                    # but that seems to cause deadlocks.
-                    time.sleep(0.001)
+                    time.sleep(0.00001)
 
                 if self._input_queue.empty():
                     break
 
                 # Grab any more available inputs up to batch size
-                while self._input_queue.empty() and len(batch) < self._batch_size:
+                while not self._input_queue.empty() and len(batch) < self._batch_size:
                     input_array, action_mask_array, client_id = self._input_queue.get()
                     batch.append((input_array, action_mask_array, client_id))
 
             if len(batch) > 0:
-                stacked_input_tensor = torch.from_numpy(np.stack([x[0] for x in batch]))
-                stacked_action_masks_tensor = torch.from_numpy(np.stack([x[1] for x in batch]))
+                stacked_input_tensor = torch.from_numpy(np.stack([x[0] for x in batch])).to(my_device())
+                stacked_action_masks_tensor = torch.from_numpy(np.stack([x[1] for x in batch])).to(my_device())
                 client_ids = [x[2] for x in batch]
 
                 # Run the evaluator on all the inputs at once
@@ -96,13 +111,13 @@ class EvaluatorServer(threading.Thread):
 
                 # Send the results back to the clients
                 for row, client_id in enumerate(client_ids):
-                    self._output_queues[client_id].put(stacked_values[row], stacked_policies[row])
-
-                # Clear out everything we just computed
-                batch = []
+                    self._output_queues[client_id].put((stacked_values[row], stacked_policies[row]))
 
                 # Keep some statistics for tuning and debugging
                 self._statistics.append((len(batch), evaluation_start_time, evaluation_end_time))
+
+                # Clear out everything we just computed
+                batch = []
 
             last_batch_end_time = time.time()
 

--- a/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/multiprocess_evaluator.py
@@ -12,7 +12,7 @@ from typing import Optional
 import numpy as np
 import torch
 import torch.multiprocessing as mp
-from quoridor import Player, Quoridor
+from quoridor import Quoridor
 from utils import my_device
 
 from agents.alphazero.nn_evaluator import NNEvaluator

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -68,8 +68,8 @@ class NNEvaluator:
 
         all_games = [game] + extra_games_to_evaluate
         all_hashes = [g.get_fast_hash() for g in all_games]
-        all_games = [self.rotate_if_needed_to_point_downwards(g)[0] for g in all_games]
-        all_games_input_arrays = [torch.from_numpy(self.game_to_input_array(g)) for g in all_games]
+        all_games = [NNEvaluator.rotate_if_needed_to_point_downwards(g)[0] for g in all_games]
+        all_games_input_arrays = [torch.from_numpy(NNEvaluator.game_to_input_array(g)) for g in all_games]
         all_games_tensors = torch.stack(all_games_input_arrays).to(device=self.device)
 
         if self.network.training:
@@ -125,7 +125,8 @@ class NNEvaluator:
 
         return game, is_rotated
 
-    def game_to_input_array(self, game: Quoridor) -> np.ndarray:
+    @staticmethod
+    def game_to_input_array(game: Quoridor) -> np.ndarray:
         """Convert Quoridor game state to tensor format for neural network."""
         player = game.get_current_player()
         opponent = Player(1 - player)

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -539,6 +539,9 @@ class Quoridor:
         # Combine all bytes and hash
         return hash(self.get_byte_repr())
 
+    def is_rotated(self) -> bool:
+        return self._rotated
+
 
 def construct_game_from_observation(observation: dict) -> tuple[Quoridor, Player, Player]:
     player_id = observation["player_turn"]

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -525,16 +525,19 @@ class Quoridor:
     def __str__(self):
         return str(self.board)
 
-    def get_fast_hash(self):
-        # Use a fast, unique hash based on the board, player positions, walls, and current player.
-        # We'll use numpy's .tobytes() for fast serialization and hash().
+    def get_byte_repr(self):
         board_bytes = self.board._grid.tobytes()
         walls_remaining_bytes = self.board._walls_remaining.tobytes()
         player_byte = bytes([self.current_player])
         rotated_byte = bytes([1] if self._rotated else [])
+        return board_bytes + walls_remaining_bytes + player_byte + rotated_byte
+
+    def get_fast_hash(self):
+        # Use a fast, unique hash based on the board, player positions, walls, and current player.
+        # We'll use numpy's .tobytes() for fast serialization and hash().
 
         # Combine all bytes and hash
-        return hash(board_bytes + walls_remaining_bytes + player_byte + rotated_byte)
+        return hash(self.get_byte_repr())
 
 
 def construct_game_from_observation(observation: dict) -> tuple[Quoridor, Player, Player]:

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -525,19 +525,16 @@ class Quoridor:
     def __str__(self):
         return str(self.board)
 
-    def get_byte_repr(self):
+    def get_fast_hash(self):
+        # Use a fast, unique hash based on the board, player positions, walls, and current player.
+        # We'll use numpy's .tobytes() for fast serialization and hash().
         board_bytes = self.board._grid.tobytes()
         walls_remaining_bytes = self.board._walls_remaining.tobytes()
         player_byte = bytes([self.current_player])
         rotated_byte = bytes([1] if self._rotated else [])
-        return board_bytes + walls_remaining_bytes + player_byte + rotated_byte
-
-    def get_fast_hash(self):
-        # Use a fast, unique hash based on the board, player positions, walls, and current player.
-        # We'll use numpy's .tobytes() for fast serialization and hash().
 
         # Combine all bytes and hash
-        return hash(self.get_byte_repr())
+        return hash(board_bytes + walls_remaining_bytes + player_byte + rotated_byte)
 
     def is_rotated(self) -> bool:
         return self._rotated

--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -138,8 +138,8 @@ def setup(
 ) -> tuple[EvaluatorServer, list[Worker]]:
     # Queues used for worker processes to send evaluation requests to the EvaluatorSerer, and for it
     # to send the resulting (value, policy) back.
-    evaluator_request_queue = mp.SimpleQueue()
-    evaluator_result_queues = [mp.SimpleQueue() for _ in range(num_workers)]
+    evaluator_request_queue = mp.Queue()
+    evaluator_result_queues = [mp.Queue() for _ in range(num_workers)]
 
     # Create the evaluator server and start its processing thread.
     action_encoder = ActionEncoder(board_size)
@@ -224,7 +224,7 @@ def main(args):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Train a DQN agent for Quoridor")
+    parser = argparse.ArgumentParser(description="Train an alphazero agent for Quoridor")
     parser.add_argument("-p", "--params", type=str, default="", help="Alphazero agent params in subargs form")
     parser.add_argument("-N", "--board-size", type=int, default=5, help="Board Size")
     parser.add_argument("-W", "--max-walls", type=int, default=3, help="Max walls per player")


### PR DESCRIPTION
The biggest change in this PR is that instead of each worker process having its own evaluator with its own GPU memory allocation, they now use an "EvaluatorClient" which does the CPU work of rotating the game and creating the action mask, and then sends them to an "EvaluatorServer" in another subprocess to do the GPU work. This allows adding more worker processes to use more of the CPU without running out of GPU memory.

Other changes:
- **Adds caching** (like in @alejandromarcu 's improvements to NNEvaluator). Caches both on the client side and on the server side. The server side cache has more game states in it since it includes results from every worker, but takes more time to get to. The client cache gets hit far more often. Actually I'm not sure its worth the complexity of having the server side cache, but I left it in for now.
- **Supports evaluating multiple game states at once**, so that mcts can pre-evaluate nodes
- **Adds statistics for the evaluator client and server** so that we can see how much time they're taking and how often their caches are hit.
- **Makes things deterministic** so that if you run it with the same parameters multiple times you should get the same result. I haven't tested this thoroughly though. The changes include setting random seeds in each subprocess, and ordering the results from the worker processes by their worker id so that their running time doesn't affect the order of things in the replay buffer.

You can try this with the following command:
```
time python -O deep_quoridor/src/train_alphazero.py -g 40 -e 2 --num-workers=10 -p mcts_n=100
```

The equivalent command using train.py would be:
```
python -O deep_quoridor/src/train.py -N 5 -W 3 -e 80 -p alphazero:training_mode=true,mcts_n=1000,train_every=40 -r arenaresults2 computationtimes
```

Before this PR the multiprocess training took about 24 minutes on my desktop. train.py takes about 17 minutes on my PC with the equivalent command. After these new changes multiprocess training takes about 2.5 minutes. I'm curious to hear how it performs on other machines.
