### PR TITLE
Load the model if passed in AlphaZero

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -186,7 +186,7 @@ class AlphaZeroAgent(TrainableAgent):
         else:
             self.evaluator = evaluator
 
-        self._fetch_model_from_wand_and_update_params()
+        self._fetch_model_from_wandb_and_update_params()
         self._resolve_and_load_model()
 
         # Disable dirichlet noise unless we are in training mode.
@@ -246,7 +246,7 @@ class AlphaZeroAgent(TrainableAgent):
                 self.first_replay_buffer_loaded = True
 
     # TO DO, this was copy-pasted from AbstractTrainableAgent, need to refactor it
-    def _fetch_model_from_wand_and_update_params(self):
+    def _fetch_model_from_wandb_and_update_params(self):
         """
         This function doesn't do anything if wandb_alias is not set in self.params.
         Otherwise, it will download the file if there's not a local copy.

--- a/deep_quoridor/src/agents/core/trainable_agent.py
+++ b/deep_quoridor/src/agents/core/trainable_agent.py
@@ -11,11 +11,11 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import wandb
 from quoridor import ActionEncoder
 from utils import SubargsBase, my_device, resolve_path
 from utils.misc import get_opponent_player_id
 
-import wandb
 from agents.core.agent import ActionLog, Agent
 from agents.core.replay_buffer import ReplayBuffer
 
@@ -200,7 +200,7 @@ class AbstractTrainableAgent(TrainableAgent):
 
         # Setup device
         self.device = my_device()
-        self._fetch_model_from_wand_and_update_params()
+        self._fetch_model_from_wandb_and_update_params()
 
         # Initialize networks
         self.online_network = self._create_network()
@@ -589,7 +589,7 @@ class AbstractTrainableAgent(TrainableAgent):
     def get_model_extension(cls):
         return "pt"
 
-    def _fetch_model_from_wand_and_update_params(self):
+    def _fetch_model_from_wandb_and_update_params(self):
         """
         This function doesn't do anything if wandb_alias is not set in self.params.
         Otherwise, it will download the file if there's not a local copy.


### PR DESCRIPTION
We were not loading the model if passed using a filename or wandb alias.  Since the metrics during training rely on loading the model, they were just measuring a random initialized network.  Same thing if you tried to play against it by using the play script and passing for example a wandb_alias