### PR TITLE
Run benchmarks every N epochs

### DIFF
--- a/deep_quoridor/src/agents/alphazero/self_play_manager.py
+++ b/deep_quoridor/src/agents/alphazero/self_play_manager.py
@@ -217,13 +217,13 @@ def run_self_play_games(
                     continue
                 environments[env_idx].step(action_index)
 
-        game_i += n
         t1 = time.time()
         alphazero_agent.end_game_batch()
         num_truncated = n - len(finished_in)
         print(
             f"Worker {worker_id}: ({t1 - t0:.2f}s) Games {game_i}...{game_i + n - 1} / {num_games} ended after {sorted(finished_in)} turns. {num_truncated} truncated"
         )
+        game_i += n
 
     # TODO implement the stats for the per process evaluator
     result_queue.put(

--- a/deep_quoridor/src/train_alphazero.py
+++ b/deep_quoridor/src/train_alphazero.py
@@ -91,13 +91,14 @@ def train_alphazero(
             print("Not enough samples - skipping training")
 
         current_filename = training_agent.save_model_with_suffix(f"_epoch_{epoch}")
-        if wandb_train_plugin is not None and epoch < args.epochs - 1:
+        if wandb_train_plugin is not None and (epoch + 1) % args.benchmarks_every == 0 and epoch < args.epochs - 1:
             # Save the model where the plugin wants it and use the plugin to compute metrics.
             wandb_train_plugin.episode_count = game_num
             wandb_train_plugin.compute_tournament_metrics(str(current_filename))
 
     # Close the arena so the best model and the final model are uploaded to wandb
     if wandb_train_plugin is not None:
+        wandb_train_plugin.episode_count = game_num
         wandb_train_plugin.end_arena(None, [])
     else:
         Timer.log_totals()
@@ -182,6 +183,13 @@ if __name__ == "__main__":
         type=int,
         default=10,
         help="How many time to play against each opponent during benchmarks",
+    )
+    parser.add_argument(
+        "-be",
+        "--benchmarks_every",
+        type=int,
+        default=1,
+        help="Every how many epochs to compute the benchmark",
     )
     parser.add_argument("-w", "--wandb", nargs="?", const="", default=None, type=str)
     parser.add_argument(


### PR DESCRIPTION
When we do longer runs with a lot of epochs, there's no need to run an evaluation after every epoch, and considering how slow it is, we are better off running it less often.
With this, you can pass `--benchmarks_every` to train_alphazero to do it once in every N epochs.
As a bonus I included 2 unrelated small fixes 