### PR TITLE
Visualize the Replay Buffer and the model prediction

### DIFF
--- a/deep_quoridor/src/replay_buffer_visualizer.py
+++ b/deep_quoridor/src/replay_buffer_visualizer.py
@@ -15,15 +15,14 @@ import pickle
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from agents import ActionLog
 from agents.alphazero.nn_evaluator import NNEvaluator
-from mpl_visualizer import visualize_board
-from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor
+from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor, WallOrientation
 from utils.misc import my_device
 
 
@@ -190,19 +189,19 @@ class ReplayBufferVisualizer:
                 board._walls_remaining[Player.ONE] = opponent_walls
                 board._walls_remaining[Player.TWO] = my_walls
 
-        # Set walls
+        # Set walls using proper board method
         for row in range(wall_size):
             for col in range(wall_size):
                 if walls[row, col, 0] > 0.5:  # Vertical wall
                     try:
-                        board._walls[row, col, 0] = True
-                    except:
-                        pass
+                        board.add_wall(Player.ONE, (row, col), WallOrientation.VERTICAL, check_if_valid=False)
+                    except Exception as e:
+                        print(f"Warning: Could not add vertical wall at ({row}, {col}): {e}")
                 if walls[row, col, 1] > 0.5:  # Horizontal wall
                     try:
-                        board._walls[row, col, 1] = True
-                    except:
-                        pass
+                        board.add_wall(Player.ONE, (row, col), WallOrientation.HORIZONTAL, check_if_valid=False)
+                    except Exception as e:
+                        print(f"Warning: Could not add horizontal wall at ({row}, {col}): {e}")
 
         # Set current player
         game.set_current_player(player)
@@ -408,7 +407,7 @@ def main():
 
     try:
         # Create and run visualizer
-        visualizer = ReplayBufferVisualizer(args.replay_buffer, args.model)
+        ReplayBufferVisualizer(args.replay_buffer, args.model)
 
         # Print usage instructions
         print("\nNavigation Controls:")

--- a/deep_quoridor/src/replay_buffer_visualizer.py
+++ b/deep_quoridor/src/replay_buffer_visualizer.py
@@ -50,7 +50,14 @@ class ReplayBufferVisualizer:
         # Sort by input array frequency (descending)
         print("Sorting entries by input array frequency...")
         self.sorted_entries = self._sort_entries_by_frequency()
-        print(f"Found {len(self.sorted_entries)} unique game states")
+
+        # Count unique game states for reporting
+        unique_inputs = set()
+        for entry, _ in self.sorted_entries:
+            hashable_array = tuple(entry["input_array"].flatten())
+            unique_inputs.add(hashable_array)
+
+        print(f"Sorted {len(self.sorted_entries)} total entries representing {len(unique_inputs)} unique game states")
 
         # Load model if provided
         self.model = None
@@ -90,12 +97,13 @@ class ReplayBufferVisualizer:
                     entries_by_input[hashable_array] = []
                 entries_by_input[hashable_array].append(entry)
 
-        # Sort by frequency (descending) and return entries with their counts
+        # Sort by frequency (descending) and return ALL entries with their frequency counts
         sorted_entries = []
         for hashable_array, count in input_array_counts.most_common():
             entries = entries_by_input[hashable_array]
-            # Take the first entry for each unique input array
-            sorted_entries.append((entries[0], count))
+            # Include ALL entries for each input array, each tagged with the frequency count
+            for entry in entries:
+                sorted_entries.append((entry, count))
 
         return sorted_entries
 

--- a/deep_quoridor/src/replay_buffer_visualizer.py
+++ b/deep_quoridor/src/replay_buffer_visualizer.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""
+Replay Buffer Visualization Tool
+
+This tool visualizes the contents of saved replay buffers and optionally compares them
+with trained model predictions. It provides an interactive matplotlib GUI for navigating
+through replay buffer entries sorted by input array frequency.
+
+Usage:
+    python replay_buffer_visualizer.py <replay_buffer_file> [model_file]
+"""
+
+import argparse
+import pickle
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from agents import ActionLog
+from agents.alphazero.nn_evaluator import NNEvaluator
+from mpl_visualizer import visualize_board
+from quoridor import ActionEncoder, Board, MoveAction, Player, Quoridor
+from utils.misc import my_device
+
+
+class ReplayBufferVisualizer:
+    """Interactive visualization tool for replay buffer contents."""
+
+    def __init__(self, replay_buffer_path: str, model_path: Optional[str] = None, figsize: tuple = (12, 6)):
+        """
+        Initialize the replay buffer visualizer.
+
+        Args:
+            replay_buffer_path: Path to the replay buffer pickle file
+            model_path: Optional path to the trained model file
+            figsize: Figure size as (width, height)
+        """
+        self.replay_buffer_path = replay_buffer_path
+        self.model_path = model_path
+        self.figsize = figsize
+
+        # Load and process replay buffer data
+        print("Loading replay buffer...")
+        self.replay_buffer = self._load_replay_buffer(replay_buffer_path)
+        print(f"Loaded {len(self.replay_buffer)} entries")
+
+        # Sort by input array frequency (descending)
+        print("Sorting entries by input array frequency...")
+        self.sorted_entries = self._sort_entries_by_frequency()
+        print(f"Found {len(self.sorted_entries)} unique game states")
+
+        # Load model if provided
+        self.model = None
+        if model_path:
+            print("Loading trained model...")
+            self.model = self._load_model(model_path)
+            print("Model loaded successfully")
+
+        # Navigation state
+        self.current_index = 0
+
+        # Create matplotlib GUI
+        self._create_gui()
+
+    def _load_replay_buffer(self, filepath: str) -> list[dict]:
+        """Load replay buffer from pickle file."""
+        with open(filepath, "rb") as f:
+            return pickle.load(f)
+
+    def _sort_entries_by_frequency(self) -> list[tuple[dict, int]]:
+        """Sort replay buffer entries by input array frequency (descending)."""
+        # Count input array frequencies
+        input_array_counts = Counter()
+        for entry in self.replay_buffer:
+            input_array = entry.get("input_array")
+            if input_array is not None:
+                hashable_array = tuple(input_array.flatten())
+                input_array_counts[hashable_array] += 1
+
+        # Group entries by input array and sort by frequency
+        entries_by_input = {}
+        for entry in self.replay_buffer:
+            input_array = entry.get("input_array")
+            if input_array is not None:
+                hashable_array = tuple(input_array.flatten())
+                if hashable_array not in entries_by_input:
+                    entries_by_input[hashable_array] = []
+                entries_by_input[hashable_array].append(entry)
+
+        # Sort by frequency (descending) and return entries with their counts
+        sorted_entries = []
+        for hashable_array, count in input_array_counts.most_common():
+            entries = entries_by_input[hashable_array]
+            # Take the first entry for each unique input array
+            sorted_entries.append((entries[0], count))
+
+        return sorted_entries
+
+    def _load_model(self, model_path: str) -> NNEvaluator:
+        """Load trained model for comparison."""
+        # Determine board size from first entry
+        sample_entry = self.sorted_entries[0][0]
+        input_array = sample_entry["input_array"]
+        board_size = self._infer_board_size(input_array)
+
+        # Create evaluator
+        action_encoder = ActionEncoder(board_size)
+        device = my_device()
+        evaluator = NNEvaluator(action_encoder, device)
+
+        # Load model state
+        model_state = torch.load(model_path, map_location=device)
+        evaluator.network.load_state_dict(model_state["network_state_dict"])
+        evaluator.network.eval()
+
+        return evaluator
+
+    def _infer_board_size(self, input_array: np.ndarray) -> int:
+        """Infer board size from input array dimensions."""
+        # Input array structure: player_board + opponent_board + walls + [my_walls, opponent_walls]
+        # For board_size B: 2*B*B + 2*(B-1)*(B-1) + 2 = total length
+        # Solving: 2*B^2 + 2*(B-1)^2 + 2 = len
+        # 2*B^2 + 2*(B^2 - 2*B + 1) + 2 = len
+        # 4*B^2 - 4*B + 4 = len
+        # 4*B^2 - 4*B + (4 - len) = 0
+        # B^2 - B + (1 - len/4) = 0
+
+        total_len = len(input_array)
+        # Try common board sizes
+        for board_size in range(3, 20):
+            expected_len = 2 * board_size**2 + 2 * (board_size - 1) ** 2 + 2
+            if expected_len == total_len:
+                return board_size
+
+        raise ValueError(f"Cannot infer board size from input array of length {total_len}")
+
+    def _input_array_to_game(self, input_array: np.ndarray, player: Player) -> Quoridor:
+        """Reconstruct Quoridor game from input array."""
+        board_size = self._infer_board_size(input_array)
+
+        # Parse the input array components
+        offset = 0
+
+        # Player boards (flattened)
+        player_board_flat = input_array[offset : offset + board_size**2]
+        offset += board_size**2
+        opponent_board_flat = input_array[offset : offset + board_size**2]
+        offset += board_size**2
+
+        # Walls (flattened)
+        wall_size = board_size - 1
+        walls_flat = input_array[offset : offset + 2 * wall_size**2]
+        offset += 2 * wall_size**2
+
+        # Wall counts
+        my_walls = int(input_array[offset])
+        opponent_walls = int(input_array[offset + 1])
+
+        # Reshape boards
+        player_board = player_board_flat.reshape(board_size, board_size)
+        opponent_board = opponent_board_flat.reshape(board_size, board_size)
+        walls = walls_flat.reshape(wall_size, wall_size, 2)
+
+        # Find player positions
+        player_pos = tuple(np.unravel_index(np.argmax(player_board), player_board.shape))
+        opponent_pos = tuple(np.unravel_index(np.argmax(opponent_board), opponent_board.shape))
+
+        # Create game
+        max_walls_per_player = my_walls + opponent_walls  # Rough estimate
+        board = Board(board_size=board_size, max_walls=max_walls_per_player)
+        game = Quoridor(board)
+
+        # Set player positions
+        if player == Player.ONE:
+            board.move_player(Player.ONE, player_pos)
+            board.move_player(Player.TWO, opponent_pos)
+            # Set wall counts (approximate) - access the private attribute carefully
+            if hasattr(board, "_walls_remaining"):
+                board._walls_remaining[Player.ONE] = my_walls
+                board._walls_remaining[Player.TWO] = opponent_walls
+        else:
+            board.move_player(Player.ONE, opponent_pos)
+            board.move_player(Player.TWO, player_pos)
+            # Set wall counts (approximate) - access the private attribute carefully
+            if hasattr(board, "_walls_remaining"):
+                board._walls_remaining[Player.ONE] = opponent_walls
+                board._walls_remaining[Player.TWO] = my_walls
+
+        # Set walls
+        for row in range(wall_size):
+            for col in range(wall_size):
+                if walls[row, col, 0] > 0.5:  # Vertical wall
+                    try:
+                        board._walls[row, col, 0] = True
+                    except:
+                        pass
+                if walls[row, col, 1] > 0.5:  # Horizontal wall
+                    try:
+                        board._walls[row, col, 1] = True
+                    except:
+                        pass
+
+        # Set current player
+        game.set_current_player(player)
+
+        return game
+
+    def _create_replay_buffer_action_log(self, entry: dict, game: Quoridor) -> ActionLog:
+        """Create ActionLog from replay buffer entry."""
+        action_log = ActionLog()
+        action_log.set_enabled(True)
+
+        # Get MCTS policy and create action scores
+        mcts_policy = entry["mcts_policy"]
+        valid_actions = game.get_valid_actions()
+        action_scores = {}
+
+        # Map policy indices to actions
+        for action in valid_actions:
+            action_index = game.action_encoder.action_to_index(action)
+            if action_index < len(mcts_policy):
+                score = float(mcts_policy[action_index])
+                action_scores[action] = score
+
+        if action_scores:
+            action_log.action_score_ranking(action_scores)
+
+        # Add value at current player position
+        value = entry["value"]
+        current_pos = game.board.get_player_position(game.current_player)
+        move_to_current = MoveAction(current_pos)
+        action_log.action_text(move_to_current, f"V:{value}")
+
+        return action_log
+
+    def _create_model_action_log(self, game: Quoridor) -> ActionLog:
+        """Create ActionLog from trained model prediction."""
+        if self.model is None:
+            return None
+
+        action_log = ActionLog()
+        action_log.set_enabled(True)
+
+        # Get model evaluation
+        value, policy = self.model.evaluate(game)
+        valid_actions = game.get_valid_actions()
+        action_scores = {}
+
+        for action in valid_actions:
+            action_index = game.action_encoder.action_to_index(action)
+            score = float(policy[action_index])
+            action_scores[action] = score
+
+        if action_scores:
+            action_log.action_score_ranking(action_scores)
+
+        # Add value at current player position
+        current_pos = game.board.get_player_position(game.current_player)
+        move_to_current = MoveAction(current_pos)
+        action_log.action_text(move_to_current, f"V:{value:.3f}")
+
+        return action_log
+
+    def _create_gui(self):
+        """Create the matplotlib GUI."""
+        # Create figure with subplots
+        if self.model_path:
+            self.fig, (self.ax_rb, self.ax_model) = plt.subplots(1, 2, figsize=self.figsize)
+        else:
+            self.fig, self.ax_rb = plt.subplots(1, 1, figsize=(self.figsize[0] // 2, self.figsize[1]))
+            self.ax_model = None
+
+        # Connect keyboard events
+        self.fig.canvas.mpl_connect("key_press_event", self._on_key_press)
+
+        # Initial render
+        self._update_visualization()
+
+        # Show plot
+        plt.tight_layout()
+        plt.show()
+
+    def _update_visualization(self):
+        """Update the visualization with current entry."""
+        if not self.sorted_entries:
+            return
+
+        entry, frequency = self.sorted_entries[self.current_index]
+
+        # Reconstruct game from input array
+        player = entry["player"]
+        game = self._input_array_to_game(entry["input_array"], player)
+
+        # Clear axes
+        self.ax_rb.clear()
+        if self.ax_model:
+            self.ax_model.clear()
+
+        # Replay buffer panel
+        rb_action_log = self._create_replay_buffer_action_log(entry, game)
+        self._visualize_game_on_axis(
+            self.ax_rb,
+            game,
+            rb_action_log,
+            f"Replay Buffer Entry {self.current_index + 1}/{len(self.sorted_entries)}\nFrequency: {frequency}, Player: {player.name}",
+        )
+
+        # Model panel (if available)
+        if self.ax_model and self.model:
+            model_action_log = self._create_model_action_log(game)
+            self._visualize_game_on_axis(self.ax_model, game, model_action_log, "Trained Model Prediction")
+
+        # Refresh display
+        self.fig.canvas.draw()
+
+    def _visualize_game_on_axis(self, ax, game: Quoridor, action_log: ActionLog, title: str):
+        """Visualize a game on a specific axis."""
+        from mpl_visualizer import _draw_action_log, _draw_board_base
+
+        # Draw base board
+        _draw_board_base(ax, game, self.figsize)
+
+        # Draw action log
+        _draw_action_log(ax, action_log)
+
+        # Set title and labels
+        ax.set_title(title)
+        ax.set_xlabel("Column")
+        ax.set_ylabel("Row")
+
+        # Set ticks
+        board_size = game.board.board_size
+        ax.set_xticks(range(board_size))
+        ax.set_yticks(range(board_size))
+
+    def _on_key_press(self, event):
+        """Handle keyboard navigation."""
+        if event.key == "right" or event.key == "n":
+            self._next_entry()
+        elif event.key == "left" or event.key == "p":
+            self._previous_entry()
+        elif event.key == "shift+right" or event.key == "N":
+            self._next_different_state()
+        elif event.key == "shift+left" or event.key == "P":
+            self._previous_different_state()
+        elif event.key == "q":
+            plt.close("all")
+
+    def _next_entry(self):
+        """Go to next entry."""
+        if self.current_index < len(self.sorted_entries) - 1:
+            self.current_index += 1
+            self._update_visualization()
+
+    def _previous_entry(self):
+        """Go to previous entry."""
+        if self.current_index > 0:
+            self.current_index -= 1
+            self._update_visualization()
+
+    def _next_different_state(self):
+        """Go to next entry with different state (skipping duplicates)."""
+        current_entry, _ = self.sorted_entries[self.current_index]
+        current_input = tuple(current_entry["input_array"].flatten())
+
+        for i in range(self.current_index + 1, len(self.sorted_entries)):
+            entry, _ = self.sorted_entries[i]
+            input_array = tuple(entry["input_array"].flatten())
+            if input_array != current_input:
+                self.current_index = i
+                self._update_visualization()
+                break
+
+    def _previous_different_state(self):
+        """Go to previous entry with different state (skipping duplicates)."""
+        current_entry, _ = self.sorted_entries[self.current_index]
+        current_input = tuple(current_entry["input_array"].flatten())
+
+        for i in range(self.current_index - 1, -1, -1):
+            entry, _ = self.sorted_entries[i]
+            input_array = tuple(entry["input_array"].flatten())
+            if input_array != current_input:
+                self.current_index = i
+                self._update_visualization()
+                break
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(description="Visualize replay buffer contents")
+    parser.add_argument("replay_buffer", help="Path to the replay buffer pickle file")
+    parser.add_argument("model", nargs="?", help="Optional path to the trained model file")
+
+    args = parser.parse_args()
+
+    # Validate files exist
+    if not Path(args.replay_buffer).exists():
+        print(f"Error: Replay buffer file not found: {args.replay_buffer}")
+        return 1
+
+    if args.model and not Path(args.model).exists():
+        print(f"Error: Model file not found: {args.model}")
+        return 1
+
+    try:
+        # Create and run visualizer
+        visualizer = ReplayBufferVisualizer(args.replay_buffer, args.model)
+
+        # Print usage instructions
+        print("\nNavigation Controls:")
+        print("  Right Arrow / 'n': Next entry")
+        print("  Left Arrow / 'p':  Previous entry")
+        print("  Shift+Right / 'N':  Next different state")
+        print("  Shift+Left / 'P':   Previous different state")
+        print("  'q':                Quit")
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This allows us to see what's in the replay buffer (i.e. training data) and how the model predicts the same input.

For example, I trained a model using:
```
python -O /Users/amarcu/code/deep_rabbit_hole/deep_quoridor/src/train.py -N 5 -W 3 -e 1000  -p alphazero:training_mode=true,mcts_n=1000,learning_rate=0.0001,batch_size=64,replay_buffer_size=100000,mcts_ucb_c=2,optimizer_iterations=100,train_every=100,save_replay_buffer=always -r arenaresults2 computationtimes -f 100 -w
```

This saved the model and the replay buffer files, so then I can do:

```
python deep_quoridor/src/replay_buffer_visualizer.py replay_buffers/alphazero_B5W3_ep100_i42_t100_rbs100000_n1000_ucbc200.pkl models/alphazero_B5W3_mv1.0_episode_100.pt
```
And navigate through the replay buffer entries

<img width="3168" height="1576" alt="image" src="https://github.com/user-attachments/assets/c7e8c4b9-841e-4d6d-9134-4dc25e0f3b67" />


I barely wrote any code for it, Claude Code did almost everything, except the last commit.  Here are the prompts for reference:

Initial Version
```
I want to create a tool to visualize the contents of the replay buffer and optionally see how it differs from the trained network.
- The tool will take one mandatory parameter (the filename of the saved replay buffer) and one optional parameter (the filename of the trained model)
- The tool will use matplotlib and take advantage of the visualizations that we already have
- In the tool we will see one panel for the replay buffer and, if present, another panel for the trained model
- In the replay buffer panel we'll have buttons to go to the previous and next reply buffer entry, as well as to the previous and next entries with a different state
- The replay buffers will be sorted descending by the number of times the input array appears.
- The input_array in the replay buffer needs to be used to re-construct a game
- The mcts_policy in the replay buffer will be shown using ActionLog, and the value as well, shown where the pawn is.

This is a long task so think hard and ask if you need further clarifications
```

Fix wall reconstruction
```
I never see any walls when looking through different entries, but there should be walls in at least some entries.
```

Fix navigation issue
```
When I start it, it's in entry 1/1841 and it says Frequency 100.  So, I expect the first 100 entries to all have the same input_array (i.e. the same game, but they will probably have different policies and values).  However, when I press the right key, the game is different.
When I try to skip to the next state pressing shift+right, I was expecting to jumpt to the entry 101/1841, but it goes to entry 2.
```

Then when I was looking at the code I realized that it was not using the number of walls placed to compute the total number of walls, so I gave it this prompt:
```
The walls variable will have an 1 per wall, so we
   can count the number of placed walls counting 
  the numbers of 1.  Then, to know the 
  max_walls_per_players exactly, we can add to the 
  remaining walls of both players the walls that 
  are already placed, and that would give us twice 
  as much walls per players
```
But it put the `//2` just for walls_placed, not for everything, which I fix by hand, and then I fixed it so that the walls remaining after the placement match what it should be, since the NN may produce different results if this is wrong