### PR TITLE
MCTS fixes

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -83,9 +83,9 @@ class Node:
             Calculate the UCB value for a child node.
             """
             penalized = -1 if visited_states and QuoridorKey(child.game) in visited_states else 0
-            q_value = 0.5
+            q_value = 0.0
             if child.visit_count != 0:
-                q_value = (child.value_sum / child.visit_count + 1) / 2
+                q_value = child.value_sum / child.visit_count
             return q_value + child.prior * ucbc_visitcount / (child.visit_count + 1) + penalized
 
         return max(self.children, key=get_child_ucb)
@@ -187,7 +187,7 @@ class MCTS:
                 node.expand(priors)
                 self.new_nodes.extend(node.children)
 
-                node.backpropagate(value)
+                node.backpropagate(-value)
 
         # Negate the value because the value is actually the value that the opponent
         # got for getting to that state.


### PR DESCRIPTION
I'm not sure if the q_value computation is the ideal one, but it seems to work much better.
I was debugging MCTS and saw that even though a child looked much better (had a score of 30 with 57 visits), another child (score 0.67 with 16 visits) had a similar ucb (and the priors where just a bit different). I thought it was not right that a node that looks a lot more promising than the other gets a similar score (I know we give more priority to the ones with less visits, but seemed to have too much weight).
I want to experiment a bit more and investigate q_value computation before moving forward.

The other thing was that the value looked reversed in the MCTS, as compared to the value that we get when we reach a terminal state.  