### PR TITLE
Self-play games in batches in each process

### DIFF
--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -124,7 +124,6 @@ class MCTS:
         max_steps: int,  # -1 means no limit
         evaluator,
         visited_states: set,
-        top_k_pre_evaluate: int = 16,
     ):
         assert n is not None or k is not None, "Either n or k need to be specified"
         self.n = n
@@ -134,7 +133,6 @@ class MCTS:
         self.noise_alpha = noise_alpha
         self.max_steps = max_steps
         self.evaluator = evaluator
-        self.top_k_pre_evaluate = top_k_pre_evaluate
         self.visited_states = visited_states
 
     def select(self, node: Node) -> Node:
@@ -147,16 +145,7 @@ class MCTS:
             node = node.select(self.visited_states)
         return node
 
-    def multi_search_trucho(self, initial_games: list[Quoridor]):
-        rcs, rvs = [], []
-        for game in initial_games:
-            rc, rv = self.search(game)
-            rcs.append(rc)
-            rvs.append(rv)
-
-        return rcs, rvs
-
-    def multi_search(self, initial_games: list[Quoridor]):
+    def search_batch(self, initial_games: list[Quoridor]):
         # if self.k is not None:
         #     num_actions = np.sum(np.array(initial_game.get_action_mask()) == 1)
         #     num_iterations = self.k * num_actions
@@ -168,7 +157,6 @@ class MCTS:
         assert num_iterations
 
         roots = [Node(g, ucb_c=self.ucb_c) for g in initial_games]
-        extra_games = []
         for _ in range(num_iterations):
             games_to_evaluate = []
             # better names
@@ -188,16 +176,8 @@ class MCTS:
                     selected_nodes.append(node)
                     selected_roots.append(root)
 
-            # trucho
-            # values, priorses = [], []
-            # for game in games_to_evaluate:
-            #     value, priors = self.evaluator.evaluate(game)
-            #     values.append(value)
-            #     priorses.append(priors)
-            values, priorses = self.evaluator.evaluate_all(games_to_evaluate, extra_games[: self.top_k_pre_evaluate])
-            extra_games = []
+            values, priorses = self.evaluator.evaluate_batch(games_to_evaluate)
 
-            top_games_and_values = []
             for node, root, value, priors in zip(selected_nodes, selected_roots, values, priorses):
                 if node is root and self.noise_epsilon > 0.0:
                     # To encourage exploration we add noise to the priors at the root node.
@@ -211,70 +191,13 @@ class MCTS:
                     priors[valid_action_indices] *= 1.0 - self.noise_epsilon
                     priors[valid_action_indices] += self.noise_epsilon * dirichlet_noise
                 node.expand(priors)
-                prev_value = root.value_sum
                 node.backpropagate(-value)
-
-                if self.top_k_pre_evaluate > 0:
-                    if node.children:
-                        top_child = max(node.children, key=lambda c: c.prior)
-                        delta = prev_value - root.value_sum
-                        top_games_and_values.append((top_child.game, delta))
-
-            if self.top_k_pre_evaluate > 0 and top_games_and_values:
-                top_games_and_values.sort(key=lambda x: x[1], reverse=True)
-                extra_games = [game for game, _ in top_games_and_values[: self.top_k_pre_evaluate]]
 
         # Negate the value because the value is actually the value that the opponent
         # got for getting to that state.
         # root_value = -(root.value_sum / root.visit_count)
         return [root.children for root in roots], [-(root.value_sum / root.visit_count) for root in roots]
 
-    def search(self, initial_game: Quoridor):
-        root = Node(initial_game, ucb_c=self.ucb_c)
-        new_nodes = []
-
-        if self.k is not None:
-            num_actions = np.sum(np.array(initial_game.get_action_mask()) == 1)
-            num_iterations = self.k * num_actions
-        else:
-            assert self.n is not None, "n must be specified if k is not"
-            num_iterations = self.n
-
-        for _ in range(num_iterations):
-            # Traverse down the tree guided by maximum UCB until we find a node to expand
-            node = self.select(root)
-
-            if node.game.is_game_over():
-                # The player who just made a move must have won.
-                node.backpropagate_result(1)
-            elif self.max_steps >= 0 and node.game.completed_steps >= self.max_steps:
-                node.backpropagate_result(0)
-            else:
-                games_to_evaluate = [n.game for n in new_nodes]
-                new_nodes = []
-
-                value, priors = self.evaluator.evaluate(node.game, games_to_evaluate)
-
-                if node is root and self.noise_epsilon > 0.0:
-                    # To encourage exploration we add noise to the priors at the root node.
-                    # NOTE: It isn't clear from the paper whether we should apply the dirichlet noise
-                    # only to the valid actions, or whether we should apply it to all actions and then
-                    # re-mask and re-normalize. These might work out to be equivalent, but I'm not sure of
-                    # that either. For now we apply the noise _only_ to the valid actions. That seems to
-                    # match what the Openspiel python implementation does.
-                    (valid_action_indices,) = np.nonzero(priors > 0.0)
-                    dirichlet_noise = dirichlet([self.noise_alpha] * len(valid_action_indices))
-                    priors[valid_action_indices] *= 1.0 - self.noise_epsilon
-                    priors[valid_action_indices] += self.noise_epsilon * dirichlet_noise
-
-                node.expand(priors)
-                if self.top_k_pre_evaluate > 0:
-                    sorted_children = sorted(node.children, key=lambda c: c.prior, reverse=True)
-                    new_nodes.extend(sorted_children[: self.top_k_pre_evaluate])
-
-                node.backpropagate(-value)
-
-        # Negate the value because the value is actually the value that the opponent
-        # got for getting to that state.
-        root_value = -(root.value_sum / root.visit_count)
-        return root.children, root_value
+    def search(self, game: Quoridor):
+        children_batch, root_value_batch = self.search_batch([game])
+        return children_batch[0], root_value_batch[0]

--- a/deep_quoridor/src/agents/alphazero/mcts.py
+++ b/deep_quoridor/src/agents/alphazero/mcts.py
@@ -146,23 +146,26 @@ class MCTS:
         return node
 
     def search_batch(self, initial_games: list[Quoridor]):
-        # if self.k is not None:
-        #     num_actions = np.sum(np.array(initial_game.get_action_mask()) == 1)
-        #     num_iterations = self.k * num_actions
-        # else:
-        #     assert self.n is not None, "n must be specified if k is not"
-        #     num_iterations = self.n
-        # TODO support K
-        num_iterations = self.n
-        assert num_iterations
+        if self.k is not None:
+            num_iterations = [self.k * int(np.sum(np.array(game.get_action_mask()) == 1)) for game in initial_games]
+        else:
+            assert self.n is not None, "n must be specified if k is not"
+            num_iterations = [self.n for _ in initial_games]
+
+        max_iterations = max(num_iterations)
+        # print(f"{num_iterations=}, {max_iterations=}")
 
         roots = [Node(g, ucb_c=self.ucb_c) for g in initial_games]
-        for _ in range(num_iterations):
+        for iteration in range(max_iterations):
             games_to_evaluate = []
             # better names
             selected_roots = []
             selected_nodes = []
-            for root in roots:
+            for game_idx, root in enumerate(roots):
+                # TODO  if iteration is passed skip
+                if iteration >= num_iterations[game_idx]:
+                    continue
+
                 # Traverse down the tree guided by maximum UCB until we find a node to expand
                 node = self.select(root)
 
@@ -198,6 +201,6 @@ class MCTS:
         # root_value = -(root.value_sum / root.visit_count)
         return [root.children for root in roots], [-(root.value_sum / root.visit_count) for root in roots]
 
-    def search(self, game: Quoridor):
-        children_batch, root_value_batch = self.search_batch([game])
+    def search(self, initial_game: Quoridor):
+        children_batch, root_value_batch = self.search_batch([initial_game])
         return children_batch[0], root_value_batch[0]

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -97,18 +97,13 @@ class NNEvaluator:
         policy_masked = policy_masked.cpu().numpy()
 
         for i, g, h in zip(range(len(games_to_evaluate)), games_to_evaluate, games_by_hash.keys()):
-            pm = policy_masked[i]
-            # Sanity checks
-            assert np.all(pm >= 0), "Policy contains negative probabilities"
-            assert np.abs(np.sum(pm) - 1) < 1e-6, "Policy does not sum to 1"
-            assert np.isfinite(values[i]), "Policy or value is non-finite"
-
             # If the game was originally rotated, rotate the resulting back to player 2's perspective
             if g.get_current_player() == Player.TWO:
                 policy_masked[i] = policy_masked[i][self.action_mapping_rotated_to_original]
 
             self.cache[h] = (values[i][0], policy_masked[i])
 
+        # list of values, list of policies
         return [self.cache[h][0] for h in hashes], [self.cache[h][1] for h in hashes]
 
     def evaluate(self, game: Quoridor):

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -73,38 +73,31 @@ class NNEvaluator:
 
         return values_tensor, policies_tensor
 
-    def evaluate_all(self, games: list[Quoridor]):
-        n = len(games)
-        multi_values = [None for _ in range(n)]
-        multi_policy_masked = [None for _ in range(n)]
+    def evaluate_all(self, games: list[Quoridor], optional_games: list[Quoridor] = []):
+        hashes = [g.get_fast_hash() for g in games]
 
-        all_games = []
-        for i, game in enumerate(games):
-            if game.get_fast_hash() in self.cache:
-                v, pm = self.cache[game.get_fast_hash()]
-                multi_values[i] = v
-                multi_policy_masked[i] = pm
-            else:
-                all_games.append(game)
-
-        if len(all_games) == 0:
+        if all([h in self.cache for h in hashes]):
             # everything was cached!
-            return multi_values, multi_policy_masked
+            return [self.cache[h][0] for h in hashes], [self.cache[h][1] for h in hashes]
 
-        all_hashes = [g.get_fast_hash() for g in all_games]
-        all_games = [NNEvaluator.rotate_if_needed_to_point_downwards(g)[0] for g in all_games]
-        all_games_input_arrays = [torch.from_numpy(NNEvaluator.game_to_input_array(g)) for g in all_games]
-        all_games_tensors = torch.stack(all_games_input_arrays).to(device=self.device)
+        # We may receive the game more than once, so this deduplicates it
+        optional_hashes = [g.get_fast_hash() for g in optional_games]
+        games_by_hash = {h: g for g, h in zip(games + optional_games, hashes + optional_hashes) if h not in self.cache}
+        games_to_evaluate = games_by_hash.values()
+
+        games_to_evaluate = [self.rotate_if_needed_to_point_downwards(g)[0] for g in games_to_evaluate]
+        input_arrays = [torch.from_numpy(self.game_to_input_array(g)) for g in games_to_evaluate]
+        tensors = torch.stack(input_arrays).to(device=self.device)
 
         with torch.no_grad():
-            action_masks = torch.stack([torch.from_numpy(g.get_action_mask()) for g in all_games]).to(
+            action_masks = torch.stack([torch.from_numpy(g.get_action_mask()) for g in games_to_evaluate]).to(
                 device=self.device
             )
-            values, policy_masked = self.evaluate_tensors(all_games_tensors, action_masks)
+            values, policy_masked = self.evaluate_tensors(tensors, action_masks)
             values = values.cpu().numpy()
             policy_masked = policy_masked.cpu().numpy()
 
-        for i, g in enumerate(all_games):
+        for i, g, h in zip(range(len(games_to_evaluate)), games_to_evaluate, games_by_hash.keys()):
             pm = policy_masked[i]
             # Sanity checks
             assert np.all(pm >= 0), "Policy contains negative probabilities"
@@ -114,14 +107,10 @@ class NNEvaluator:
             # If the game was originally rotated, rotate the resulting back to player 2's perspective
             if g.get_current_player() == Player.TWO:
                 policy_masked[i] = policy_masked[i][self.action_mapping_rotated_to_original]
-            self.cache[all_hashes[i]] = (values[i][0], policy_masked[i])
 
-        # print(multi_values)
-        for i in range(n):
-            if multi_values[i] is None:
-                multi_values[i], multi_policy_masked[i] = self.cache[games[i].get_fast_hash()]
+            self.cache[h] = (values[i][0], policy_masked[i])
 
-        return multi_values, multi_policy_masked
+        return [self.cache[h][0] for h in hashes], [self.cache[h][1] for h in hashes]
 
     def evaluate(self, game: Quoridor, extra_games_to_evaluate: list[Quoridor] = []):
         if game.get_fast_hash() in self.cache:

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -73,7 +73,8 @@ class NNEvaluator:
 
         return values_tensor, policies_tensor
 
-    def evaluate_all(self, games: list[Quoridor], optional_games: list[Quoridor] = []):
+    @torch.no_grad
+    def evaluate_batch(self, games: list[Quoridor]):
         hashes = [g.get_fast_hash() for g in games]
 
         if all([h in self.cache for h in hashes]):
@@ -81,21 +82,19 @@ class NNEvaluator:
             return [self.cache[h][0] for h in hashes], [self.cache[h][1] for h in hashes]
 
         # We may receive the game more than once, so this deduplicates it
-        optional_hashes = [g.get_fast_hash() for g in optional_games]
-        games_by_hash = {h: g for g, h in zip(games + optional_games, hashes + optional_hashes) if h not in self.cache}
+        games_by_hash = {h: g for g, h in zip(games, hashes) if h not in self.cache}
         games_to_evaluate = games_by_hash.values()
 
         games_to_evaluate = [self.rotate_if_needed_to_point_downwards(g)[0] for g in games_to_evaluate]
         input_arrays = [torch.from_numpy(self.game_to_input_array(g)) for g in games_to_evaluate]
         tensors = torch.stack(input_arrays).to(device=self.device)
+        action_masks = torch.stack([torch.from_numpy(g.get_action_mask()) for g in games_to_evaluate]).to(
+            device=self.device
+        )
 
-        with torch.no_grad():
-            action_masks = torch.stack([torch.from_numpy(g.get_action_mask()) for g in games_to_evaluate]).to(
-                device=self.device
-            )
-            values, policy_masked = self.evaluate_tensors(tensors, action_masks)
-            values = values.cpu().numpy()
-            policy_masked = policy_masked.cpu().numpy()
+        values, policy_masked = self.evaluate_tensors(tensors, action_masks)
+        values = values.cpu().numpy()
+        policy_masked = policy_masked.cpu().numpy()
 
         for i, g, h in zip(range(len(games_to_evaluate)), games_to_evaluate, games_by_hash.keys()):
             pm = policy_masked[i]
@@ -112,37 +111,9 @@ class NNEvaluator:
 
         return [self.cache[h][0] for h in hashes], [self.cache[h][1] for h in hashes]
 
-    def evaluate(self, game: Quoridor, extra_games_to_evaluate: list[Quoridor] = []):
-        if game.get_fast_hash() in self.cache:
-            return self.cache[game.get_fast_hash()]
-
-        all_games = [game] + extra_games_to_evaluate
-        all_hashes = [g.get_fast_hash() for g in all_games]
-        all_games = [self.rotate_if_needed_to_point_downwards(g)[0] for g in all_games]
-        all_games_input_arrays = [torch.from_numpy(self.game_to_input_array(g)) for g in all_games]
-        all_games_tensors = torch.stack(all_games_input_arrays).to(device=self.device)
-
-        with torch.no_grad():
-            action_masks = torch.stack([torch.from_numpy(g.get_action_mask()) for g in all_games]).to(
-                device=self.device
-            )
-            values, policy_masked = self.evaluate_tensors(all_games_tensors, action_masks)
-            values = values.cpu().numpy()
-            policy_masked = policy_masked.cpu().numpy()
-
-        for i, g in enumerate(all_games):
-            pm = policy_masked[i]
-            # Sanity checks
-            assert np.all(pm >= 0), "Policy contains negative probabilities"
-            assert np.abs(np.sum(pm) - 1) < 1e-6, "Policy does not sum to 1"
-            assert np.isfinite(values[i]), "Policy or value is non-finite"
-
-            # If the game was originally rotated, rotate the resulting back to player 2's perspective
-            if g.get_current_player() == Player.TWO:
-                policy_masked[i] = policy_masked[i][self.action_mapping_rotated_to_original]
-            self.cache[all_hashes[i]] = (values[i][0], policy_masked[i])
-
-        return values[0][0], policy_masked[0]
+    def evaluate(self, game: Quoridor):
+        value, policy_masked = self.evaluate_batch([game])
+        return value[0], policy_masked[0]
 
     def rotate_policy_from_original(self, policy: np.ndarray):
         """

--- a/deep_quoridor/src/agents/alphazero/self_play_manager.py
+++ b/deep_quoridor/src/agents/alphazero/self_play_manager.py
@@ -109,7 +109,8 @@ class SelfPlayManager(threading.Thread):
                 results = sorted(self._results, key=lambda r: r.worker_id)
                 for r in results:
                     print(f"Worker {r.worker_id} replay buffer size: {len(r.replay_buffer)}")
-                    print(r.evaluator_statistics)
+                    if r.evaluator_statistics is not None:
+                        print(r.evaluator_statistics)
 
                     # NOTE: Make sure the replay buffer size for the training agent is large enough to hold
                     # the replay buffer results from all agents each epoch or else we'll end up discarding
@@ -232,5 +233,3 @@ def run_self_play_games(
             None,
         )
     )
-
-    print(f"Worker {worker_id} exiting")

--- a/deep_quoridor/src/agents/alphazero/self_play_manager.py
+++ b/deep_quoridor/src/agents/alphazero/self_play_manager.py
@@ -208,18 +208,17 @@ def run_self_play_games(
                     print(environments[i].render())
                     finished[i] = True
                 else:
-                    observations.append(observation)
+                    observations.append((i, observation))
                     num_turns[i] += 1
 
             action_indexes = alphazero_agent.multi_get_action(observations)
             # print(f"action indexes: {action_indexes}")
             # print(f"finished: {finished}, obs: {len(observations)}, turns {num_turns}")
-            for i in range(n):
-                if finished[i]:
+            for env_idx, action_index in action_indexes:
+                if finished[env_idx]:
                     continue
-                action_index = action_indexes.pop(0)
-                # print(f"game {i}, action {action_index}")
-                environments[i].step(action_index)
+                # print(f"game {env_idx}, action {action_index}")
+                environments[env_idx].step(action_index)
 
         game_i += n
         t1 = time.time()

--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -70,6 +70,7 @@ def train_alphazero(
             args.games_per_epoch,
             game_params,
             self_play_params,
+            args.parallel_games,
         )
         self_play_manager.start()
         new_replay_buffer_items = None
@@ -181,6 +182,13 @@ if __name__ == "__main__":
         "--per-process-evaluation",
         action="store_true",
         help="Deprecated; Worker processes always do their own NN evaluations.",
+    )
+    parser.add_argument(
+        "-pg",
+        "--parallel_games",
+        type=int,
+        default=32,
+        help="How many games to play in parallel per process",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Currently, each process plays one game at a time, so when we call the evaluator, we have only 1 state to evaluate (I did the pre-evaluation thing but didn't help much, e.g. in Jon's computer it was faster with 0).  This technique of playing in batches seems to be common (e.g. The Kid explains it), and the idea is that you take N games, do the first move in the N games, then do the second move for the N games and so on.  The advantage is that you can then just batch the N evaluations together, which makes it significantly faster.

I ended up removing mcts_top_k_pre_evaluate because sometimes it was performing worse, sometimes a bit better, but I thought it was not worth the complexity. 

The result is that this runs a bit more than 2x faster.

For example, running the following:
```
time .venv/bin/python -O deep_quoridor/src/train_alphazero.py -N 5 -W 3 \
-g 500 -e 1 --max-steps=50 --num-workers 8 \
-p replay_buffer_size=50000,mcts_ucb_c=1.5,\
save_replay_buffer=first,mcts_noise_epsilon=0.15,mcts_n=1000,\
learning_rate=0.0001,batch_size=256,optimizer_iterations=10,\
validation_ratio=0.2 
```
Took 358 seconds in main, vs 175 in this PR with the default of 32 parallel games (seems to be the fastest in my machine).  So that's a 2x in speed.

To make sure this is still working, I ran a longer training session, and verified that the results are similar to the base in main:
<img width="1149" height="320" alt="image" src="https://github.com/user-attachments/assets/0fa8c9bc-4b37-441b-baa6-072516bdf113" />

There's a significant speedup, but not as much as the above because the time to play the tournaments for the metrics is still the same and it's a significant percentage of the total time.
Additionally, I made the output to console more compact, e.g. it looks like this now:

```
Worker 3: (37.64s) Games 83...101 / 83 ended after [14, 14, 15, 16, 17, 17, 17, 17, 18, 18, 18, 19, 21, 21, 25, 26, 26, 26, 29] turns. 0 truncated
Worker 2: (40.77s) Games 83...101 / 83 ended after [14, 14, 15, 17, 17, 18, 18, 18, 18, 18, 18, 20, 22, 30, 33, 33, 45, 46] turns. 1 truncated
Worker 1: (37.48s) Games 84...103 / 84 ended after [10, 13, 14, 16, 16, 17, 17, 18, 18, 18, 18, 18, 18, 20, 21, 22, 29, 38, 41] turns. 1 truncated
Worker 0: (38.98s) Games 84...103 / 84 ended after [14, 15, 16, 16, 17, 18, 18, 20, 20, 20, 20, 22, 22, 24, 25, 26, 28, 29, 40] turns. 1 truncated
Worker 5: (42.62s) Games 83...101 / 83 ended after [11, 14, 16, 17, 18, 18, 18, 20, 21, 22, 22, 24, 26, 33, 33, 33, 42, 44] turns. 1 truncated
Worker 4: (35.55s) Games 83...101 / 83 ended after [12, 15, 15, 16, 16, 16, 16, 17, 18, 18, 18, 18, 18, 21, 21, 22, 26, 29, 46] turns. 0 truncated
```
So, we have all the parallel games in one line. If we wanted we could make it even more compact by doing something like [12x3, 15x2, 16, 18x5], etc, or even just showing the quartiles or some statistical information to give a sense of the length of the matches.


