### PR TITLE
Save Replay Buffers to files and allow to use it for bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ deep_quoridor/tn.sh
 
 # Videos of the game play
 videos
+
+# Contents of the replay buffer for debugging
+replay_buffers


### PR DESCRIPTION
Now if you use`save_replay_buffer=true` it will save the replay buffer to a file before each training.
Then, you can "bootstrap" it by starting AlphaZero by training it right away with the replay buffer.  This allow us to quickly try different training parameters without having to run all the initial games, which won't change if you don't change the parameters.  
Another part of this, that I'll do in a separate PR, is to have an utility that will load a replay buffer and visualize it (e.g. show a state and the policy as a board).


Here's an example usage.
First I run a training session with `save_replay_buffer=true`.  I just want to play the first N (=100 in this case) games and then save it, so I use -e 100 and train_every=100:

```
python -O /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 100 -i 43 -p alphazero:training_mode=true,mcts_n=100,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=2,optimizer_iterations=100,save_replay_buffer=true,train_every=100 -r arenaresults2 computationtimes -f 20
```

This generated the file `replay_buffers/replay_buffer_episode_100.pkl`.

Now I can try using the generated file, so that it will run the training right away.   With this I could try for example different values for the learning_rate, batch_size, optimizer_iterations to see how different trainings parameters affect the result.

```
python -O /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 1 -i 43 -p alphazero:training_mode=true,mcts_n=1000,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=2,optimizer_iterations=100,bootstrap_replay_buffer=replay_buffers/replay_buffer_episode_100.pkl -r video arenaresults2 computationtimes -f 20
Starting DQN training...
Board size: 5x5
Max walls: 3
Training for 1 episodes
Using step rewards: False
Device: mps
Initializing random seed 43
Loaded 5196 samples from replay_buffers/replay_buffer_episode_100.pkl
Running bootstrap training iteration...
Training the network (buffer size: 5196, batch size: 64)...done in 0.92s
alphazero P2 Episode     1/1 [ ], Steps: 150, Time: 13622ms,  Avg Reward:   0.00, Avg Loss:  3.9474, Epsilon: 0.0000 opponent: alphazero
alphazero P2 Episode     1/1 [ ], Steps: 150, Time: 13622ms,  Avg Reward:   0.00, Avg Loss:  3.9474, Epsilon: 0.0000 opponent: alphazero
AlphaZero model saved to /Users/amarcu/code/deep_rabbit_hole/models/alphazero_B5W3_mv1.0_final.pt
```

From here, I could for example check the generated video to see how it played the game, or I could use the interactive visualizer to see how the NN responds to different states, e.g. by doing:

```
python deep_quoridor/src/interactive_evaluator_visualizer.py models/alphazero_B5W3_mv1.0_final.pt
```
