### PR TITLE
MCTS: bug fix and optimization

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -124,7 +124,7 @@ class MCTS:
         max_steps: int,  # -1 means no limit
         evaluator,
         visited_states: set,
-        pre_evaluate_nodes_total: int = 64,
+        top_k_pre_evaluate: int = 16,
     ):
         assert n is not None or k is not None, "Either n or k need to be specified"
         self.n = n
@@ -135,7 +135,7 @@ class MCTS:
         self.max_steps = max_steps
         self.evaluator = evaluator
         self.new_nodes = []
-        self.extra_eval = pre_evaluate_nodes_total - 1
+        self.top_k_pre_evaluate = top_k_pre_evaluate
         self.visited_states = visited_states
 
     def select(self, node: Node) -> Node:
@@ -150,6 +150,7 @@ class MCTS:
 
     def search(self, initial_game: Quoridor):
         root = Node(initial_game, ucb_c=self.ucb_c)
+        self.new_nodes = []
 
         if self.k is not None:
             num_actions = np.sum(np.array(initial_game.get_action_mask()) == 1)
@@ -168,8 +169,9 @@ class MCTS:
             elif self.max_steps >= 0 and node.game.completed_steps >= self.max_steps:
                 node.backpropagate_result(0)
             else:
-                games_to_evaluate = [n.game for n in self.new_nodes[: self.extra_eval]]
-                self.new_nodes = self.new_nodes[self.extra_eval :]
+                games_to_evaluate = [n.game for n in self.new_nodes]
+                self.new_nodes = []
+
                 value, priors = self.evaluator.evaluate(node.game, games_to_evaluate)
 
                 if node is root and self.noise_epsilon > 0.0:
@@ -185,7 +187,9 @@ class MCTS:
                     priors[valid_action_indices] += self.noise_epsilon * dirichlet_noise
 
                 node.expand(priors)
-                self.new_nodes.extend(node.children)
+                if self.top_k_pre_evaluate > 0:
+                    sorted_children = sorted(node.children, key=lambda c: c.prior, reverse=True)
+                    self.new_nodes.extend(sorted_children[: self.top_k_pre_evaluate])
 
                 node.backpropagate(-value)
 


### PR DESCRIPTION
When experimenting with a regular size board, the play was exteremely slow, usually more than 10 minutes per game!
I discovered that there was a bug that was slowing it down: `self.new_nodes` was not cleared, so if there were left overs from the previous search (which didn't happen that often in a smaller board because the number of children is much less) we will be spending compute time in evaluating games from the previous move, that usually won't be needed, instead of the games from this move, that will probably be needed.  Just that fix improved the speed 7x in the 9x9 board (but doesn't make a difference in the 5x5 board).

I also had an idea: instead of queuing all the children for piggy-back evaluation, just queue the top K based on the prior, since those are the first ones to be evaluated.   That way, we evaluate games that are more likely to be used.  So we get less cache hits, but we can significantly reduce the evaluation size to the point of making it worth.  This gave another almost 2x in speed in 9x9.  Notice that the gains vary greatly depending on the board size and mcts_n.


### Benchmarks

**9x9 board**

I used the following command:
```
.venv/bin/python -O deep_quoridor/src/train.py \
-N 9 -W 10 -e 1 -f 500 -i 26 --benchmark random greedy:p_random=0.5,nick=greedy-05 greedy:p_random=0.3,nick=greedy-03 greedy:p_random=0.1,nick=greedy-01 simple \
-p alphazero:training_mode=true,replay_buffer_size=100000,mcts_ucb_c=2,\
train_every=500,save_replay_buffer=first,mcts_noise_epsilon=0.1,\
mcts_n=2000,learning_rate=0.0001,batch_size=128,optimizer_iterations=200,validation_ratio=0.2
```

Running it in main took 827 seconds.
Just by clearing the nodes (`self.new_nodes = []`) the time decreased to 112s

I tried also to run it with mcts_pre_evaluate_nodes_total=1024 but the time increased to 166s.

Then, with this pr I tried with the following values of mcts_top_k_pre_evaluate, and got the following times and cache hits, out of 233k evaluations
- 4: 77s (203k hits)
- 8: 72s (209k hits)
- 10: 67s (212k hits)
- 12: 64s (214k hits)
- 16: 62s (217k hits)
- 20: 63s (218k hits)
- 24: 65s (218k hits)

As expected, when increasing the value the number of hits increases (but gets slower), and also the number of elements in the evaluations increase, making the evaluation slower.  Around 16 seems to be ideal in this case.

** 5x5 board**
I used the same command than 9x9 but with `-N 5 -W 3`

Running it in main took 8s, and when clearing the nodes was about the same.
I tried a few different values of mcts_pre_evaluate_nodes_total (in main) and got:
- 4: 8.2s
- 8: 7.4s
- 64: 8s (the default)

With this PR and different values of mcts_top_k_pre_evaluate I got (out of 16k evaluations)
- 4: 7.6s (12k hits)
- 8: 6.9s (12.5k hits)
- 16: 6.5s (13k hits)
- 20: 6.6s (13k hits)
- 24: 6.6s (13k hits)

So, again around 16 works the best.   With higher numbers of mcts_n we may need a higher value, because it's more likely that we'll explore more of its children.





