### PR TITLE
Consistency text fix: use production policy builder

### DIFF
--- a/deep_quoridor/coding-agents/manual-update-validate-commit-pr-plan.md
+++ b/deep_quoridor/coding-agents/manual-update-validate-commit-pr-plan.md
@@ -1,0 +1,16 @@
+I'm using AGENTS.md
+
+# Manual Update Validate/Commit/PR Plan
+
+## Goal
+Validate recent manual edits still behave correctly, then commit, push, and open a PR against `main`.
+
+## Steps
+1. Identify tests that cover `alphazero.py` and `selfplay_real_model_reference.py` changes.
+2. Run targeted tests and checks in the project virtualenv.
+3. If tests pass, commit staged changes with required commit message format.
+4. Push branch and create PR to `main` with concise summary.
+
+## Notes
+- Keep commit history review-friendly.
+- Do not include unrelated changes.

--- a/deep_quoridor/coding-agents/remove-visit-probs-duplication-plan.md
+++ b/deep_quoridor/coding-agents/remove-visit-probs-duplication-plan.md
@@ -1,0 +1,12 @@
+I'm using AGENTS.md
+
+# Remove Visit-Prob Duplication Plan
+
+## Goal
+Eliminate duplicated MCTS visit-count normalization logic in AlphaZero agent code.
+
+## Steps
+1. Add one internal helper that computes normalized visit probabilities and performs the zero-visit guard.
+2. Reuse this helper from both policy-vector construction and action selection.
+3. Run diagnostics for the modified file.
+4. Update results markdown with this follow-up cleanup.

--- a/deep_quoridor/coding-agents/use-production-policy-vector-plan.md
+++ b/deep_quoridor/coding-agents/use-production-policy-vector-plan.md
@@ -1,0 +1,17 @@
+I'm using AGENTS.md
+
+# Use Production Policy Vector Plan
+
+## Goal
+Update the real-model selfplay reference script to use production AlphaZero policy-vector logic instead of re-implementing it.
+
+## Steps
+1. Add the smallest possible helper in `AlphaZeroAgent` that builds a full action-space policy vector from MCTS root children.
+2. Replace the local policy builder in `selfplay_real_model_reference.py` with a call to that helper.
+3. Keep behavior unchanged (same normalization and dtype) and avoid unrelated refactors.
+4. Run targeted validation for changed Python files.
+
+## Expected Outcome
+- No duplicated policy-vector implementation in the reference script.
+- Reference test path uses production code for policy reconstruction.
+- Minimal, review-friendly diff.

--- a/deep_quoridor/coding-agents/use-production-policy-vector-results.md
+++ b/deep_quoridor/coding-agents/use-production-policy-vector-results.md
@@ -1,0 +1,23 @@
+# Use Production Policy Vector Results
+
+## What changed
+- Added a production helper method on `AlphaZeroAgent` to construct a full action-space policy vector from MCTS root children visit counts.
+- Updated self-play training data collection to use the new helper instead of duplicating policy-vector logic inline.
+- Updated `selfplay_real_model_reference.py` to use the production helper, removing its local policy-vector implementation.
+
+## Why
+- The reference trace path was re-implementing policy-vector construction already present in production behavior.
+- Reusing production code reduces drift risk and keeps parity checks aligned with real agent behavior.
+
+## Validation
+- Checked both modified files with workspace diagnostics; no errors reported.
+
+## Follow-up cleanup
+- Removed duplicated visit-count normalization logic from `AlphaZeroAgent.get_action_batch`.
+- Added a single shared helper for root-child visit-probability normalization and reused it in both:
+	- policy-vector construction
+	- action-selection probability computation
+- Re-ran diagnostics on `alphazero.py`; no errors reported.
+
+## Notes
+- Behavior remains unchanged: same normalization, same dtype (`float32`), and same error condition when no MCTS visits are available.

--- a/deep_quoridor/src/agents/alphazero/alphazero.py
+++ b/deep_quoridor/src/agents/alphazero/alphazero.py
@@ -748,6 +748,21 @@ class AlphaZeroAgent(TrainableAgent):
         self.action_log.action_score_ranking(scores)
         self.action_log.action_text(root_action, f"{root_value:0.2f}")
 
+    def visit_probs_from_root_children(self, root_children) -> np.ndarray:
+        visit_counts = np.array([child.visit_count for child in root_children], dtype=np.float32)
+        visit_counts_sum = np.sum(visit_counts)
+        if visit_counts_sum == 0:
+            raise RuntimeError("No nodes visited during MCTS")
+        return visit_counts / visit_counts_sum
+
+    def build_policy_vector_from_root_children(self, root_children, visit_probs) -> np.ndarray:
+        """Build a full action-space policy vector from root children visit counts."""
+        policy = np.zeros(self.action_encoder.num_actions, dtype=np.float32)
+        for i, child in enumerate(root_children):
+            action_index = self.action_encoder.action_to_index(child.action_taken)
+            policy[action_index] = visit_probs[i]
+        return policy
+
     def get_action_batch(self, observations_with_ids: list[tuple[int, dict]]) -> list[tuple[int, int]]:
         """
         Get actions for multiple observations.  Each entry in observation_with_ids needs a distinct id that can be
@@ -771,12 +786,7 @@ class AlphaZeroAgent(TrainableAgent):
         for game_idx, root_children, root_value, game, player in zip(
             game_indices, root_children_batch, root_value_batch, games, players
         ):
-            visit_counts = np.array([child.visit_count for child in root_children])
-            visit_counts_sum = np.sum(visit_counts)
-            if visit_counts_sum == 0:
-                raise RuntimeError("No nodes visited during MCTS")
-
-            visit_probs = visit_counts / visit_counts_sum
+            visit_probs = self.visit_probs_from_root_children(root_children)
 
             # _log_action is used to display information about the action (e.g. probabilities of moves) in the GUI.
             # We allow that only when there's one game at the time, since we won't be playing multiple games and
@@ -817,11 +827,7 @@ class AlphaZeroAgent(TrainableAgent):
 
             # Store training data if in training mode
             if self.params.training_mode:
-                # Convert visit counts to policy target (normalized)
-                policy_target = np.zeros(self.action_encoder.num_actions, dtype=np.float32)
-                for child in root_children:
-                    action_index = self.action_encoder.action_to_index(child.action_taken)
-                    policy_target[action_index] = child.visit_count / visit_counts_sum
+                policy_target = self.build_policy_vector_from_root_children(root_children, visit_probs)
                 self.store_training_data(game, policy_target, player, game_idx)
 
         return actions

--- a/deep_quoridor/src/selfplay_real_model_reference.py
+++ b/deep_quoridor/src/selfplay_real_model_reference.py
@@ -29,6 +29,7 @@ import os
 import random
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -72,19 +73,6 @@ def tensor_to_hex(arr):
 
 def float32_to_hex(value):
     return np.asarray([value], dtype=np.float32).tobytes().hex()
-
-
-def build_policy_vector(root_children, action_encoder):
-    visit_counts = np.array([child.visit_count for child in root_children], dtype=np.int64)
-    total_visits = int(visit_counts.sum())
-    if total_visits <= 0:
-        raise RuntimeError("No nodes visited during MCTS")
-
-    policy = np.zeros(action_encoder.num_actions, dtype=np.float32)
-    for child in root_children:
-        idx = action_encoder.action_to_index(child.action_taken)
-        policy[idx] = np.float32(child.visit_count / total_visits)
-    return policy
 
 
 def emit_snapshot(agent, game, step, player_enum):
@@ -144,11 +132,11 @@ def run_trace_and_write_game(
 
     agent = AlphaZeroAgent(board_size=board_size, max_walls=max_walls, max_steps=max_steps, params=params)
 
-    captured = {"children_batch": None, "root_values": None}
+    captured: dict[str, Any] = {"children_batch": None, "root_values": None}
     original_search_batch = agent.mcts.search_batch
 
-    def wrapped_search_batch(games):
-        children_batch, root_values = original_search_batch(games)
+    def wrapped_search_batch(initial_games):
+        children_batch, root_values = original_search_batch(initial_games)
         captured["children_batch"] = children_batch
         captured["root_values"] = root_values
         return children_batch, root_values
@@ -185,7 +173,8 @@ def run_trace_and_write_game(
 
         root_children = children_batch[0]
         root_value = float(root_values[0])
-        policy = build_policy_vector(root_children, game.action_encoder)
+        visit_probs = agent.visit_probs_from_root_children(root_children)
+        policy = agent.build_policy_vector_from_root_children(root_children, visit_probs)
 
         print(f"V,{step},{float32_to_hex(np.float32(root_value))}")
         print(f"Q,{step},{policy.astype(np.float32).tobytes().hex()}")


### PR DESCRIPTION
Use AlphaZeroAgent helpers in the real-model parity script so policy\nconstruction follows the production path and does not drift over time.\n\nAlso remove duplicated visit-probability logic in get_action_batch by\nsharing a single helper used for both sampling and policy targets.