### PR TITLE
Fix rotation in replay_buffer_visualizer

### DIFF
--- a/deep_quoridor/src/replay_buffer_visualizer.py
+++ b/deep_quoridor/src/replay_buffer_visualizer.py
@@ -217,6 +217,9 @@ class ReplayBufferVisualizer:
 
         # Get MCTS policy and create action scores
         mcts_policy = entry["mcts_policy"]
+        if game.is_rotated():
+            mcts_policy = self.model.rotate_policy_from_original(mcts_policy)
+
         valid_actions = game.get_valid_actions()
         action_scores = {}
 
@@ -295,6 +298,7 @@ class ReplayBufferVisualizer:
         # Reconstruct game from input array
         player = entry["player"]
         game = self._input_array_to_game(entry["input_array"], player)
+        game, _ = self.model.rotate_if_needed_to_point_downwards(game)
 
         # Clear axes
         self.ax_rb.clear()


### PR DESCRIPTION
The input_array that we store in the replay buffer is already rotated.  The tool was using input_array to reconstruct a game, so the game was already rotated, but then when calling evaluate it was rotating it again.
With this PR I recover the game as it was originally, and let evaluate do its thing.  Now the training looks good and there's no rotation when displaying the data, which is easier to see.

I used the following to train with just 1 episode a 5x5 with no walls:
```
.venv/bin/python -O deep_quoridor/src/train.py \
-N 5 -W 0 -e 1  \
-p alphazero:training_mode=true,replay_buffer_size=100000,mcts_ucb_c=2,\
train_every=1,save_replay_buffer=first,\
mcts_n=10000,learning_rate=0.0001,batch_size=8,optimizer_iterations=1000 \
-r video
```

Then I visualized the values using:
```
.venv/bin/python deep_quoridor/src/replay_buffer_visualizer.py \
replay_buffers/alphazero_B5W0_ep1_i42_t100_rbs100000_n10000_ucbc200.pkl \
models/alphazero_B5W0_mv1.0_final.pt
```

And I can see that the training looks good for both players, e.g.:

<img width="1189" height="634" alt="image" src="https://github.com/user-attachments/assets/55642031-07b1-4358-9c71-a9a833fcb718" />

<img width="1189" height="634" alt="image" src="https://github.com/user-attachments/assets/582c634a-050b-4ccc-9649-dc6673651747" />
