### PR TITLE
Time self-play and benchmarks

### DIFF
--- a/deep_quoridor/src/utils/__init__.py
+++ b/deep_quoridor/src/utils/__init__.py
@@ -6,7 +6,19 @@ __all__ = [
     "SubargsBase",
     "yargs",
     "get_initial_random_seed",
+    "format_time",
+    "timer",
+    "Timer",
 ]
 
-from utils.misc import compute_elo, get_initial_random_seed, my_device, resolve_path, set_deterministic, yargs
+from utils.misc import (
+    compute_elo,
+    format_time,
+    get_initial_random_seed,
+    my_device,
+    resolve_path,
+    set_deterministic,
+    yargs,
+)
 from utils.subargs import SubargsBase, parse_subargs
+from utils.timer import Timer, timer

--- a/deep_quoridor/src/utils/misc.py
+++ b/deep_quoridor/src/utils/misc.py
@@ -168,3 +168,19 @@ def get_opponent_player_id(player_id: str) -> str:
 
 def cnn_output_size_per_channel(input_size, padding, kernel_size=3, stride=1):
     return (input_size + 2 * padding - kernel_size) // stride + 1
+
+
+def format_time(time_in_seconds: float) -> str:
+    if time_in_seconds > 120:
+        hours = int(time_in_seconds // 3600)
+        minutes = int((time_in_seconds % 3600) // 60)
+        seconds = int(time_in_seconds % 60)
+        return f"{hours:02d}:{minutes:02d}:{seconds:02d} ({int(time_in_seconds)}s)"
+
+    if time_in_seconds < 0.001:
+        return f"{time_in_seconds * 1e6:.2f}µs"
+
+    if time_in_seconds < 1:
+        return f"{time_in_seconds * 1e3:.2f}ms"
+
+    return f"{time_in_seconds:.2f}s"

--- a/deep_quoridor/src/utils/timer.py
+++ b/deep_quoridor/src/utils/timer.py
@@ -1,0 +1,83 @@
+import time
+from typing import Optional
+
+import wandb
+import wandb.wandb_run
+
+from utils.misc import format_time
+
+
+class Timer:
+    """
+    Class to measure elapsed time and log it to the console and optionally wandb.
+    It's a class just to create a container for the functions and variables, it can't be instantiated.
+    TO DO: would be nice if it would easily support multi-process, so we can gather information coming
+    from different processes and compile it.
+    """
+
+    starts = {}
+    counts = {}
+    totals = {}
+    wandb_run: Optional[wandb.wandb_run.Run] = None
+
+    def __new__(cls, *args, **kwargs):
+        raise TypeError("Timer is a static class and cannot be instantiated.")
+
+    @classmethod
+    def set_wandb_run(cls, wandb_run: wandb.wandb_run.Run):
+        cls.wandb_run = wandb_run
+
+    @classmethod
+    def start(cls, name: str):
+        if name in cls.starts:
+            print(f"TIMER: WARNING - timer for {name} was already started")
+
+        cls.starts[name] = time.perf_counter()
+
+    @classmethod
+    def finish(cls, name: str, episode: Optional[int] = None):
+        if name not in cls.starts:
+            print(f"TIMER: WARNING - timer for {name} was not started but trying to finish")
+            return
+
+        elapsed = time.perf_counter() - cls.starts[name]
+        del cls.starts[name]
+
+        cls.counts[name] = cls.counts.get(name, 0) + 1
+        cls.totals[name] = cls.totals.get(name, 0.0) + elapsed
+        if episode is not None:
+            print(f"TIMER: [{episode}] {name} took {format_time(elapsed)}")
+            if cls.wandb_run:
+                cls.wandb_run.log({f"time-{name}": elapsed, "Episode": episode})
+
+    @classmethod
+    def log_totals(cls):
+        if len(cls.starts) > 0:
+            print(f"TIMER: WARNING - timers for {list(cls.starts.keys())} still running")
+
+        print("===== Timer Stats ====")
+        for name, total in cls.totals.items():
+            print(f"- {name} took {format_time(total)} in {cls.counts[name]} calls")
+        print("======================")
+
+        if cls.wandb_run:
+            totals = {f"time-total-{name}": total for name, total in cls.totals.items()}
+            print(totals)
+            cls.wandb_run.log(totals)
+
+
+def timer(name: str):
+    """
+    Decorator to time a function or method
+    """
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            Timer.start(name)
+            result = func(*args, **kwargs)
+            Timer.finish(name)
+            return result
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
I wanted to measure how long it takes to do the self-play and running the tournament benchmarks, so it's easier to measure gains when doing performance work in just a specific part, and I think in general it's interesting to see.
I created the Timer class to make it easier to use it.
I tried to also measure the time in evaluate and mcts, but the aggregation doesn't work because they are in separate process, we need a bit more work for that to happen (e.g. when the process is done, send the aggregated data back to the root process).

E.g. when I ran:

```
.venv/bin/python -O deep_quoridor/src/train_alphazero.py -N 5 -W 3 \
-g 100 -e 8 --max-steps=50 --num-workers 6 \
-p replay_buffer_size=50000,mcts_ucb_c=1.5,\
save_replay_buffer=first,mcts_n=500,\
learning_rate=0.0001,batch_size=16,optimizer_iterations=10,\
validation_ratio=0.2 \
-w project="cucutest"
```
I got this in wandb:

<img width="1516" height="329" alt="image" src="https://github.com/user-attachments/assets/cf460a83-5c39-4ed4-8694-5acec248c525" />
