### PR TITLE
Add Resnet option to NNEvaluator

### DIFF
--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -153,6 +153,10 @@ class AlphaZeroParams(SubargsBase):
     # What fraction of the total moves will be used for validation during training, or 0.0 to not use a validation set
     validation_ratio: float = 0.0
 
+    # What neural network structure to use
+    # The options are "mlp" or "resnet"
+    nn_type: str = "mlp"
+
     @classmethod
     def training_only_params(cls) -> set[str]:
         """
@@ -195,7 +199,7 @@ class AlphaZeroAgent(TrainableAgent):
 
         self.action_encoder = ActionEncoder(board_size)
         if evaluator is None:
-            self.evaluator = NNEvaluator(self.action_encoder, self.device)
+            self.evaluator = NNEvaluator(self.action_encoder, self.device, params.nn_type)
         else:
             self.evaluator = evaluator
 

--- a/deep_quoridor/src/agents/alphazero/nn_evaluator.py
+++ b/deep_quoridor/src/agents/alphazero/nn_evaluator.py
@@ -8,6 +8,7 @@ import torch.nn.functional as F
 from quoridor import ActionEncoder, Player, Quoridor
 
 from agents.alphazero.mlp_network import MLPNetwork
+from agents.alphazero.resnet_network import ResnetNetwork
 from agents.core.rotation import create_rotation_mapping
 
 INVALID_ACTION_VALUE = -1e32
@@ -30,15 +31,17 @@ class NNEvaluator:
         self,
         action_encoder: ActionEncoder,
         device,
-        network_type: str = "mlp",
+        nn_type: str = "mlp",
     ):
         self.action_encoder = action_encoder
         self.device = device
 
-        if network_type == "mlp":
+        if nn_type == "mlp":
             self.network = MLPNetwork(self.action_encoder, self.device)
+        elif nn_type == "resnet":
+            self.network = ResnetNetwork(self.action_encoder, self.device)
         else:
-            raise ValueError(f"Unknown network type: {network_type}")
+            raise ValueError(f"Unknown network type: {nn_type}")
 
         [self.action_mapping_original_to_rotated, self.action_mapping_rotated_to_original] = create_rotation_mapping(
             self.action_encoder.board_size

--- a/deep_quoridor/src/agents/alphazero/resnet_network.py
+++ b/deep_quoridor/src/agents/alphazero/resnet_network.py
@@ -26,7 +26,7 @@ class ResidualBlock(nn.Module):
 
 
 class ResnetNetwork(nn.Module):
-    def __init__(self, action_encoder: ActionEncoder, device, num_blocks: Optional[int] = None, num_channels: int = 16):
+    def __init__(self, action_encoder: ActionEncoder, device, num_blocks: Optional[int] = None, num_channels: int = 32):
         """
         ResNet-based network following AlphaZero architecture.
 

--- a/deep_quoridor/src/agents/alphazero/resnet_network.py
+++ b/deep_quoridor/src/agents/alphazero/resnet_network.py
@@ -1,0 +1,141 @@
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+from quoridor import ActionEncoder, Player, Quoridor
+
+
+class ResidualBlock(nn.Module):
+    """Residual block with two convolutional layers and skip connection."""
+
+    def __init__(self, num_channels):
+        super(ResidualBlock, self).__init__()
+        self.conv1 = nn.Conv2d(num_channels, num_channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(num_channels)
+        self.conv2 = nn.Conv2d(num_channels, num_channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(num_channels)
+
+    def forward(self, x):
+        residual = x
+        out = torch.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += residual
+        out = torch.relu(out)
+        return out
+
+
+class ResnetNetwork(nn.Module):
+    def __init__(self, action_encoder: ActionEncoder, device, num_blocks: Optional[int] = None, num_channels: int = 16):
+        """
+        ResNet-based network following AlphaZero architecture.
+
+        Args:
+            action_encoder: ActionEncoder for the game
+            device: torch device to use
+            num_blocks: Number of residual blocks.  Alphazero used 20 for chess and 40 for go, which
+             is a bit more than twice the board dimension. We default to the twice the dimension of
+             the combined grid, plus two.
+            num_channels: Number of channels in convolutional layers (Alphazero used 256)
+        """
+        super(ResnetNetwork, self).__init__()
+
+        self.action_encoder = action_encoder
+        self.device = device
+        self.num_channels = num_channels
+
+        # Calculate input dimensions: MxMx5 where M = board_size * 2 + 3
+        self.input_size = action_encoder.board_size * 2 + 3
+
+        self.num_blocks = num_blocks
+        if self.num_blocks is None:
+            # Alphazero used 20 blocks for chess and 40 for Go, which seems to be a bit more
+            # than double the board dimension.
+            self.num_blocks = self.input_size * 2 + 2
+
+        # Initial convolutional block
+        self.conv_input = nn.Conv2d(5, num_channels, kernel_size=3, padding=1)
+        self.bn_input = nn.BatchNorm2d(num_channels)
+
+        # Residual tower
+        self.residual_blocks = nn.ModuleList([ResidualBlock(num_channels) for _ in range(self.num_blocks)])
+
+        # Policy head
+        self.policy_conv = nn.Conv2d(num_channels, 2, kernel_size=1)
+        self.policy_bn = nn.BatchNorm2d(2)
+        self.policy_fc = nn.Linear(2 * self.input_size * self.input_size, action_encoder.num_actions)
+
+        # Value head
+        self.value_conv = nn.Conv2d(num_channels, 1, kernel_size=1)
+        self.value_bn = nn.BatchNorm2d(1)
+        self.value_fc1 = nn.Linear(self.input_size * self.input_size, 256)
+        self.value_fc2 = nn.Linear(256, 1)
+
+        self.to(self.device)
+
+    def forward(self, x):
+        """
+        Forward pass through the network.
+
+        Args:
+            x: Input tensor of shape (batch_size, 5, M, M) where M = board_size * 2 + 3
+               or tuple of such tensors
+
+        Returns:
+            policy: Policy logits of shape (batch_size, num_actions)
+            value: Value estimate of shape (batch_size, 1) in range [-1, 1]
+        """
+        if isinstance(x, tuple):
+            x = torch.stack([i for i in x]).to(self.device)
+
+        # Initial convolution
+        out = torch.relu(self.bn_input(self.conv_input(x)))
+
+        # Residual tower
+        for block in self.residual_blocks:
+            out = block(out)
+
+        # Policy head
+        policy = torch.relu(self.policy_bn(self.policy_conv(out)))
+        policy = policy.view(policy.size(0), -1)
+        policy = self.policy_fc(policy)
+
+        # Value head
+        value = torch.relu(self.value_bn(self.value_conv(out)))
+        value = value.view(value.size(0), -1)
+        value = torch.relu(self.value_fc1(value))
+        value = torch.tanh(self.value_fc2(value))
+
+        return policy, value
+
+    def game_to_input_array(self, game: Quoridor) -> np.ndarray:
+        """
+        Convert Quoridor game state to tensor format for neural network.
+
+
+        1. Walls
+        2. Current player's position, as a 1-hot encoding
+        3. Opponent's position, as a 1-hot encoding
+        4. Current player walls remaining
+        5. Opponent walls remaining.
+        """
+        input_array = np.zeros((5, self.input_size, self.input_size), dtype=np.float32)
+
+        # First channel is a 1 where there are walls
+        input_array[0, :, :] = game.board._grid == game.board.WALL
+
+        # Second channel is a 1-hot encoding of current player position.
+        player = game.get_current_player()
+        input_array[1, :, :] = game.board._grid == player
+
+        # Third channel is a 1-hot encoding of opponent position.
+        opponent = Player(1 - player)
+        input_array[2, :, :] = game.board._grid == opponent
+
+        # Fourth channel is current player walls remaining (all values the same)
+        input_array[3, :, :] = game.board._walls_remaining[player]
+
+        # Fifth channel is opponent walls remaining (all values the same)
+        input_array[4, :, :] = game.board._walls_remaining[opponent]
+
+        return input_array

--- a/deep_quoridor/src/agents/alphazero/resnet_network.py
+++ b/deep_quoridor/src/agents/alphazero/resnet_network.py
@@ -110,14 +110,18 @@ class ResnetNetwork(nn.Module):
 
     def game_to_input_array(self, game: Quoridor) -> np.ndarray:
         """
-        Convert Quoridor game state to tensor format for neural network.
+        Convert Quoridor game state to an input array for the neural network.
 
+        The returned array is 5xMxM, where M is the dimension of the combined
+        grid representation, which is twice the board dimension plus three.
 
-        1. Walls
-        2. Current player's position, as a 1-hot encoding
-        3. Opponent's position, as a 1-hot encoding
-        4. Current player walls remaining
-        5. Opponent walls remaining.
+        The 5 planes in the array are:
+
+            1. Walls (1 where there is a wall, zero otherwise)
+            2. Current player's position, as a 1-hot encoding
+            3. Opponent's position, as a 1-hot encoding
+            4. Current player walls remaining (same value for entire plane)
+            5. Opponent walls remaining (same value for the entire plane)
         """
         input_array = np.zeros((5, self.input_size, self.input_size), dtype=np.float32)
 

--- a/deep_quoridor/src/agents/alphazero/self_play_manager.py
+++ b/deep_quoridor/src/agents/alphazero/self_play_manager.py
@@ -106,7 +106,8 @@ class SelfPlayManager(threading.Thread):
                 results = sorted(self._results, key=lambda r: r.worker_id)
                 for r in results:
                     print(f"Worker {r.worker_id} replay buffer size: {len(r.replay_buffer)}")
-                    print(r.evaluator_statistics)
+                    if r.evaluator_statistics is not None:
+                        print(r.evaluator_statistics)
 
                     # NOTE: Make sure the replay buffer size for the training agent is large enough to hold
                     # the replay buffer results from all agents each epoch or else we'll end up discarding


### PR DESCRIPTION
There is a new param in AlphazeroParams called "nn_type" which defaults to "mlp" but can be changed to "resnet". Some of this code was generated by claude. I've gone through and read it and compared to the resnet structure used by alphazero, and I think it is doing the right thing.

In a future PR, I'd like to make the number of channels and number of residual blocks of resnet configurable via parameters. For now I've set the number of channels to 32 and the number of blocks to the width of the combined grid times 2 plus 2. Alphazero used 256 channels internally, but that is very slow - if things work well we can up it in later training runs. Alphazero used 20 residual blocks for chess and 40 for Go, so I followed the pattern of "a bit more than twice the width of the input array".

Since the resnet is much bigger than the mlp, it is also much slower. Self-play is ok when run on a big machine in lots of parallel processes. Training is still fast. Benchmarking is veeeeery slow since it only uses one process.

Here's the command I'm using to train on a hyperstack machine with an Nvidia L40:
```
train_alphazero.py -N 5 -W 3 -g 500 -e 10000 --max-steps=40 --num-workers 20 -w --benchmarks random greedy simple:branching_factor=8,nick=simple-bf8 simple:branching_factor=16,nick=simple-bf16 -p replay_buffer_size=50000,mcts_ucb_c=1.5,save_replay_buffer=first,mcts_noise_epsilon=0.25,mcts_n=2000,learning_rate=0.0001,batch_size=256,optimizer_iterations=100,validation_ratio=0.2,nn_type=resnet
```