### PR TITLE
AI Training Reports

### DIFF
--- a/deep_quoridor/experiments/B5W3/cucu-01.yaml
+++ b/deep_quoridor/experiments/B5W3/cucu-01.yaml
@@ -1,0 +1,84 @@
+run_id: cucu-01-$DATETIME
+quoridor:
+  board_size: 5
+  max_walls: 3
+  max_steps: 60
+alphazero:
+  network:
+    type: resnet
+    num_blocks: 4
+    num_channels: 64
+  mcts_n: 400
+  mcts_c_puct: 1.2
+wandb:
+  project: B5W3
+  upload_model:
+    every: 100 models
+    when_max:
+      - raw_win_perc
+      - p2_win_perc
+    when_min:
+      - dumb_score
+self_play:
+  num_workers: 2
+  parallel_games: 8
+  alphazero:
+    mcts_noise_epsilon: 0.25
+training:
+  games_per_training_step: 25.0
+  learning_rate: 0.0002
+  batch_size: 2048
+  weight_decay: 0.0001
+  replay_buffer_size: 20000
+  max_cached_games: 20000
+benchmarks:
+  - every: 10 models
+    jobs:
+      - type: tournament
+        prefix: raw
+        alphazero:
+          mcts_n: 0
+        times: 100
+        opponents:
+          - random
+          - greedy:p_random=0.3,nick=greedy-03
+          - greedy:p_random=0.1,nick=greedy-01
+          - greedy
+          - simple:branching_factor=8,nick=simple-bf8
+          - simple:branching_factor=16,nick=simple-bf16
+      - type: dumb_score
+        prefix: raw
+        alphazero:
+          mcts_n: 0
+  - every: 100 models
+    jobs:
+      - type: agent_evolution
+        prefix: raw
+        alphazero:
+          mcts_n: 0
+        top_n: 5
+        times: 10
+  - every: 100 models
+    jobs:
+      - type: tournament
+        prefix: ""
+        times: 20
+        opponents:
+          - random
+          - greedy:p_random=0.3,nick=greedy-03
+          - greedy:p_random=0.1,nick=greedy-01
+          - greedy
+          - simple:branching_factor=8,nick=simple-bf8
+          - simple:branching_factor=16,nick=simple-bf16
+      - type: dumb_score
+        prefix: ""
+  - every: 100 models
+    jobs:
+      - type: tournament
+        prefix: "hard"
+        times: 4
+        opponents:
+          - simple:branching_factor=256,nick=simple,max_depth=6
+ai_report:
+  every: 1 hour
+  model: sonnet

--- a/deep_quoridor/src/ai_report_cli.py
+++ b/deep_quoridor/src/ai_report_cli.py
@@ -49,6 +49,14 @@ def main() -> int:
         help="AI backend to use (default: claude).",
     )
     parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Model identifier passed to the AI backend. For Claude: 'sonnet', "
+            "'opus', 'haiku', or a full model ID. Defaults to the backend's default."
+        ),
+    )
+    parser.add_argument(
         "-g",
         "--guidance",
         default=None,
@@ -64,7 +72,8 @@ def main() -> int:
         f"from project '{args.project}'...",
         file=sys.stderr,
     )
-    print(f"Running {args.ai}...", file=sys.stderr)
+    model_label = args.model or "default"
+    print(f"Running {args.ai} (model={model_label})...", file=sys.stderr)
 
     try:
         text = generate_on_demand_report(
@@ -73,6 +82,7 @@ def main() -> int:
             ai=args.ai,
             entity=args.entity,
             guidance=args.guidance,
+            model=args.model,
         )
     except Exception as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/deep_quoridor/src/ai_report_cli.py
+++ b/deep_quoridor/src/ai_report_cli.py
@@ -1,0 +1,88 @@
+"""Generate an AI training report on demand for a wandb run group.
+
+Useful for:
+  - Generating reports on older / completed runs.
+  - Iterating on the prompt without having to spin up training.
+  - Asking the AI specific questions via ``--guidance``.
+
+The report is printed to stdout. Nothing is saved to disk and nothing is
+uploaded to wandb. Pipe to a file if you want to keep a copy:
+
+    python deep_quoridor/src/ai_report_cli.py my-run-20260415-1340 \\
+        --project B5W3 > report.md
+
+A logical ``<run_id>`` (same name as the local ``runs/<run_id>/`` directory)
+maps to a wandb group containing the training, benchmark, and ai-report runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from v2.ai_report import SUPPORTED_AIS, generate_on_demand_report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate an AI training report on demand for a wandb run group.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "run_id",
+        help="Logical run_id (the wandb group name — same as the local runs/<id>/ dir).",
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="wandb project containing the run.",
+    )
+    parser.add_argument(
+        "--entity",
+        default=None,
+        help="wandb entity (user or team). Optional; defaults to your wandb default.",
+    )
+    parser.add_argument(
+        "--ai",
+        default="claude",
+        choices=list(SUPPORTED_AIS),
+        help="AI backend to use (default: claude).",
+    )
+    parser.add_argument(
+        "-g",
+        "--guidance",
+        default=None,
+        help=(
+            "Extra text appended to the prompt — use it to ask a specific question, "
+            "focus on a particular metric, or steer the analysis."
+        ),
+    )
+    args = parser.parse_args()
+
+    print(
+        f"Fetching wandb metrics for group '{args.run_id}' "
+        f"from project '{args.project}'...",
+        file=sys.stderr,
+    )
+    print(f"Running {args.ai}...", file=sys.stderr)
+
+    try:
+        text = generate_on_demand_report(
+            project=args.project,
+            group=args.run_id,
+            ai=args.ai,
+            entity=args.entity,
+            guidance=args.guidance,
+        )
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(text)
+    if not text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deep_quoridor/src/train_v2.py
+++ b/deep_quoridor/src/train_v2.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from v2 import benchmarks, load_config_and_setup_run, self_play, train
+from v2 import benchmarks, check_ai_available, load_config_and_setup_run, run_ai_reporter, self_play, train
 from v2.common import ShutdownSignal
 
 # Prevents getting messages in the console every few lines telling you to install weave
@@ -30,6 +30,15 @@ if __name__ == "__main__":
 
     config = load_config_and_setup_run(args.config_file, runs_dir, overrides=args.overrides)
 
+    # Validate AI report prerequisites before spawning anything, so a misconfigured
+    # run aborts early instead of failing silently inside a sibling process.
+    if config.ai_report is not None:
+        try:
+            check_ai_available(config.ai_report.ai)
+        except Exception as e:
+            print(f"ERROR: {e}")
+            exit(1)
+
     mp.set_start_method("spawn", force=True)
 
     # Make sure we don't have the shutdown signal from a previous run
@@ -40,6 +49,11 @@ if __name__ == "__main__":
 
     benchmark_processes = benchmarks.create_benchmark_processes(config)
     [p.start() for p in benchmark_processes]
+
+    ai_report_process = None
+    if config.ai_report is not None:
+        ai_report_process = mp.Process(target=run_ai_reporter, args=[config])
+        ai_report_process.start()
 
     self_play_processes = []
     rust_subprocesses = []
@@ -73,16 +87,20 @@ if __name__ == "__main__":
     ShutdownSignal.signal(config)
     print("Shutting down!")
 
-    b_count_prev, sf_count_prev = -1, -1
+    b_count_prev, sf_count_prev, ai_count_prev = -1, -1, -1
     while True:
         b_count = sum([p.is_alive() for p in benchmark_processes])
         sf_count = sum([p.is_alive() for p in self_play_processes])
         sf_count += sum([p.poll() is None for p in rust_subprocesses])
-        if b_count_prev != b_count or sf_count_prev != sf_count:
-            print(f"Waiting for {b_count} benchmark processes and {sf_count} self_play processes")
-            b_count_prev, sf_count_prev = b_count, sf_count
+        ai_count = 1 if ai_report_process is not None and ai_report_process.is_alive() else 0
+        if b_count_prev != b_count or sf_count_prev != sf_count or ai_count_prev != ai_count:
+            print(
+                f"Waiting for {b_count} benchmark processes, {sf_count} self_play processes"
+                f" and {ai_count} ai_report processes"
+            )
+            b_count_prev, sf_count_prev, ai_count_prev = b_count, sf_count, ai_count
 
-        if (b_count + sf_count) == 0:
+        if (b_count + sf_count + ai_count) == 0:
             break
         time.sleep(1)
 

--- a/deep_quoridor/src/v2/__init__.py
+++ b/deep_quoridor/src/v2/__init__.py
@@ -10,8 +10,12 @@ __all__ = [
     "GameInfo",
     "ShutdownSignal",
     "upload_model",
+    "check_ai_available",
+    "run_ai_reporter",
+    "generate_on_demand_report",
 ]
 
+from v2.ai_report import check_ai_available, generate_on_demand_report, run_ai_reporter
 from v2.benchmarks import create_benchmark_processes
 from v2.common import JobTrigger, MockWandb, ShutdownSignal, create_alphazero, upload_model
 from v2.config import load_config_and_setup_run

--- a/deep_quoridor/src/v2/ai_report.py
+++ b/deep_quoridor/src/v2/ai_report.py
@@ -1,0 +1,577 @@
+"""Periodic AI-generated training reports.
+
+When ``config.ai_report`` is set, ``train_v2`` spawns :func:`run_ai_reporter`
+in a sibling process. This process:
+
+1. On startup, generates a one-time *context document* (``reports/context.md``)
+   by asking the AI to read the config and source code and explain the run's
+   hyperparameters and project-specific metrics (e.g. ``dumb_score``).
+   If ``reports/context.md`` already exists (resumed run), regeneration is
+   skipped.
+
+2. Loops on a :class:`~v2.common.JobTrigger` parsed from ``config.ai_report.every``.
+   Each tick, it asks the AI to produce the next ``reports/report_NNN.md``,
+   pointing the AI at the context doc, the previous report (for delta
+   analysis), and a fresh wandb metrics snapshot. Report numbering continues
+   from the highest existing ``report_*.md`` on disk, so resume works.
+
+3. Each report is uploaded to wandb as an artifact of type ``ai_report``.
+
+The AI is invoked as a subprocess (``claude -p <prompt>``) with the run
+directory as the working directory, so it can read ``config.yaml``, the
+metrics snapshot, and prior reports directly from the filesystem.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import traceback
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+import wandb
+from v2.common import JobTrigger, MockWandb, ShutdownSignal
+from v2.config import Config
+from v2.wandb_metrics import dump_group_metrics
+
+SUPPORTED_AIS = ("claude",)
+
+# How long to wait for the AI subprocess before killing it.
+AI_SUBPROCESS_TIMEOUT_SECONDS = 20 * 60
+
+
+# ---------------------------------------------------------------------------
+# AI backend abstraction
+# ---------------------------------------------------------------------------
+
+
+class AIBackend(ABC):
+    """Run an AI tool over a prompt."""
+
+    name: str
+
+    @abstractmethod
+    def check_available(self) -> None:
+        """Raise RuntimeError with a helpful message if the tool isn't installed."""
+
+    @abstractmethod
+    def generate(self, prompt: str, cwd: Path) -> None:
+        """Invoke the AI with ``prompt``, running inside ``cwd``.
+
+        The prompt must tell the AI where to write its output; this method does
+        not return the AI's stdout.
+        """
+
+    @abstractmethod
+    def generate_text(self, prompt: str, cwd: Path) -> str:
+        """Invoke the AI with ``prompt`` inside ``cwd`` and return its stdout.
+
+        Used for on-demand reports where the output goes back to the user
+        instead of to disk.
+        """
+
+
+class ClaudeBackend(AIBackend):
+    name = "claude"
+
+    def check_available(self) -> None:
+        if shutil.which("claude") is None:
+            raise RuntimeError(
+                "AI reports are enabled (ai_report.ai='claude') but the 'claude' CLI "
+                "was not found on PATH. Install Claude Code from "
+                "https://claude.com/claude-code and make sure `claude` is runnable, "
+                "or remove the 'ai_report' section from the config."
+            )
+
+    def _run(self, prompt: str, cwd: Path) -> subprocess.CompletedProcess:
+        # --print (non-interactive) with --permission-mode acceptEdits so the AI
+        # can read source files and (in file-writing mode) write reports without
+        # interactive prompts.
+        cmd = [
+            "claude",
+            "--print",
+            "--permission-mode",
+            "acceptEdits",
+            prompt,
+        ]
+        print(f"[ai_report] invoking claude (cwd={cwd})")
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=AI_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"claude exited with code {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+        return result
+
+    def generate(self, prompt: str, cwd: Path) -> None:
+        self._run(prompt, cwd)
+
+    def generate_text(self, prompt: str, cwd: Path) -> str:
+        return self._run(prompt, cwd).stdout
+
+
+def backend_for(ai: str) -> AIBackend:
+    if ai == "claude":
+        return ClaudeBackend()
+    raise ValueError(f"Unknown ai_report.ai={ai!r}. Supported: {', '.join(SUPPORTED_AIS)}")
+
+
+# Backward-compatible alias used inside this module.
+_backend_for = backend_for
+
+
+def check_ai_available(ai: str) -> None:
+    """Raise RuntimeError with a helpful message if the requested AI isn't installed.
+
+    Called from train_v2.py at startup, before any processes are spawned, so an
+    incorrectly configured run aborts early instead of silently failing later.
+    """
+    backend_for(ai).check_available()
+
+
+# ---------------------------------------------------------------------------
+# Report numbering
+# ---------------------------------------------------------------------------
+
+
+REPORT_GLOB = "report_*.md"
+
+
+def _report_path(reports_dir: Path, index: int) -> Path:
+    return reports_dir / f"report_{index:03d}.md"
+
+
+def _report_index(path: Path) -> Optional[int]:
+    stem = path.stem  # "report_007"
+    try:
+        return int(stem.split("_", 1)[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _next_report_index(reports_dir: Path) -> int:
+    """1-indexed next report number.
+
+    Uses ``max(existing index) + 1`` so gaps in the sequence never cause a
+    report to be overwritten.
+    """
+    indices = [i for i in (_report_index(p) for p in reports_dir.glob(REPORT_GLOB)) if i is not None]
+    return max(indices) + 1 if indices else 1
+
+
+def _latest_report(reports_dir: Path) -> Optional[Path]:
+    candidates = [(i, p) for p in reports_dir.glob(REPORT_GLOB) for i in [_report_index(p)] if i is not None]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda t: t[0])[1]
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+
+def _source_paths_for_context(src_root: Path) -> list[Path]:
+    """Source files the AI should read to understand the training pipeline."""
+    return [
+        src_root / "v2" / "config.py",
+        src_root / "v2" / "trainer.py",
+        src_root / "v2" / "benchmarks.py",
+        src_root / "v2" / "self_play.py",
+        src_root / "metrics.py",
+        src_root / "agents" / "alphazero" / "mcts.py",
+        src_root / "agents" / "alphazero" / "nn_evaluator.py",
+        src_root / "agents" / "alphazero" / "resnet_network.py",
+        src_root / "agents" / "alphazero" / "mlp_network.py",
+    ]
+
+
+def _build_context_prompt(config: Config, src_root: Path, context_md: Path) -> str:
+    source_list = "\n".join(f"- {p}" for p in _source_paths_for_context(src_root))
+    return f"""You are helping document a reinforcement-learning training run so that
+future AI reports (generated during training) have the context they need to
+interpret metrics correctly.
+
+Please produce a single markdown file at:
+
+    {context_md}
+
+It must be self-contained: later reports will read only this file plus the
+previous report, not the original source.
+
+Read the run's config at:
+
+    {config.paths.config_file}
+
+And read these source files to understand what the training does and what the
+metrics mean (especially the project-specific ones like `dumb_score`):
+
+{source_list}
+
+The markdown file should cover:
+
+1. A short summary of this run's configuration — board size, walls, network
+   type, MCTS settings, self-play and training hyperparameters, benchmark
+   schedules. Call out any values that differ from what looks like the
+   project's common defaults.
+2. What each logged wandb metric means. In particular, explain `dumb_score`
+   (see metrics.py) — what it measures, how it's computed, whether lower or
+   higher is better. Also explain the tournament metrics (win_perc, relative_elo,
+   absolute_elo, etc.), policy_loss / value_loss / total_loss, and model_lag.
+3. How the wandb group is structured: a logical run_id '{config.run_id}' maps
+   to a wandb group under project '{config.wandb.project if config.wandb else "(no wandb)"}'
+   containing `<run_id>-training`, `<run_id>-benchmark-<idx>`, and
+   `<run_id>-ai-report`. Explain the 'Model version' x-axis convention.
+4. Any non-obvious project conventions you notice (e.g. the `every: N models`
+   scheduling idiom, `raw_` prefix meaning, `dumb_score` scale 0-100 where
+   lower is better).
+
+Keep it tight — aim for something a future report can skim in under a minute.
+Do not write anything outside the markdown file. When you're done, just confirm
+with the path you wrote."""
+
+
+def _build_report_prompt(
+    config: Config,
+    context_md: Path,
+    prev_report: Optional[Path],
+    report_path: Path,
+    metrics_snapshot: Path,
+) -> str:
+    prev_line = (
+        f"Previous report (for comparing progress):\n    {prev_report}\n"
+        if prev_report is not None
+        else "This is the first report for this run — there is no previous report.\n"
+    )
+    return f"""You are generating a periodic AI report on an in-progress training run.
+
+Read first:
+
+    {context_md}
+
+{prev_line}
+A fresh wandb metrics snapshot for this run's group has been written to:
+
+    {metrics_snapshot}
+
+It is a JSON dump with the shape:
+    {{ "project", "group", "runs": {{ <wandb run name>: {{ "summary", "history", ... }} }} }}
+Use it as your primary data source. You may also read the run's config at
+{config.paths.config_file} and any files under {config.paths.run_dir} if useful.
+
+Write the report to:
+
+    {report_path}
+
+The report MUST contain these sections, in this order:
+
+1. **General observations about training progress.** How are losses evolving?
+   How are benchmark metrics (win_perc, relative_elo, dumb_score) trending?
+   How many models trained so far? Any anomalies?
+2. **Progress since the last report.** If there is no previous report, say so.
+   Otherwise, concretely compare: what changed in the metrics, did progress
+   continue / stall / regress? Reference specific numbers.
+3. **Likelihood this run produces a strong model.** Either state
+   "too early to determine" (with a sentence on what you'd need to see to
+   commit to a number) or give a score 0-10 with a one-paragraph justification.
+4. **Is it worth continuing this run?** Especially if the likelihood is low,
+   argue whether continuing will at least yield useful signal for tuning
+   hyperparameters for the next run, or whether it's better to stop now.
+5. **Recommended hyperparameter adjustments for the next run.** Concrete
+   suggestions tied to specific config fields (learning_rate, mcts_n,
+   batch_size, network architecture, etc.), each with a one-line rationale.
+
+Keep the report readable (headings, short paragraphs, bullets where helpful).
+Be honest about uncertainty. Do not write anything outside {report_path.name}."""
+
+
+def _build_on_demand_prompt(
+    project: str,
+    group: str,
+    metrics_snapshot: Path,
+    repo_root: Path,
+    guidance: Optional[str] = None,
+) -> str:
+    """Prompt for the on-demand CLI path: no file outputs, just stdout text."""
+    sources = [
+        "deep_quoridor/src/v2/config.py",
+        "deep_quoridor/src/v2/trainer.py",
+        "deep_quoridor/src/v2/benchmarks.py",
+        "deep_quoridor/src/metrics.py",
+    ]
+    source_list = "\n".join(f"- {repo_root / p}" for p in sources)
+
+    guidance_block = ""
+    if guidance:
+        guidance_block = (
+            "\nSPECIFIC GUIDANCE FROM THE USER — address this directly and prominently "
+            "in your report, in addition to the standard sections below:\n\n"
+            f"{guidance}\n"
+        )
+
+    return f"""You are generating an ad-hoc AI report on a training run for the
+deep_quoridor Quoridor RL project.
+
+A wandb metrics snapshot for the group '{group}' in project '{project}' has been
+written to:
+
+    {metrics_snapshot}
+
+It is a JSON dump with shape:
+    {{ "project", "group", "runs": {{ <wandb run name>: {{ "config", "summary", "history", ... }} }} }}
+
+Each run's "config" field holds wandb's native config dict (equivalent to the
+training config.yaml). Use the snapshot as your primary data source — it is
+self-contained, even for old runs with no local files.
+
+To understand what the metrics mean and the project's conventions, read these
+source files (absolute paths):
+{source_list}
+
+Key conventions to note:
+- `dumb_score` is a 0-100 metric (lower = better) — see metrics.py.
+- Tournament metrics use a `{{prefix}}` prefix (`raw_`, '', etc.); common keys
+  are `{{prefix}}win_perc`, `{{prefix}}relative_elo`, `{{prefix}}absolute_elo`.
+- The "Model version" axis increments once per trained model.
+- A logical run_id maps to a wandb group with `<run_id>-training`,
+  `<run_id>-benchmark-<idx>`, and optionally `<run_id>-ai-report`.
+{guidance_block}
+IMPORTANT: respond with the report as your final text answer. Do NOT write any
+files — the user is capturing your stdout and printing it.
+
+Produce a markdown report with these sections (adapted for ad-hoc use):
+
+1. **Run summary.** One paragraph: what this run was configured to do
+   (board size, walls, network, MCTS, self-play, key hyperparameters),
+   and how far it got.
+2. **General observations about training progress.** Loss trajectories,
+   benchmark trends, dumb_score evolution, anomalies. Cite specific numbers.
+3. **Likelihood this run produced a strong model.** Either "too early to
+   determine" (with what you'd want to see), or a 0-10 score with a
+   one-paragraph justification.
+4. **Was/is it worth continuing this run?** Even if the answer is no, call out
+   what signal (if any) it yields for tuning the next run.
+5. **Recommended hyperparameter adjustments for the next run.** Concrete
+   suggestions tied to specific config fields, each with a one-line rationale.
+
+Be honest about uncertainty. Keep it readable."""
+
+
+def generate_on_demand_report(
+    project: str,
+    group: str,
+    ai: str = "claude",
+    entity: Optional[str] = None,
+    guidance: Optional[str] = None,
+) -> str:
+    """Generate an AI training report on demand and return it as text.
+
+    Does not write any files to disk and does not upload anything. Fetches
+    wandb metrics for the group, invokes the AI, and returns its response.
+
+    Args:
+        project: wandb project name.
+        group: wandb group name (equivalent to the logical run_id).
+        ai: AI backend to use. Currently only "claude".
+        entity: wandb entity (user/team), optional.
+        guidance: Optional extra text appended to the prompt. Useful for asking
+            the AI specific questions or steering the analysis.
+
+    Returns:
+        The AI's response text — a markdown report.
+    """
+    backend = backend_for(ai)
+    backend.check_available()
+
+    # ai_report.py lives at <repo>/deep_quoridor/src/v2/ai_report.py
+    # -> parents: v2 -> src -> deep_quoridor -> <repo root>
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+
+    with tempfile.TemporaryDirectory(prefix="ai_report_on_demand_") as tmp:
+        metrics_snapshot = Path(tmp) / "metrics.json"
+        dump_group_metrics(
+            project=project,
+            group=group,
+            out_path=metrics_snapshot,
+            entity=entity,
+        )
+        prompt = _build_on_demand_prompt(
+            project=project,
+            group=group,
+            metrics_snapshot=metrics_snapshot,
+            repo_root=repo_root,
+            guidance=guidance,
+        )
+        # cwd = repo root so the AI can freely read source files; the metrics
+        # snapshot is passed by absolute path.
+        return backend.generate_text(prompt, cwd=repo_root)
+
+
+# ---------------------------------------------------------------------------
+# wandb plumbing
+# ---------------------------------------------------------------------------
+
+
+def _init_wandb_run(config: Config):
+    """Initialize the ai_report wandb run (or a mock if wandb is disabled)."""
+    if not config.wandb:
+        return MockWandb()
+    run_id = f"{config.run_id}-ai-report"
+    wandb_run = wandb.init(
+        project=config.wandb.project,
+        job_type="ai_report",
+        group=config.run_id,
+        name=run_id,
+        id=run_id,
+        resume="allow",
+    )
+    wandb.define_metric("Model version", hidden=True)
+    wandb.define_metric("*", "Model version")
+    return wandb_run
+
+
+def _upload_report(wandb_run, config: Config, report_path: Path, index: int) -> None:
+    """Upload a report as a wandb artifact. Silent no-op if wandb is mocked."""
+    if isinstance(wandb_run, MockWandb):
+        return
+    try:
+        # Prefix the artifact name with the project so that two runs with the
+        # same run_id in different projects don't land on the same artifact.
+        artifact_name = f"{config.wandb.project}-{config.run_id}-ai-report"
+        artifact = wandb.Artifact(
+            artifact_name,
+            type="ai_report",
+            metadata={
+                "report_index": index,
+                "run_id": config.run_id,
+                "project": config.wandb.project,
+            },
+        )
+        artifact.add_file(local_path=str(report_path))
+        wandb_run.log_artifact(artifact, aliases=[f"r{index:03d}", "latest"])
+        print(f"[ai_report] uploaded {report_path.name} as artifact {artifact_name}:r{index:03d}")
+    except Exception as e:
+        print(f"[ai_report] !!! failed to upload report artifact: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _src_root() -> Path:
+    # This file lives at deep_quoridor/src/v2/ai_report.py
+    return Path(__file__).resolve().parent.parent
+
+
+def _ensure_context_doc(config: Config, backend: AIBackend) -> Path:
+    context_md = config.paths.reports / "context.md"
+    if context_md.exists():
+        print(f"[ai_report] reusing existing context doc at {context_md}")
+        return context_md
+
+    print(f"[ai_report] generating context doc at {context_md}")
+    prompt = _build_context_prompt(config, _src_root(), context_md)
+    backend.generate(prompt, cwd=config.paths.run_dir)
+    if not context_md.exists():
+        raise RuntimeError(f"AI did not produce {context_md} as instructed. Aborting periodic reports.")
+    return context_md
+
+
+def _generate_one_report(
+    config: Config,
+    backend: AIBackend,
+    context_md: Path,
+    wandb_run,
+) -> Optional[Path]:
+    index = _next_report_index(config.paths.reports)
+    report_path = _report_path(config.paths.reports, index)
+    prev_report = _latest_report(config.paths.reports)
+
+    metrics_snapshot = config.paths.reports / f".metrics_{index:03d}.json"
+    if config.wandb:
+        try:
+            dump_group_metrics(
+                project=config.wandb.project,
+                group=config.run_id,
+                out_path=metrics_snapshot,
+            )
+        except Exception as e:
+            print(f"[ai_report] !!! failed to dump wandb metrics: {e}")
+            # We still attempt the report; the AI can fall back to reading files.
+    else:
+        metrics_snapshot.write_text('{"note": "wandb disabled — no metrics snapshot"}')
+
+    prompt = _build_report_prompt(
+        config=config,
+        context_md=context_md,
+        prev_report=prev_report,
+        report_path=report_path,
+        metrics_snapshot=metrics_snapshot,
+    )
+
+    print(f"[ai_report] generating {report_path.name}")
+    try:
+        backend.generate(prompt, cwd=config.paths.run_dir)
+    except subprocess.TimeoutExpired:
+        print(f"[ai_report] !!! AI subprocess timed out for {report_path.name}")
+        return None
+    except Exception as e:
+        print(f"[ai_report] !!! AI subprocess failed: {e}")
+        return None
+
+    if not report_path.exists():
+        print(f"[ai_report] !!! AI did not produce {report_path} — skipping upload")
+        return None
+
+    _upload_report(wandb_run, config, report_path, index)
+    return report_path
+
+
+def run_ai_reporter(config: Config) -> None:
+    """Sibling-process entry point. Runs until ShutdownSignal is set."""
+    if config.ai_report is None:
+        return
+
+    try:
+        backend = _backend_for(config.ai_report.ai)
+    except Exception as e:
+        print(f"[ai_report] cannot start reporter: {e}")
+        return
+
+    # Don't start racing before the trainer has even written its first model.
+    from v2.yaml_models import LatestModel
+
+    LatestModel.wait_for_creation(config)
+
+    wandb_run = _init_wandb_run(config)
+
+    try:
+        context_md = _ensure_context_doc(config, backend)
+    except Exception as e:
+        print(f"[ai_report] failed to prepare context doc: {e}")
+        traceback.print_exc()
+        return
+
+    trigger = JobTrigger.from_string(config, config.ai_report.every)
+
+    # Unlike benchmarks, we do NOT run a report at t=0: a baseline report would
+    # have nothing to analyze yet. Wait for the first trigger interval to elapse
+    # before generating the first report.
+    while trigger.wait(lambda: ShutdownSignal.is_set(config)):
+        try:
+            _generate_one_report(config, backend, context_md, wandb_run)
+        except Exception as e:
+            # One bad report shouldn't kill the whole reporter.
+            print(f"[ai_report] !!! unexpected error during report generation: {e}")
+            traceback.print_exc()
+
+    print("[ai_report] shutdown signal received, exiting")

--- a/deep_quoridor/src/v2/ai_report.py
+++ b/deep_quoridor/src/v2/ai_report.py
@@ -257,6 +257,35 @@ Do not write anything outside the markdown file. When you're done, just confirm
 with the path you wrote."""
 
 
+def _hyperparameter_and_code_sections(schema_reference_sentence: str) -> str:
+    """Sections 5 and 6 of a training report, shared by the periodic and on-demand
+    prompts. ``schema_reference_sentence`` fills in the one part that differs
+    between callers: where to find the authoritative list of tweakable fields.
+    The periodic prompt points at a precomputed context doc; the on-demand prompt
+    points directly at ``config.py``.
+    """
+    return f"""5. **Recommended hyperparameter adjustments for the next run.**
+
+   CRITICAL CONSTRAINT: every recommendation in this section MUST correspond to
+   a field that already exists in the project's config schema. {schema_reference_sentence}
+   Reference each suggestion by its dotted config path
+   (e.g. `training.learning_rate`, `alphazero.mcts_n`,
+   `alphazero.network.num_channels`, `self_play.alphazero.mcts_noise_epsilon`,
+   `training.batch_size`). If a value must be an existing enum / literal
+   (e.g. `alphazero.network.type` is `mlp` or `resnet`), respect that.
+   DO NOT suggest anything that requires code changes here (no new schedulers,
+   no new loss functions, no new network types — those go in section 6).
+   Each suggestion: config path, proposed value (or direction), one-line
+   rationale tied to a metric you observed.
+
+6. **(Optional) Suggested code changes / new features.** ONLY include this
+   section if there's something concrete worth implementing — e.g. "add cosine
+   learning-rate decay", "support a different optimizer", "expose a new MCTS
+   parameter". Each item: what to implement, why the metrics suggest it would
+   help, and (if relevant) which file would change. If nothing concrete comes
+   to mind, OMIT this section entirely — do not fill it with speculation."""
+
+
 def _build_report_prompt(
     config: Config,
     context_md: Path,
@@ -303,28 +332,12 @@ The report MUST contain these sections, in this order:
 4. **Is it worth continuing this run?** Especially if the likelihood is low,
    argue whether continuing will at least yield useful signal for tuning
    hyperparameters for the next run, or whether it's better to stop now.
-5. **Recommended hyperparameter adjustments for the next run.**
-
-   CRITICAL CONSTRAINT: every recommendation in this section MUST correspond to
-   a field that already exists in the project's config schema. The context doc
-   you read above enumerates the authoritative list. You can also cross-check
-   against the pydantic models at {_src_root() / "v2" / "config.py"}, or the
-   run's `config.yaml` at {config.paths.config_file}. Reference each suggestion
-   by its dotted config path (e.g. `training.learning_rate`,
-   `alphazero.mcts_n`, `alphazero.network.num_channels`,
-   `self_play.alphazero.mcts_noise_epsilon`, `training.batch_size`).
-   If a value must be an existing enum / literal (e.g. `alphazero.network.type`
-   is `mlp` or `resnet`), respect that.
-   DO NOT suggest anything that requires code changes here (no new schedulers,
-   no new loss functions, no new network types — those go in section 6).
-   Each suggestion gets one line of rationale tied to a metric you observed.
-
-6. **(Optional) Suggested code changes / new features.** ONLY include this
-   section if there's something concrete worth implementing — e.g. "add cosine
-   learning-rate decay", "support a different optimizer", "expose a new MCTS
-   parameter". Each item: what to implement, why the metrics suggest it would
-   help, and (if relevant) which file would change. If nothing concrete comes
-   to mind, OMIT this section entirely — do not fill it with speculation.
+{_hyperparameter_and_code_sections(
+    f"The context doc you read above enumerates the authoritative list. "
+    f"You can also cross-check against the pydantic models at "
+    f"{_src_root() / 'v2' / 'config.py'}, or the run's `config.yaml` at "
+    f"{config.paths.config_file}."
+)}
 
 Keep the report readable (headings, short paragraphs, bullets where helpful).
 Be honest about uncertainty. Do not write anything outside {report_path.name}."""
@@ -396,27 +409,10 @@ Produce a markdown report with these sections (adapted for ad-hoc use):
    one-paragraph justification.
 4. **Was/is it worth continuing this run?** Even if the answer is no, call out
    what signal (if any) it yields for tuning the next run.
-5. **Recommended hyperparameter adjustments for the next run.**
-
-   CRITICAL CONSTRAINT: every recommendation in this section MUST correspond to
-   a field that already exists in the project's config schema — read
-   {repo_root / "deep_quoridor/src/v2/config.py"} for the authoritative list of
-   tweakable fields. Reference each suggestion by its dotted config path
-   (e.g. `training.learning_rate`, `alphazero.mcts_n`,
-   `alphazero.network.num_channels`, `self_play.alphazero.mcts_noise_epsilon`,
-   `training.batch_size`). If a value must be an existing enum / literal
-   (e.g. `alphazero.network.type` is `mlp` or `resnet`), respect that.
-   DO NOT suggest anything that requires code changes here (no new schedulers,
-   no new loss functions — those go in section 6).
-   Each suggestion: config path, proposed value (or direction), one-line
-   rationale tied to a metric you observed.
-
-6. **(Optional) Suggested code changes / new features.** ONLY include this
-   section if there's something concrete worth implementing — e.g. "add cosine
-   learning-rate decay", "support a different optimizer", "expose a new MCTS
-   parameter". Each item: what to implement, why the metrics suggest it would
-   help, and (if relevant) which file would change. If nothing concrete comes
-   to mind, OMIT this section entirely — do not fill it with speculation.
+{_hyperparameter_and_code_sections(
+    f"Read {repo_root / 'deep_quoridor/src/v2/config.py'} for the "
+    f"authoritative list of tweakable fields."
+)}
 
 Be honest about uncertainty. Keep it readable."""
 

--- a/deep_quoridor/src/v2/ai_report.py
+++ b/deep_quoridor/src/v2/ai_report.py
@@ -77,6 +77,11 @@ class AIBackend(ABC):
 class ClaudeBackend(AIBackend):
     name = "claude"
 
+    def __init__(self, model: Optional[str] = None):
+        """``model``: optional Claude model identifier (e.g. 'sonnet', 'opus',
+        'haiku', or a full model ID). ``None`` uses the CLI's default."""
+        self.model = model
+
     def check_available(self) -> None:
         if shutil.which("claude") is None:
             raise RuntimeError(
@@ -95,9 +100,12 @@ class ClaudeBackend(AIBackend):
             "--print",
             "--permission-mode",
             "acceptEdits",
-            prompt,
         ]
-        print(f"[ai_report] invoking claude (cwd={cwd})")
+        if self.model:
+            cmd += ["--model", self.model]
+        cmd.append(prompt)
+        model_label = self.model or "default"
+        print(f"[ai_report] invoking claude (model={model_label}, cwd={cwd})")
         result = subprocess.run(
             cmd,
             cwd=str(cwd),
@@ -118,9 +126,9 @@ class ClaudeBackend(AIBackend):
         return self._run(prompt, cwd).stdout
 
 
-def backend_for(ai: str) -> AIBackend:
+def backend_for(ai: str, model: Optional[str] = None) -> AIBackend:
     if ai == "claude":
-        return ClaudeBackend()
+        return ClaudeBackend(model=model)
     raise ValueError(f"Unknown ai_report.ai={ai!r}. Supported: {', '.join(SUPPORTED_AIS)}")
 
 
@@ -371,6 +379,7 @@ def generate_on_demand_report(
     ai: str = "claude",
     entity: Optional[str] = None,
     guidance: Optional[str] = None,
+    model: Optional[str] = None,
 ) -> str:
     """Generate an AI training report on demand and return it as text.
 
@@ -384,11 +393,13 @@ def generate_on_demand_report(
         entity: wandb entity (user/team), optional.
         guidance: Optional extra text appended to the prompt. Useful for asking
             the AI specific questions or steering the analysis.
+        model: Optional AI model identifier (e.g. 'sonnet', 'opus'). None uses
+            the backend's default.
 
     Returns:
         The AI's response text — a markdown report.
     """
-    backend = backend_for(ai)
+    backend = backend_for(ai, model=model)
     backend.check_available()
 
     # ai_report.py lives at <repo>/deep_quoridor/src/v2/ai_report.py
@@ -542,7 +553,7 @@ def run_ai_reporter(config: Config) -> None:
         return
 
     try:
-        backend = _backend_for(config.ai_report.ai)
+        backend = _backend_for(config.ai_report.ai, model=config.ai_report.model)
     except Exception as e:
         print(f"[ai_report] cannot start reporter: {e}")
         return

--- a/deep_quoridor/src/v2/ai_report.py
+++ b/deep_quoridor/src/v2/ai_report.py
@@ -241,8 +241,18 @@ The markdown file should cover:
 4. Any non-obvious project conventions you notice (e.g. the `every: N models`
    scheduling idiom, `raw_` prefix meaning, `dumb_score` scale 0-100 where
    lower is better).
+5. **Tweakable config fields.** Enumerate every hyperparameter that future
+   reports are allowed to recommend adjusting. Source of truth: the pydantic
+   models in config.py (QuoridorConfig, AlphaZeroBaseConfig, MLPConfig /
+   ResnetConfig, SelfPlayConfig, AlphaZeroSelfPlayConfig, TrainingConfig, and
+   the benchmark configs). For each field give: the dotted path
+   (e.g. `training.learning_rate`), the type / valid range, and a one-line
+   note on what it controls. Be exhaustive — this list is the authoritative
+   reference future reports use when recommending hyperparameter changes, and
+   they are explicitly forbidden from suggesting anything outside it.
 
-Keep it tight — aim for something a future report can skim in under a minute.
+Keep it tight — aim for something a future report can skim in under a minute
+(except section 5, which can be a longer reference table).
 Do not write anything outside the markdown file. When you're done, just confirm
 with the path you wrote."""
 
@@ -293,9 +303,28 @@ The report MUST contain these sections, in this order:
 4. **Is it worth continuing this run?** Especially if the likelihood is low,
    argue whether continuing will at least yield useful signal for tuning
    hyperparameters for the next run, or whether it's better to stop now.
-5. **Recommended hyperparameter adjustments for the next run.** Concrete
-   suggestions tied to specific config fields (learning_rate, mcts_n,
-   batch_size, network architecture, etc.), each with a one-line rationale.
+5. **Recommended hyperparameter adjustments for the next run.**
+
+   CRITICAL CONSTRAINT: every recommendation in this section MUST correspond to
+   a field that already exists in the project's config schema. The context doc
+   you read above enumerates the authoritative list. You can also cross-check
+   against the pydantic models at {_src_root() / "v2" / "config.py"}, or the
+   run's `config.yaml` at {config.paths.config_file}. Reference each suggestion
+   by its dotted config path (e.g. `training.learning_rate`,
+   `alphazero.mcts_n`, `alphazero.network.num_channels`,
+   `self_play.alphazero.mcts_noise_epsilon`, `training.batch_size`).
+   If a value must be an existing enum / literal (e.g. `alphazero.network.type`
+   is `mlp` or `resnet`), respect that.
+   DO NOT suggest anything that requires code changes here (no new schedulers,
+   no new loss functions, no new network types — those go in section 6).
+   Each suggestion gets one line of rationale tied to a metric you observed.
+
+6. **(Optional) Suggested code changes / new features.** ONLY include this
+   section if there's something concrete worth implementing — e.g. "add cosine
+   learning-rate decay", "support a different optimizer", "expose a new MCTS
+   parameter". Each item: what to implement, why the metrics suggest it would
+   help, and (if relevant) which file would change. If nothing concrete comes
+   to mind, OMIT this section entirely — do not fill it with speculation.
 
 Keep the report readable (headings, short paragraphs, bullets where helpful).
 Be honest about uncertainty. Do not write anything outside {report_path.name}."""
@@ -367,8 +396,27 @@ Produce a markdown report with these sections (adapted for ad-hoc use):
    one-paragraph justification.
 4. **Was/is it worth continuing this run?** Even if the answer is no, call out
    what signal (if any) it yields for tuning the next run.
-5. **Recommended hyperparameter adjustments for the next run.** Concrete
-   suggestions tied to specific config fields, each with a one-line rationale.
+5. **Recommended hyperparameter adjustments for the next run.**
+
+   CRITICAL CONSTRAINT: every recommendation in this section MUST correspond to
+   a field that already exists in the project's config schema — read
+   {repo_root / "deep_quoridor/src/v2/config.py"} for the authoritative list of
+   tweakable fields. Reference each suggestion by its dotted config path
+   (e.g. `training.learning_rate`, `alphazero.mcts_n`,
+   `alphazero.network.num_channels`, `self_play.alphazero.mcts_noise_epsilon`,
+   `training.batch_size`). If a value must be an existing enum / literal
+   (e.g. `alphazero.network.type` is `mlp` or `resnet`), respect that.
+   DO NOT suggest anything that requires code changes here (no new schedulers,
+   no new loss functions — those go in section 6).
+   Each suggestion: config path, proposed value (or direction), one-line
+   rationale tied to a metric you observed.
+
+6. **(Optional) Suggested code changes / new features.** ONLY include this
+   section if there's something concrete worth implementing — e.g. "add cosine
+   learning-rate decay", "support a different optimizer", "expose a new MCTS
+   parameter". Each item: what to implement, why the metrics suggest it would
+   help, and (if relevant) which file would change. If nothing concrete comes
+   to mind, OMIT this section entirely — do not fill it with speculation.
 
 Be honest about uncertainty. Keep it readable."""
 

--- a/deep_quoridor/src/v2/config.py
+++ b/deep_quoridor/src/v2/config.py
@@ -150,6 +150,11 @@ class AIReportConfig(StrictBaseModel):
     ai: str = "claude"
     """Which AI backend to use. Currently only 'claude' is supported."""
 
+    model: Optional[str] = None
+    """Model identifier passed to the AI backend. For Claude, values like
+    'sonnet', 'opus', 'haiku', or a full model ID work. If None, the backend's
+    default model is used."""
+
 
 class UserConfig(StrictBaseModel):
     """A normal pydantic model that can be used as an inner class."""

--- a/deep_quoridor/src/v2/config.py
+++ b/deep_quoridor/src/v2/config.py
@@ -134,6 +134,23 @@ class BenchmarkScheduleConfig(StrictBaseModel):
     jobs: list[BenchmarkJobConfig]
 
 
+class AIReportConfig(StrictBaseModel):
+    """Configuration for periodic AI-generated training reports.
+
+    When this section is present in the yaml, train_v2 spawns a sibling process
+    that periodically invokes an AI tool (currently only Claude) to generate a
+    markdown report summarizing training progress. When absent, no reports are
+    generated.
+    """
+
+    every: str
+    """How often to generate a report. Parsed by JobTrigger.from_string
+    (e.g. '100 models', '30 minutes')."""
+
+    ai: str = "claude"
+    """Which AI backend to use. Currently only 'claude' is supported."""
+
+
 class UserConfig(StrictBaseModel):
     """A normal pydantic model that can be used as an inner class."""
 
@@ -144,6 +161,7 @@ class UserConfig(StrictBaseModel):
     self_play: SelfPlayConfig
     training: TrainingConfig
     benchmarks: list[BenchmarkScheduleConfig] = []
+    ai_report: Optional[AIReportConfig] = None
 
     @field_validator("run_id")
     @classmethod
@@ -164,6 +182,7 @@ class PathsConfig(StrictBaseModel):
     replay_buffers_ready: Path
     replay_buffers_tmp: Path
     config_file: Path
+    reports: Path
 
     @classmethod
     def create(cls, base_dir: str, run_id: str, create_dirs: bool = True) -> "PathsConfig":
@@ -176,6 +195,7 @@ class PathsConfig(StrictBaseModel):
         replay_buffers = run_dir / "replay_buffers"
         replay_buffers_ready = replay_buffers / "ready"
         replay_buffers_tmp = replay_buffers_ready / "tmp"
+        reports = run_dir / "reports"
 
         if create_dirs:
             for path in (
@@ -184,6 +204,7 @@ class PathsConfig(StrictBaseModel):
                 replay_buffers,
                 replay_buffers_ready,
                 replay_buffers_tmp,
+                reports,
             ):
                 path.mkdir(parents=True, exist_ok=True)
 
@@ -196,6 +217,7 @@ class PathsConfig(StrictBaseModel):
             replay_buffers_ready=replay_buffers_ready,
             replay_buffers_tmp=replay_buffers_tmp,
             config_file=config_file,
+            reports=reports,
         )
 
 

--- a/deep_quoridor/src/v2/wandb_metrics.py
+++ b/deep_quoridor/src/v2/wandb_metrics.py
@@ -1,0 +1,123 @@
+"""Dump wandb metrics for a logical run group to a single JSON file.
+
+A deep_quoridor training run corresponds to a wandb *group* (``config.run_id``)
+containing one ``<run_id>-training`` run plus one ``<run_id>-benchmark-<idx>``
+run per benchmark schedule, plus ``<run_id>-ai-report`` if AI reports are
+enabled. The AI reporter calls :func:`dump_group_metrics` to snapshot the
+whole group so the AI prompt can reason over raw metrics without having to
+write wandb API code itself.
+
+Patterns here mirror ``deep_quoridor/src/metrics_reader.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import wandb
+
+
+def _summary_dict(run) -> dict:
+    """Return ``run.summary`` as a plain dict (defensive against SDK variants)."""
+    summary = run.summary
+    raw = getattr(summary, "_json_dict", None)
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+    try:
+        return dict(summary)
+    except Exception:
+        return {}
+
+
+def _runs_path(project: str, entity: str | None) -> str:
+    return f"{entity}/{project}" if entity else project
+
+
+def _clean_summary(summary: dict) -> dict:
+    """Strip wandb-internal and bookkeeping keys from a summary dict."""
+    return {
+        k: v
+        for k, v in summary.items()
+        if not k.startswith("_") and not k.startswith("time-")
+    }
+
+
+def dump_group_metrics(
+    project: str,
+    group: str,
+    out_path: Path,
+    entity: str | None = None,
+    history_samples: int = 500,
+) -> Path:
+    """Snapshot every wandb run in ``group`` and write JSON to ``out_path``.
+
+    The output JSON has the shape::
+
+        {
+          "project": "...",
+          "group": "...",
+          "runs": {
+             "<wandb run name>": {
+                "state": "...",
+                "summary": { metric_name: latest_value, ... },
+                "history": [ {x_axis: v, metric: v, ...}, ... ],  # downsampled
+             },
+             ...
+          }
+        }
+
+    History is downsampled server-side to ``history_samples`` rows per run, so
+    memory is bounded regardless of run length.
+    """
+    api = wandb.Api()
+    runs = list(api.runs(path=_runs_path(project, entity), filters={"group": group}))
+
+    payload: dict[str, Any] = {
+        "project": project,
+        "group": group,
+        "runs": {},
+    }
+
+    for run in runs:
+        summary = _clean_summary(_summary_dict(run))
+        # Fetch all metric keys present in summary (one history call covers them all).
+        metric_keys = [k for k in summary.keys() if not k.startswith("time-")]
+
+        history: list[dict] = []
+        try:
+            # run.history with pandas=False returns a list of dicts.
+            history = list(
+                run.history(keys=metric_keys, samples=history_samples, pandas=False)
+            )
+        except Exception as exc:
+            history = []
+            print(f"[wandb_metrics] failed to fetch history for {run.name}: {exc}")
+
+        # run.config is wandb's native hyperparameter store — equivalent to config.yaml
+        # values. Including it makes the snapshot self-contained for old runs where
+        # the local config.yaml may no longer be around.
+        try:
+            run_config = dict(run.config)
+        except Exception:
+            run_config = {}
+
+        payload["runs"][run.name] = {
+            "state": getattr(run, "state", None),
+            "job_type": getattr(run, "job_type", None),
+            "config": run_config,
+            "summary": summary,
+            "history": history,
+        }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str))
+    return out_path


### PR DESCRIPTION
This PR introduces the ability to periodically (or on-demand) generate an AI report on how the training is going, e.g. observations about the training, how likely is to produce a strong model, what changes would it make in code and hyperparameter.
The reports are saved on markdown files in the run directory, and also uploaded to wandb as artifacts. (e.g. [here](https://wandb.ai/the-lazy-learning-lair/B5W3/artifacts/ai_report/B5W3-cucu-02-20260419-1553-ai-report/v4/files/report_005.md))

For now, this is useful to judge whether to finish the training and start a new one, and which parameters would be used in the next iteration.
A next step would be to have the AI actually shuting down the training when it considers it's not worth continuing, generating a new config file with updated hyperparameters, and starting a new training.  This shouldn't be too hard to do (for Claude :p).

And if we want to go further, we can also have the AI implement the code changes that it recommended in the report!  


-------
# Example report

# AI Report 005 — cucu-02-20260419-1553
**Generated:** 2026-04-19 | **Model version at report time:** 335 | **Games played:** 8,376

---

## 1. General Observations About Training Progress

### Training losses (model v335)

| Metric | Report 003 (v202) | Report 004 (v284) | Report 005 (v335) | Δ (004→005) |
|---|---|---|---|---|
| `policy_loss` | 1.583 | 1.455 | **1.435** | −0.020 |
| `value_loss` | 0.461 | 0.415 | **0.417** | +0.002 |
| `total_loss` | 2.044 | 1.871 | **1.852** | −0.019 |
| `game_length` | 13 | 18 | **26** | +8 |
| `model_lag` | 1 | 1 | **0** | −1 ✓ |

**Loss decay has sharply decelerated.** Total loss dropped only 0.019 over 51 model versions, compared to −0.173 over the prior 82-version interval. Value loss is essentially flat (+0.002, within noise). This is the first meaningful stall in loss improvement this run has shown. Game length continues to rise (13→18→26), reflecting more contested self-play as both sides grow stronger. Model lag improved to 0 — the trainer is keeping pace with self-play.

The replay buffer holds 8,376 games — still only 20.9% of the 40,000-game capacity. Buffer still dominated by weaker early games.

### Benchmark metrics

**Benchmark-0 (every-10-models, raw/no-MCTS, last at v330):**

| Metric | Report 004 (v280) | Report 005 (v330) | Δ |
|---|---|---|---|
| `raw_win_perc` | 80.3% | **81.7%** | +1.4pp |
| `raw_p1_win_perc` | 77.7% | **83.0%** | +5.3pp |
| `raw_p2_win_perc` | 83.0% | **80.3%** | −2.7pp |
| `raw_relative_elo` | −141 | **+36** | **+177** ✓ |
| `raw_absolute_elo` | 1,767 | **1,883** | +116 |
| `raw_dumb_score` | 53 | **46** | −7 ✓ |

The headline raw result: **`raw_relative_elo` crossed positive**, reaching +36 at v330 (from −141 at v280). Without any MCTS, the model now beats the best opponent in the raw pool. This is a genuine capability milestone. However, overall raw win rate is nearly flat (+1.4pp) suggesting the Elo jump reflects quality improvement against the hardest opponents rather than broad dominance. P2 raw win rate edged slightly down (−2.7pp), though this is within sampling noise. The hardest opponents remain `simple-bf16` (P1: 46%, P2: 50%) and `simple-bf8` (P1: 62%, P2: 52%).

**Benchmark-2 (every-50-models, MCTS N=400, last at v300):**

| Metric | Report 004 (v250) | Report 005 (v300) | Δ |
|---|---|---|---|
| `win_perc` | 85.0% | **89.3%** | +4.3pp |
| `p1_win_perc` | 88.6% | **95.7%** | +7.1pp |
| `p2_win_perc` | 81.4% | **82.9%** | +1.5pp |
| `relative_elo` | +50 | **+171** | +121 ✓ |
| `absolute_elo` | 1,852 | **1,893** | +41 |
| `dumb_score` | 26 | **20** | −6 ✓ |

MCTS performance continues to improve significantly. `relative_elo` surged from +50 to +171 — the model is now comfortably above the best opponent with tree search. MCTS `dumb_score` reached 20, approaching the 9/10 threshold. The persistent weakness remains P2 vs `simple-bf256` at only 20% win rate (60% loss, 20% tie) — improved from 10% last report but still a clear structural gap.

**Benchmark-1 (agent evolution, no-MCTS, last at v300):**

| Model version | Elo (hall-of-fame) | Rank |
|---|---|---|
| v0 | 963 | 6 |
| v50 | 974 | 7 |
| v100 | 1,073 | 5 |
| v150 | 1,259 | 4 |
| v200 | 1,630 | 3 |
| v250 | **1,647** | **1 (best)** |
| v300 | 1,638 | 2 |

**Alert:** v300 (Elo 1,638) is slightly weaker than v250 (Elo 1,647) without MCTS. Raw policy quality appears to have plateaued or marginally regressed around v300. This is consistent with the near-flat loss curve — gradient steps are not translating into better greedy policy decisions at this scale of training data.

**Models trained:** 335. No training anomalies. All processes running.

---

## 2. Progress Since the Last Report

This interval (v284→v335) showed a mixed picture — strong MCTS gains, near-stall in raw policy and losses.

**Losses:** Near-flat. Total loss −0.019 over 51 versions. Value loss increased +0.002 (noise-level). The prior interval dropped −0.173 over 82 versions. The per-version rate fell from −0.0021 to −0.0004 — roughly a 5× deceleration.

**Raw win rate:** 80.3% → 81.7% (+1.4pp, essentially flat). Last interval delivered +38.6pp; this interval delivered +1.4pp.

**Raw relative_elo:** −141 → +36 (+177). Qualitatively important — greedy policy now beats the best no-MCTS opponent. But the overall win-rate flatness suggests this is improvement concentrated on the hardest matchups.

**Raw dumb_score:** 53 → 46 (−7). Continued slow improvement; still failing 46% of forced-win/block scenarios without MCTS.

**MCTS relative_elo:** +50 → +171 (+121). Strong. MCTS-augmented play is still improving robustly.

**MCTS dumb_score:** 26 → 20 (−6). Reached the 9/10 improvement threshold cited in report 004 (raw < 25 was for raw; MCTS score < 20 is nearly there).

**Agent evolution:** v300 placed 2nd (1,638) behind v250 (1,647). Raw policy did not improve between v250 and v300 — a plateau in greedy-policy strength. However, v300 still beats all earlier checkpoints, so monotonic progression is technically intact (v300 > v200 > v150...).

**Summary:** MCTS-based performance continues improving meaningfully; raw/no-MCTS quality has stalled. Loss decay near-zero. The training run is entering a different regime.

---

## 3. Likelihood This Run Produces a Strong Model

**Score: 7 / 10**

Downgraded from 8/10 last report due to the raw policy plateau and loss stall. Justification: MCTS relative_elo at +171 confirms this model is genuinely strong with tree search — it robustly beats the best opponent pool with N=400 simulations. MCTS dumb_score of 20 is close to the 9/10 target threshold. However, without MCTS the policy shows clear signs of plateauing (agent evolution v300 < v250; raw win rate +1.4pp). The loss deceleration is sharp enough to flag as a concern — if value_loss has found its floor near 0.417, the model may not substantially improve further. The remaining P2 weakness vs `simple-bf256` (20% win rate even with MCTS) is a structural gap that may not self-resolve. Score of 8/10 requires: raw_dumb_score < 35 (approaching) AND raw agent_evolution v350 clearly above v250 (not yet confirmed).

---

## 4. Is It Worth Continuing This Run?

**Yes, but with lower conviction than last report.**

The run still has positive momentum in MCTS metrics, which are arguably the more important measure for actual play strength. Two considerations:

1. **Loss plateau may be transient.** The replay buffer is only 21% full — as v300+ games (much higher quality) accumulate and displace early weak-policy games, the training distribution will shift. A second improvement phase is plausible in the v350–v450 range. The per-step signal should improve as the buffer fills with stronger self-play.

2. **Raw plateau is a real concern.** If v350 and v400 benchmarks also fail to beat v250 in agent evolution, that signals the run has hit a capacity or data-quality ceiling and should be terminated in favor of a new run with adjusted hyperparameters.

**Recommendation:** Continue to v400. Re-evaluate at v400 based on agent evolution placing. If v350 or v400 tops the hall-of-fame, continue. If v250 still leads at v400, stop and launch a new run with the hyperparameter changes below.

---

## 5. Recommended Hyperparameter Adjustments for the Next Run

Carrying forward validated recommendations from report 004, plus two new ones based on current observations.

- **`alphazero.network.mask_training_predictions`: false → true**
  Raw `dumb_score` (46) remains 26 points above MCTS `dumb_score` (20); the gap has barely closed (was 27pp in report 004). Policy gradients from invalid actions continue to distort greedy-policy behavior. Masking would directly attack this divergence.

- **`self_play.alphazero.mcts_noise_alpha`: 0.8 → 0.3**
  P2 win rate vs `simple-bf256` with MCTS is 20% — improved from 10% but still clearly deficient. Near-uniform Dirichlet noise (α=0.8) continues to suppress structured defensive play from the network's learned prior in P2 positions.

- **`self_play.alphazero.mcts_noise_epsilon`: 0.3 → 0.25**
  Complementary to the alpha reduction — reduce noise fraction slightly to give the trained policy more influence at the self-play root, especially important as policy quality matures past v300.

- **`training.learning_rate`: 0.0002 → 0.0004**
  Loss decay rate fell ~5× this interval. Value loss is flat. A 2× LR increase would restart the loss curve's descent. The run is far from any instability risk at v335 — total loss (1.85) is still well above noise floor.

- **`training.games_per_training_step`: 25 → 15**
  Model lag is now 0 (trainer keeping up comfortably). Reducing games-per-step increases gradient density per unit of self-play data, critical while the buffer transitions from early-game data to v300+ quality data.

- **`training.replay_buffer_size` and `training.max_cached_games`: 40000 → 25000**
  At the current pace, the buffer will still be majority pre-v150 data past v400. A tighter buffer forces faster eviction of stale weak-policy games, keeping the training distribution current. Trade-off is reduced diversity, justified given the plateau signals.

- **`training.initial_model.wandb_project` / `training.initial_model.wandb_alias`**: warm-start next run from the best checkpoint of this run.
  Agent evolution v250 and v300 are close. Warm-starting from the best hall-of-fame checkpoint (currently v250) would skip the first ~250 model versions of curriculum and immediately engage the stronger self-play regime.

---

## 6. Suggested Code Changes / New Features

- **Learning rate schedule (cosine or linear decay).** Loss decay has effectively stalled at v335 while training is only ~335/~800 model versions in. A decay schedule allows a higher initial LR (0.0004–0.001) for fast early progress and a lower final LR to stabilize late. This is standard in AlphaZero literature. The training loop in `src/v2/` would need an `lr_scheduler` step call. Current flat LR means neither fast early learning nor careful late convergence.

- **Investigate P2 data distribution in self-play.** The persistent P2 weakness vs `simple-bf256` (20% win rate even with N=400) is the largest remaining gap. Before attributing it to policy quality alone, it would be worth logging P1/P2 game-start frequency in self-play output — a distribution bug (e.g., always starting as P1) could explain a structural blind spot in P2 value estimates.
