### PR TITLE
Compute metrics against each opponent

### DIFF
--- a/deep_quoridor/src/plugins/wandb_train.py
+++ b/deep_quoridor/src/plugins/wandb_train.py
@@ -139,8 +139,8 @@ class WandbTrainPlugin(ArenaPlugin):
         wandb.finish()
 
     def compute_tournament_metrics(self, model_filename: str) -> int:
-        _, elo_table, relative_elo, win_perc, absolute_elo, dumb_score = self.metrics.compute(
-            self.agent_encoded_name + f",model_filename={model_filename}"
+        _, elo_table, relative_elo, win_perc, p1_win_percentages, p2_win_percentages, absolute_elo, dumb_score = (
+            self.metrics.compute(self.agent_encoded_name + f",model_filename={model_filename}")
         )
 
         print(f"Tournament Metrics - Relative elo: {relative_elo}, win percentage: {win_perc}")
@@ -152,14 +152,19 @@ class WandbTrainPlugin(ArenaPlugin):
         wandb_elo_table = wandb.Table(
             columns=["Player", "elo"], data=[[player, elo] for player, elo in elo_table.items()]
         )
+        metrics = {
+            "elo": wandb_elo_table,
+            "relative_elo": relative_elo,
+            "win_perc": win_perc,
+            "absolute_elo": absolute_elo,
+            "dumb_score": dumb_score,
+        }
+        for opponent in p1_win_percentages:
+            metrics[f"p1_win_perc_vs_{opponent}"] = p1_win_percentages[opponent]
+        for opponent in p2_win_percentages:
+            metrics[f"p2_win_perc_vs_{opponent}"] = p2_win_percentages[opponent]
         self.run.log(
-            {
-                "elo": wandb_elo_table,
-                "relative_elo": relative_elo,
-                "win_perc": win_perc,
-                "absolute_elo": absolute_elo,
-                "dumb_score": dumb_score,
-            },
+            metrics,
             step=self.episode_count,
         )
 

--- a/deep_quoridor/src/run_metrics.py
+++ b/deep_quoridor/src/run_metrics.py
@@ -30,7 +30,9 @@ if __name__ == "__main__":
 
     for player in args.players:
         print(f"Computing metrics for {player}")
-        _, _, relative_elo, win_perc, absolute_elo, dumb_score = m.compute(player)
+        _, _, relative_elo, win_perc, p1_win_percentages, p2_win_percentages, absolute_elo, dumb_score = m.compute(
+            player
+        )
         table.add_row([player, absolute_elo, relative_elo, win_perc, dumb_score])
 
     print(table)


### PR DESCRIPTION
In metrics, and in the wandb training plugin, this PR adds a wandb metric for the win rate as p1 against each opponent agent, and against p2 against each other agent. This should be helpful since the win rate against random often gets to 100% quickly, whereas as P2 against simple is much harder. You can't see it in this screenshot, but if you hover over the graph it shows you which color is which opponent agent.

<img width="602" height="356" alt="image" src="https://github.com/user-attachments/assets/af90572a-5143-48ea-bf82-553ba2b90ba0" />
