### PR TITLE
Log loss in WandB and other fixes

### DIFF
--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -60,7 +60,7 @@ class ActionEncoder:
         self.board_size = board_size
         self.wall_size = board_size - 1
         self.num_actions = self.board_size**2 + self.wall_size**2 * 2
-        self.constant_action_mask_template = np.zeros(self.num_actions, dtype=np.float32)
+        self.constant_action_mask_template = np.zeros(self.num_actions, dtype=np.int8)
 
     def get_action_mask_template(self):
         return np.copy(self.constant_action_mask_template)

--- a/deep_quoridor/src/run_metrics.py
+++ b/deep_quoridor/src/run_metrics.py
@@ -23,8 +23,29 @@ if __name__ == "__main__":
         required=True,
         help="List of players to run the metrics.  The metrics for each player are computed independently",
     )
+    parser.add_argument(
+        "-b",
+        "--benchmarks",
+        nargs="+",
+        type=str,
+        default=["random", "simple"],
+        help=f"List of players to benchmark against. Can include parameters in parentheses. Allowed types {AgentRegistry.names()}",
+    )
+    parser.add_argument(
+        "-bt",
+        "--benchmarks_t",
+        type=int,
+        default=10,
+        help="How many time to play against each opponent during benchmarks",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=200,
+        help="Max number of turns before game is called a tie (pass -1 for no limit)",
+    )
     args = parser.parse_args()
-    m = Metrics(args.board_size, args.max_walls)
+    m = Metrics(args.board_size, args.max_walls, args.benchmarks, args.benchmarks_t, args.max_steps)
     table = PrettyTable()
     table.field_names = ["Agent", "Elo", "Relative Elo", "Win %", "Dumb Score"]
 

--- a/deep_quoridor/test/agents/alphazero_test.py
+++ b/deep_quoridor/test/agents/alphazero_test.py
@@ -95,7 +95,7 @@ def test_evaluator_training_with_deterministic_policy():
     value, policy = evaluator.evaluate(game)
     assert np.abs(value - target_value) < required_precision
     assert (np.abs(policy - target_policy) < required_precision).all()
-    assert training_stats["total_loss"] < required_precision
+    assert training_stats["loss_total"] < required_precision
 
 
 def test_evaluator_training_with_probabilistic_policy():
@@ -131,4 +131,4 @@ def test_evaluator_training_with_probabilistic_policy():
     # If the NN models the policy perfectly then the remaining policy loss should equal the
     # entropy of the target policy.
     target_policy_entropy = Categorical(torch.Tensor(target_policy)).entropy()
-    assert training_stats["total_loss"] - target_policy_entropy < required_precision
+    assert training_stats["loss_total"] - target_policy_entropy < required_precision


### PR DESCRIPTION
The main thing in this PR is to log the loss in WandB so we easily see how it evolves.  I ended up adding a lot of other changes, some related some completely orthogonal. 
The loss track ended up being tricky because we were using "steps" but you can only increase them monotonically and they need to be int, and I needed a different way to track losses.  I find it very confusing the way wandb does it, but I defined the metrics "Loss step" and "Episode" which would be the x axis:

```
        wandb.define_metric("Loss step", hidden=True)
        wandb.define_metric("Episode", hidden=True)
```

And then I indicated that all the metrics starting with loss_ will use 'Loss Step' and the rest 'Episode`:
```
        wandb.define_metric("loss_*", "Loss step")
        wandb.define_metric("*", "Episode")
```

E.g. from [this run](https://wandb.ai/the-lazy-learning-lair/deep_quoridor/runs/amarcu-20250926-000648?nw=nwuseramarcu)

<img width="1305" height="305" alt="image" src="https://github.com/user-attachments/assets/0693a848-09cb-4f3a-a1b0-5fa3f14a4d10" />

The training for each epoch is in the X coordinates between that epoch number and extends for 0.5, so we can distinguish epochs.

E.g. when zooming in:
<img width="423" height="309" alt="image" src="https://github.com/user-attachments/assets/764d6624-d917-49d5-b468-658d91912d74" />
Between 0 and 0.5 I see how the training evolved after epoch 0.  Then from 1 to 1.5 how it evolved in epoch 1 and so on. 
