### PR TITLE
Option to do per-process evaluation in train_alphazero

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -364,6 +364,11 @@ class AlphaZeroAgent(TrainableAgent):
         torch.save(model_state, path)
         print(f"AlphaZero model saved to {path}")
 
+    def save_model_with_suffix(self, suffix: str) -> Path:
+        path = resolve_path(self.params.model_dir, self.resolve_filename(suffix))
+        self.save_model(path)
+        return path
+
     def set_model_state(self, model_state: dict):
         self.evaluator.network.load_state_dict(model_state["network_state_dict"])
 

--- a/deep_quoridor/src/arena.py
+++ b/deep_quoridor/src/arena.py
@@ -16,6 +16,7 @@ from utils.misc import get_opponent_player_id
 class PlayMode(Enum):
     ALL_VS_ALL = "all_vs_all"  # Legacy mode where all players play against each other
     FIRST_VS_RANDOM = "first_vs_random"  # First player plays against randomly selected opponents
+    FIRST_VS_ALL = "first_vs_all"  # First player plays against all the opponents
 
 
 class Arena:
@@ -158,7 +159,7 @@ class Arena:
 
         if mode == PlayMode.ALL_VS_ALL:
             total_games = len(agents) * (len(agents) - 1) * times // 2
-        else:  # FIRST_VS_RANDOM mode
+        else:  # FIRST_VS_RANDOM or FIRST_VS_ALL mode
             total_games = (len(agents) - 1) * times
 
         self.plugins.start_arena(self.game, total_games=total_games)
@@ -179,13 +180,13 @@ class Arena:
                             result = self._play_game(agent_1, agent_2, f"game_{match_id:04d}")
                             results.append(result)
                             match_id += 1
-            else:  # FIRST_VS_RANDOM mode
+            else:  # FIRST_VS_RANDOM or FIRST_VS_ALL mode
                 first_agent = agents[0]
                 remaining_agents = agents[1:]
 
-                for _ in range(times):
-                    for _ in range(len(remaining_agents)):
-                        opponent = random.choice(remaining_agents)
+                for opp in remaining_agents:
+                    for _ in range(times):
+                        opponent = random.choice(remaining_agents) if mode == PlayMode.FIRST_VS_RANDOM else opp
                         agent_1, agent_2 = (
                             (first_agent, opponent)
                             if not self.swap_players or match_id % 2 == 0

--- a/deep_quoridor/src/metrics.py
+++ b/deep_quoridor/src/metrics.py
@@ -122,7 +122,7 @@ class Metrics:
             results = arena._play_games(players, times, PlayMode.ALL_VS_ALL)
             self.stored_elos = compute_elo(results)
 
-        results = arena._play_games([agent] + players, times, PlayMode.FIRST_VS_RANDOM)
+        results = arena._play_games([agent] + players, times, PlayMode.FIRST_VS_ALL)
 
         elo_table = compute_elo(results, initial_elos=self.stored_elos.copy())
         relative_elo = self._compute_relative_elo(elo_table, agent.name())


### PR DESCRIPTION
In some hardware (at least in Mac), it runs much faster to have each process do the evaluations rather than queuing them for a central evaluator.  So this PR gives the option to run the training in either mode, with the following results:
- Using the train script (no subprocesses): 123 min
- With centralized evaluation, 8 workers: 76 min
- With per process evaluation, 8 workers: 35 min

So it's about 2x from centralized.
Also I'm sending an unrelated change: I created the mode FIRST_VS_ALL, because I realized that if we use FIRST_VS_RANDOM in the metrics, it will introduce unnecessary randomness.  E.g. if one time the agen plays more against random than simple it will get better metrics.

Here are the commands that I used (wandb runs [here](https://wandb.ai/the-lazy-learning-lair/benchmark-ppe))
To run with the train script:
```
.venv/bin/python -O deep_quoridor/src/train.py -N 5 -W 3 \
-e 1000 -f 250 --max_steps=200 \
--benchmark greedy:p_random=0.3,nick=greedy-03 greedy:p_random=0.1,nick=greedy-01 \
-p alphazero:training_mode=true,replay_buffer_size=1000000,mcts_ucb_c=2,train_every=250,\
save_replay_buffer=first,mcts_noise_epsilon=0.2,mcts_n=2000,\
learning_rate=0.0005,batch_size=256,optimizer_iterations=100,\
validation_ratio=0.2 \
-w project=benchmark-ppe,notes="old train script"
```

Centralized evaluation:
```
.venv/bin/python -O deep_quoridor/src/train_alphazero.py -N 5 -W 3 \
-g 250 -e 4 --max-steps=200 --num-workers 8 \
--benchmark greedy:p_random=0.3,nick=greedy-03 greedy:p_random=0.1,nick=greedy-01 \
-p replay_buffer_size=1000000,mcts_ucb_c=2,train_every=500,\
save_replay_buffer=first,mcts_noise_epsilon=0.2,mcts_n=2000,\
learning_rate=0.0005,batch_size=256,optimizer_iterations=100,\
validation_ratio=0.2 \
-w project=benchmark-ppe,notes="centralized evaluation 8 workers"
```

Per process evaluation (the only difference is the flag --per-process-evaluation):
```
.venv/bin/python -O deep_quoridor/src/train_alphazero.py -N 5 -W 3 \
-g 250 -e 4 --max-steps=200 --num-workers 8 \
--benchmark greedy:p_random=0.3,nick=greedy-03 greedy:p_random=0.1,nick=greedy-01 \
-p replay_buffer_size=1000000,mcts_ucb_c=2,train_every=500,\
save_replay_buffer=first,mcts_noise_epsilon=0.2,mcts_n=2000,\
learning_rate=0.0005,batch_size=256,optimizer_iterations=100,\
validation_ratio=0.2 \
--per-process-evaluation \
-w project=benchmark-ppe,notes="per process evaluation 8 workers"
```