### PR TITLE
Improve worker random seed computation

### DIFF
--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -50,19 +50,16 @@ def train_alphazero(
     for epoch in range(args.epochs):
         print(f"Starting epoch {epoch}")
 
-        # We use a different random seed each epoch to make sure we don't get correlated games, but
-        # we want the runs to be repeatable so we use a deterministic scheme to generate the seeds.
-        random_seed = args.seed + args.num_workers * epoch
-
         # When using per process evaluation, set the filename so that each process loads the most recent model.
         if args.per_process_evaluation:
-            self_play_params.model_filename = current_filename
+            self_play_params.model_filename = str(current_filename)
 
         # Create a self-play manager to run self-play games across multiple processes. The
         # worker processes get re-spawned each epoch to make sure all cached values get freed.
         self_play_manager = SelfPlayManager(
             args.num_workers,
-            random_seed,
+            args.seed,
+            epoch,
             args.games_per_epoch,
             game_params,
             self_play_params,


### PR DESCRIPTION
We've been adding and multiplying numbers together to get a random seed that is different per worker. I wanted to make sure it was also different per epoch (if training doesn't occur between epochs then i think we could get the same self-play games again). After multiply by epoch and running for a while, the random seed overflowed an int32, which causes numpy to throw an exception

The approach used in this PR is to turn all the numbers we want our random seed to depend on into byte strings, then hash them using sha256, then take only 4 bytes of the sha256 value and turn that into an int. This should be a reliable and extendable way to get a (probably) unique and definitely deterministic seed that fits in an int32.

NOTE: This is on top of #288 and probably needs to be rebased after that is merged. No need to review until then.