### PR TITLE
Better training from policy database

### DIFF
--- a/deep_quoridor/rust/Cargo.toml
+++ b/deep_quoridor/rust/Cargo.toml
@@ -28,7 +28,8 @@ ndarray = "0.16"
 rand = "0.8"
 dashmap = "6"
 rayon = "1.10"
-rusqlite = { version = "0.32", features = ["bundled"] }
+arrow = "53"
+parquet = { version = "53", default-features = false, features = ["arrow", "zstd"] }
 serde = { version = "1", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.11", optional = true }

--- a/deep_quoridor/rust/src/bin/create_policy_db.rs
+++ b/deep_quoridor/rust/src/bin/create_policy_db.rs
@@ -53,14 +53,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut initial_state = mechanics.create_initial_state();
 
     // Print game state info
-    let current_player = mechanics.repr().get_current_player(&initial_state);
-    let (p0_row, p0_col) = mechanics.repr().get_player_position(&initial_state, 0);
-    let (p1_row, p1_col) = mechanics.repr().get_player_position(&initial_state, 1);
-    let p0_walls = mechanics.repr().get_walls_remaining(&initial_state, 0);
-    let p1_walls = mechanics.repr().get_walls_remaining(&initial_state, 1);
+    let current_player = mechanics.repr().get_current_player(initial_state);
+    let (p0_row, p0_col) = mechanics.repr().get_player_position(initial_state, 0);
+    let (p1_row, p1_col) = mechanics.repr().get_player_position(initial_state, 1);
+    let p0_walls = mechanics.repr().get_walls_remaining(initial_state, 0);
+    let p1_walls = mechanics.repr().get_walls_remaining(initial_state, 1);
 
     println!("\nGame state:");
-    println!("  State size: {} bytes", initial_state.len());
+    println!("  State size: {} bits", mechanics.repr().size_bits());
     println!(
         "  Player positions: [({}, {}), ({}, {})]",
         p0_row, p0_col, p1_row, p1_col

--- a/deep_quoridor/rust/src/bin/create_policy_db.rs
+++ b/deep_quoridor/rust/src/bin/create_policy_db.rs
@@ -35,8 +35,8 @@ struct Args {
     #[arg(long, default_value_t = 1)]
     step_interval: usize,
 
-    /// Output SQLite database file path
-    #[arg(short, long, default_value = "policy_db.sqlite")]
+    /// Output Parquet database file path
+    #[arg(short, long, default_value = "policy_db.parquet")]
     output: String,
 }
 

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -121,9 +121,9 @@ impl PolicyDb {
                 // child_opponent just won
                 any_found = true;
                 if child_opponent == 0 {
-                    -1
-                } else {
                     1
+                } else {
+                    -1
                 }
             } else if mechanics.repr().get_completed_steps(&child_data)
                 >= mechanics.repr().max_steps()

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -59,16 +59,31 @@ struct DecodedRowGroup {
     values: Vec<i8>,
 }
 
+/// Backing storage for an open PolicyDb. The lazy variant defers row-group
+/// decode until each lookup; the eager variant loads everything into RAM
+/// up front for O(1) state lookups and O(1) rowid access.
+enum Storage {
+    Lazy {
+        path: String,
+        metadata: ArrowReaderMetadata,
+        row_groups: Vec<RowGroupStats>,
+        /// `cum_rows[i]` = sum of `num_rows` over row groups `0..i`.
+        /// Length `row_groups.len() + 1`. `cum_rows.last()` = total rows.
+        cum_rows: Vec<u64>,
+    },
+    Eager {
+        /// File order (= sorted by state-as-i64). Indexable by `rowid - 1`.
+        ordered: Vec<(u64, i8)>,
+        /// O(1) point lookups for `lookup_values_by_state`.
+        table: HashMap<u64, i8>,
+    },
+}
+
 /// Parquet-backed policy database for storing and querying pre-computed
 /// minimax values. Single file per DB; sorted by `state` for efficient
 /// row-group pruning on point lookups.
 pub struct PolicyDb {
-    path: String,
-    metadata: ArrowReaderMetadata,
-    row_groups: Vec<RowGroupStats>,
-    /// `cum_rows[i]` = sum of `num_rows` over row groups `0..i`.
-    /// Length `row_groups.len() + 1`. `cum_rows.last()` = total rows.
-    cum_rows: Vec<u64>,
+    storage: Storage,
     mechanics: QGameMechanics,
     board_size: usize,
     max_walls: usize,
@@ -92,7 +107,13 @@ fn parse_meta(kv: Option<&Vec<KeyValue>>, key: &str) -> Option<usize> {
 
 impl PolicyDb {
     /// Open an existing policy database for reading.
-    pub fn open(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
+    ///
+    /// When `lazy` is `false` (the default for callers), the entire dataset
+    /// is decoded into a `HashMap<u64, i8>` at open time so subsequent
+    /// state lookups are O(1). When `lazy` is `true`, lookups walk Parquet
+    /// row groups on demand using the file's min/max statistics; useful for
+    /// DBs too large to fit in memory.
+    pub fn open(path: &str, lazy: bool) -> Result<Self, Box<dyn std::error::Error>> {
         let file = File::open(Path::new(path))?;
         let metadata = ArrowReaderMetadata::load(&file, Default::default())?;
 
@@ -134,11 +155,44 @@ impl PolicyDb {
         // Prefer the cached count from metadata, fall back to summed row counts.
         let num_states = num_states_meta.unwrap_or(total as usize);
 
+        let storage = if lazy {
+            Storage::Lazy {
+                path: path.to_string(),
+                metadata,
+                row_groups,
+                cum_rows,
+            }
+        } else {
+            // Eager load: walk all row groups in one pass, decoding each
+            // RecordBatch into the running ordered Vec, then build the
+            // O(1) lookup HashMap from it.
+            let file = File::open(Path::new(path))?;
+            let reader = ParquetRecordBatchReaderBuilder::new_with_metadata(
+                file,
+                metadata.clone(),
+            )
+            .build()?;
+
+            let mut state_buf: Vec<i64> = Vec::with_capacity(num_states);
+            let mut value_buf: Vec<i8> = Vec::with_capacity(num_states);
+            for batch in reader {
+                let batch = batch?;
+                append_batch(&batch, &mut state_buf, &mut value_buf)?;
+            }
+
+            let mut ordered: Vec<(u64, i8)> = Vec::with_capacity(state_buf.len());
+            for (s, v) in state_buf.into_iter().zip(value_buf.into_iter()) {
+                ordered.push((s as u64, v));
+            }
+            let mut table = HashMap::with_capacity(ordered.len());
+            for &(s, v) in &ordered {
+                table.insert(s, v);
+            }
+            Storage::Eager { ordered, table }
+        };
+
         Ok(Self {
-            path: path.to_string(),
-            metadata,
-            row_groups,
-            cum_rows,
+            storage,
             mechanics,
             board_size,
             max_walls,
@@ -166,19 +220,20 @@ impl PolicyDb {
 
     /// Decode a single row group into `(states, values)` columns.
     /// Reopens the file so this is safe to call from a `&self` context
-    /// without interior mutability or sync.
+    /// without interior mutability or sync. Lazy mode only.
     fn decode_row_group(
-        &self,
-        rg_idx: usize,
+        path: &str,
+        metadata: &ArrowReaderMetadata,
+        rg: &RowGroupStats,
     ) -> Result<DecodedRowGroup, Box<dyn std::error::Error>> {
-        let file = File::open(&self.path)?;
-        let mut reader = ParquetRecordBatchReaderBuilder::new_with_metadata(file, self.metadata.clone())
-            .with_row_groups(vec![rg_idx])
-            .with_batch_size(self.row_groups[rg_idx].num_rows as usize)
+        let file = File::open(path)?;
+        let mut reader = ParquetRecordBatchReaderBuilder::new_with_metadata(file, metadata.clone())
+            .with_row_groups(vec![rg.idx])
+            .with_batch_size(rg.num_rows as usize)
             .build()?;
 
-        let mut states = Vec::with_capacity(self.row_groups[rg_idx].num_rows as usize);
-        let mut values = Vec::with_capacity(self.row_groups[rg_idx].num_rows as usize);
+        let mut states = Vec::with_capacity(rg.num_rows as usize);
+        let mut values = Vec::with_capacity(rg.num_rows as usize);
         while let Some(batch) = reader.next() {
             let batch = batch?;
             append_batch(&batch, &mut states, &mut values)?;
@@ -293,51 +348,86 @@ impl PolicyDb {
         if rowids.is_empty() {
             return Ok(Vec::new());
         }
-        let total_rows = *self.cum_rows.last().unwrap_or(&0);
 
-        let mut sorted: Vec<u64> = rowids
-            .iter()
-            .filter_map(|&r| {
-                if r >= 1 && (r as u64) <= total_rows {
-                    Some((r - 1) as u64)
-                } else {
-                    None
+        match &self.storage {
+            Storage::Eager { ordered, .. } => {
+                let total_rows = ordered.len() as u64;
+                let mut sorted: Vec<u64> = rowids
+                    .iter()
+                    .filter_map(|&r| {
+                        if r >= 1 && (r as u64) <= total_rows {
+                            Some((r - 1) as u64)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                sorted.sort_unstable();
+
+                let mut results = Vec::with_capacity(sorted.len());
+                for r0 in sorted {
+                    let (s, v) = ordered[r0 as usize];
+                    results.push((s, v as i32));
                 }
-            })
-            .collect();
-        sorted.sort_unstable();
-
-        let mut results = Vec::with_capacity(sorted.len());
-        let mut current_rg: Option<usize> = None;
-        let mut decoded: Option<DecodedRowGroup> = None;
-
-        for r0 in sorted {
-            // cum_rows is sorted ascending; find the row group whose range
-            // [cum_rows[i], cum_rows[i+1]) contains r0.
-            let rg_idx = match self.cum_rows.binary_search(&r0) {
-                Ok(i) => i,        // r0 is the first row of group i
-                Err(i) => i - 1,   // r0 falls in group i-1
-            };
-            let row_in_group = (r0 - self.cum_rows[rg_idx]) as usize;
-
-            if current_rg != Some(rg_idx) {
-                decoded = Some(self.decode_row_group(rg_idx)?);
-                current_rg = Some(rg_idx);
+                Ok(results)
             }
-            let dec = decoded.as_ref().unwrap();
-            let s = dec.states[row_in_group] as u64;
-            let v = dec.values[row_in_group] as i32;
-            results.push((s, v));
-        }
+            Storage::Lazy {
+                path,
+                metadata,
+                row_groups,
+                cum_rows,
+            } => {
+                let total_rows = *cum_rows.last().unwrap_or(&0);
+                let mut sorted: Vec<u64> = rowids
+                    .iter()
+                    .filter_map(|&r| {
+                        if r >= 1 && (r as u64) <= total_rows {
+                            Some((r - 1) as u64)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                sorted.sort_unstable();
 
-        Ok(results)
+                let mut results = Vec::with_capacity(sorted.len());
+                let mut current_rg: Option<usize> = None;
+                let mut decoded: Option<DecodedRowGroup> = None;
+
+                for r0 in sorted {
+                    // cum_rows is sorted ascending; find the row group whose
+                    // range [cum_rows[i], cum_rows[i+1]) contains r0.
+                    let rg_idx = match cum_rows.binary_search(&r0) {
+                        Ok(i) => i,        // r0 is the first row of group i
+                        Err(i) => i - 1,   // r0 falls in group i-1
+                    };
+                    let row_in_group = (r0 - cum_rows[rg_idx]) as usize;
+
+                    if current_rg != Some(rg_idx) {
+                        decoded = Some(Self::decode_row_group(
+                            path,
+                            metadata,
+                            &row_groups[rg_idx],
+                        )?);
+                        current_rg = Some(rg_idx);
+                    }
+                    let dec = decoded.as_ref().unwrap();
+                    let s = dec.states[row_in_group] as u64;
+                    let v = dec.values[row_in_group] as i32;
+                    results.push((s, v));
+                }
+
+                Ok(results)
+            }
+        }
     }
 
     /// Look up values for the given states.
     ///
     /// Returns `(state, value)` for each state found in the DB. States
-    /// not present are omitted. Internally walks row groups in sorted
-    /// order, decoding each at most once.
+    /// not present are omitted. In eager mode this is an O(N) HashMap
+    /// scan; in lazy mode it walks Parquet row groups in sorted order,
+    /// decoding each at most once.
     pub fn lookup_values_by_state(
         &self,
         states: &[u64],
@@ -345,41 +435,55 @@ impl PolicyDb {
         if states.is_empty() {
             return Ok(Vec::new());
         }
-        let mut sorted: Vec<i64> = states.iter().map(|&s| s as i64).collect();
-        sorted.sort_unstable();
-        sorted.dedup();
 
-        let mut results = Vec::new();
-        let mut q_idx = 0usize;
-        let mut rg_idx = 0usize;
+        match &self.storage {
+            Storage::Eager { table, .. } => Ok(states
+                .iter()
+                .filter_map(|s| table.get(s).map(|v| (*s, *v as i32)))
+                .collect()),
+            Storage::Lazy {
+                path,
+                metadata,
+                row_groups,
+                ..
+            } => {
+                let mut sorted: Vec<i64> = states.iter().map(|&s| s as i64).collect();
+                sorted.sort_unstable();
+                sorted.dedup();
 
-        while q_idx < sorted.len() && rg_idx < self.row_groups.len() {
-            let q = sorted[q_idx];
-            let rg = &self.row_groups[rg_idx];
+                let mut results = Vec::new();
+                let mut q_idx = 0usize;
+                let mut rg_idx = 0usize;
 
-            if q < rg.min {
-                // Sorted file: q can't appear in any later row group either.
-                q_idx += 1;
-            } else if q > rg.max {
-                rg_idx += 1;
-            } else {
-                // q is in [min, max]; decode this row group once and
-                // resolve every query whose value falls in the same range.
-                let decoded = self.decode_row_group(rg.idx)?;
-                while q_idx < sorted.len() && sorted[q_idx] <= rg.max {
-                    let q2 = sorted[q_idx];
-                    if q2 >= rg.min {
-                        if let Ok(pos) = decoded.states.binary_search(&q2) {
-                            results.push((q2 as u64, decoded.values[pos] as i32));
+                while q_idx < sorted.len() && rg_idx < row_groups.len() {
+                    let q = sorted[q_idx];
+                    let rg = &row_groups[rg_idx];
+
+                    if q < rg.min {
+                        // Sorted file: q can't appear in any later group either.
+                        q_idx += 1;
+                    } else if q > rg.max {
+                        rg_idx += 1;
+                    } else {
+                        // q is in [min, max]; decode this row group once and
+                        // resolve every query whose value falls in the range.
+                        let decoded = Self::decode_row_group(path, metadata, rg)?;
+                        while q_idx < sorted.len() && sorted[q_idx] <= rg.max {
+                            let q2 = sorted[q_idx];
+                            if q2 >= rg.min {
+                                if let Ok(pos) = decoded.states.binary_search(&q2) {
+                                    results.push((q2 as u64, decoded.values[pos] as i32));
+                                }
+                            }
+                            q_idx += 1;
                         }
+                        rg_idx += 1;
                     }
-                    q_idx += 1;
                 }
-                rg_idx += 1;
+
+                Ok(results)
             }
         }
-
-        Ok(results)
     }
 
     /// Create a new policy database from a transposition table.
@@ -705,7 +809,7 @@ mod tests {
         .unwrap();
         assert_eq!(written, expected.len());
 
-        let db = PolicyDb::open(path_str).unwrap();
+        let db = PolicyDb::open(path_str, false).unwrap();
         assert_eq!(
             db.read_metadata().unwrap(),
             (3, 0, 8, Some(expected.len()))
@@ -745,7 +849,7 @@ mod tests {
         let path_str = path.to_str().unwrap();
         PolicyDb::write(&mechanics, table, path_str, 3, 8, 0, 1).unwrap();
 
-        let db = PolicyDb::open(path_str).unwrap();
+        let db = PolicyDb::open(path_str, false).unwrap();
 
         // Construct a state where P0 is one row from goal — at least one
         // child action wins immediately (terminal child, no DB lookup).
@@ -765,5 +869,78 @@ mod tests {
             values.iter().any(|&v| v == 1),
             "expected at least one winning action value, got {values:?}"
         );
+    }
+
+    /// Eager and lazy modes must return identical results across all
+    /// public query methods.
+    #[test]
+    fn test_eager_matches_lazy() {
+        let mechanics = QGameMechanics::new(3, 0, 8);
+        let mut root = mechanics.create_initial_state();
+        let table = TranspositionTable::new();
+        minimax(&mechanics, &mut root, &table);
+        let expected: Vec<(u64, i8)> =
+            table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.parquet");
+        let path_str = path.to_str().unwrap();
+        PolicyDb::write(&mechanics, table, path_str, 3, 8, 0, 1).unwrap();
+
+        let eager = PolicyDb::open(path_str, false).unwrap();
+        let lazy = PolicyDb::open(path_str, true).unwrap();
+
+        // Same metadata.
+        assert_eq!(eager.read_metadata().unwrap(), lazy.read_metadata().unwrap());
+        assert_eq!(eager.count_states().unwrap(), lazy.count_states().unwrap());
+
+        // Same lookup_values_by_state results (sort both since order isn't
+        // guaranteed across modes).
+        let states: Vec<u64> = expected.iter().map(|(s, _)| *s).collect();
+        let mut e_pairs = eager.lookup_values_by_state(&states).unwrap();
+        let mut l_pairs = lazy.lookup_values_by_state(&states).unwrap();
+        e_pairs.sort_unstable_by_key(|(s, _)| *s);
+        l_pairs.sort_unstable_by_key(|(s, _)| *s);
+        assert_eq!(e_pairs, l_pairs);
+        assert_eq!(e_pairs.len(), expected.len());
+
+        // Same fetch_states_by_rowid results in sequential order. Both
+        // modes return rows in ascending rowid order, which is by
+        // sorted-state order on disk.
+        let all_ids: Vec<i64> = (1..=expected.len() as i64).collect();
+        let e_by_id = eager.fetch_states_by_rowid(&all_ids).unwrap();
+        let l_by_id = lazy.fetch_states_by_rowid(&all_ids).unwrap();
+        assert_eq!(e_by_id, l_by_id);
+
+        // Same lookup_action_values: pick a non-terminal state from the
+        // table and compare the (actions, values) tuple. Use sorting
+        // since action enumeration order is identical but we sort to be
+        // robust against any future reordering.
+        let probe_state = expected
+            .iter()
+            .find(|(s, _)| {
+                !mechanics.check_win(*s, 0)
+                    && !mechanics.check_win(*s, 1)
+                    && mechanics.repr().get_completed_steps(*s) < mechanics.repr().max_steps()
+            })
+            .map(|(s, _)| *s)
+            .expect("expected at least one non-terminal state");
+
+        let (e_actions, e_values) = eager
+            .lookup_action_values(probe_state)
+            .unwrap()
+            .expect("eager: action values");
+        let (l_actions, l_values) = lazy
+            .lookup_action_values(probe_state)
+            .unwrap()
+            .expect("lazy: action values");
+
+        let mut e_pairs: Vec<((u8, u8, u8), i32)> =
+            e_actions.into_iter().zip(e_values).collect();
+        let mut l_pairs: Vec<((u8, u8, u8), i32)> =
+            l_actions.into_iter().zip(l_values).collect();
+        e_pairs.sort_unstable_by_key(|(a, _)| *a);
+        l_pairs.sort_unstable_by_key(|(a, _)| *a);
+        assert_eq!(e_pairs, l_pairs);
     }
 }

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -11,45 +11,8 @@ use std::path::Path;
 
 use super::q_game_mechanics::QGameMechanics;
 
-/// Maximum state size in bytes. Covers up to 9x9 boards with generous parameters.
-pub const MAX_STATE_BYTES: usize = 8;
-
-/// Fixed-size key for the transposition table, avoiding heap allocation.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct StateKey {
-    bytes: [u8; MAX_STATE_BYTES],
-    len: u8,
-}
-
-impl StateKey {
-    pub fn from_slice(data: &[u8]) -> Self {
-        assert!(
-            data.len() <= MAX_STATE_BYTES,
-            "State size {} exceeds MAX_STATE_BYTES {}",
-            data.len(),
-            MAX_STATE_BYTES
-        );
-        let mut bytes = [0u8; MAX_STATE_BYTES];
-        bytes[..data.len()].copy_from_slice(data);
-        Self {
-            bytes,
-            len: data.len() as u8,
-        }
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        &self.bytes[..self.len as usize]
-    }
-}
-
-impl std::hash::Hash for StateKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_slice().hash(state);
-    }
-}
-
 /// Transposition table type alias.
-pub type TranspositionTable = DashMap<StateKey, i8>;
+pub type TranspositionTable = DashMap<u64, i8>;
 
 /// SQLite-backed policy database for storing and querying pre-computed minimax values.
 pub struct PolicyDb {
@@ -107,13 +70,13 @@ impl PolicyDb {
     /// player's perspective (positive = good for the acting player).
     pub fn lookup_action_values(
         &self,
-        data: &[u8],
+        data: u64,
     ) -> Result<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>, Box<dyn std::error::Error>> {
         let mechanics = &self.mechanics;
         let cp = mechanics.repr().get_current_player(data);
 
-        let mut data_mut = data.to_vec();
-        let moves = mechanics.get_valid_moves(&mut data_mut);
+        let mut data_mut = data;
+        let moves = mechanics.get_valid_moves(data_mut);
         let walls = mechanics.get_valid_wall_placements(&mut data_mut);
 
         let mut actions: Vec<(u8, u8, u8)> = moves
@@ -138,7 +101,7 @@ impl PolicyDb {
         let mut any_found = false;
 
         for &(row, col, action_type) in &actions {
-            let mut child_data = data.to_vec();
+            let mut child_data = data;
             let (r, c, t) = (row as usize, col as usize, action_type as usize);
             if action_type == 2 {
                 mechanics.execute_move(&mut child_data, cp, r, c);
@@ -147,11 +110,11 @@ impl PolicyDb {
             }
             mechanics.switch_player(&mut child_data);
 
-            let child_cp = mechanics.repr().get_current_player(&child_data);
+            let child_cp = mechanics.repr().get_current_player(child_data);
             let child_opponent = 1 - child_cp;
 
             // P0-perspective value for this child state.
-            let value_p0: i32 = if mechanics.check_win(&child_data, child_opponent) {
+            let value_p0: i32 = if mechanics.check_win(child_data, child_opponent) {
                 // child_opponent just won
                 any_found = true;
                 if child_opponent == 0 {
@@ -159,14 +122,16 @@ impl PolicyDb {
                 } else {
                     -1
                 }
-            } else if mechanics.repr().get_completed_steps(&child_data)
+            } else if mechanics.repr().get_completed_steps(child_data)
                 >= mechanics.repr().max_steps()
             {
                 any_found = true;
                 0
             } else {
-                let result: Result<i32, _> =
-                    stmt.query_row(rusqlite::params![child_data], |row| row.get(0));
+                let result: Result<i32, _> = stmt.query_row(
+                    rusqlite::params![child_data.to_le_bytes().as_ref()],
+                    |row| row.get(0),
+                );
                 match result {
                     Ok(v) => {
                         any_found = true;
@@ -233,8 +198,9 @@ impl PolicyDb {
 
     /// Fetch states and values by rowid.
     ///
-    /// Returns a list of `(state_bytes, value)` tuples for each found rowid.
-    pub fn fetch_states_by_rowid(&self, rowids: &[i64]) -> Result<Vec<(Vec<u8>, i32)>, Box<dyn std::error::Error>> {
+    /// Returns a list of `(state, value)` tuples for each found rowid, where
+    /// `state` is the u64 packed state.
+    pub fn fetch_states_by_rowid(&self, rowids: &[i64]) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
         if rowids.is_empty() {
             return Ok(Vec::new());
         }
@@ -242,7 +208,10 @@ impl PolicyDb {
         let sql = format!("SELECT state, value FROM policy WHERE rowid IN ({})", placeholders);
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(rusqlite::params_from_iter(rowids.iter()), |row| {
-            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i32>(1)?))
+            let bytes: Vec<u8> = row.get(0)?;
+            let mut arr = [0u8; 8];
+            arr[..bytes.len()].copy_from_slice(&bytes);
+            Ok((u64::from_le_bytes(arr), row.get::<_, i32>(1)?))
         })?;
         let mut results = Vec::with_capacity(rowids.len());
         for row in rows {
@@ -251,20 +220,24 @@ impl PolicyDb {
         Ok(results)
     }
 
-    /// Look up values for the given state blobs.
+    /// Look up values for the given states.
     ///
-    /// Returns a list of `(state_bytes, value)` for each state found in the DB.
+    /// Returns a list of `(state, value)` for each state found in the DB.
     /// States not present in the DB are omitted from the result.
-    pub fn lookup_values_by_state(&self, states: &[&[u8]]) -> Result<Vec<(Vec<u8>, i32)>, Box<dyn std::error::Error>> {
+    pub fn lookup_values_by_state(&self, states: &[u64]) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
         if states.is_empty() {
             return Ok(Vec::new());
         }
         let placeholders: String = std::iter::repeat("?").take(states.len()).collect::<Vec<_>>().join(",");
         let sql = format!("SELECT state, value FROM policy WHERE state IN ({})", placeholders);
         let mut stmt = self.conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::ToSql> = states.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let blobs: Vec<Vec<u8>> = states.iter().map(|s| s.to_le_bytes().to_vec()).collect();
+        let params: Vec<&dyn rusqlite::ToSql> = blobs.iter().map(|b| b as &dyn rusqlite::ToSql).collect();
         let rows = stmt.query_map(params.as_slice(), |row| {
-            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i32>(1)?))
+            let bytes: Vec<u8> = row.get(0)?;
+            let mut arr = [0u8; 8];
+            arr[..bytes.len()].copy_from_slice(&bytes);
+            Ok((u64::from_le_bytes(arr), row.get::<_, i32>(1)?))
         })?;
         let mut results = Vec::with_capacity(states.len());
         for row in rows {
@@ -336,16 +309,14 @@ impl PolicyDb {
         {
             let mut stmt = tx.prepare("INSERT INTO policy (state, value) VALUES (?1, ?2)")?;
 
-            for item in entries.into_iter() {
-                let (key, value) = item;
-
-                let steps = mechanics.repr().get_completed_steps(key.as_slice());
+            for (key, value) in entries.into_iter() {
+                let steps = mechanics.repr().get_completed_steps(key);
                 if steps % step_interval != 0 {
                     continue;
                 }
 
                 // Store P0-absolute values (1=P0 wins, -1=P0 loses).
-                stmt.execute(params![key.as_slice(), value as i32])?;
+                stmt.execute(params![key.to_le_bytes().as_ref(), value as i32])?;
             }
             drop(stmt);
         }
@@ -367,8 +338,8 @@ impl PolicyDb {
 }
 
 /// Get all valid actions (moves + wall placements) for the current player.
-fn get_all_actions(mechanics: &QGameMechanics, data: &mut [u8]) -> Vec<(u8, u8, u8)> {
-    let moves = mechanics.get_valid_moves(data);
+fn get_all_actions(mechanics: &QGameMechanics, data: &mut u64) -> Vec<(u8, u8, u8)> {
+    let moves = mechanics.get_valid_moves(*data);
     let mut actions: Vec<(u8, u8, u8)> = moves
         .into_iter()
         .map(|(r, c)| (r as u8, c as u8, 2))
@@ -393,7 +364,7 @@ fn get_all_actions(mechanics: &QGameMechanics, data: &mut [u8]) -> Vec<(u8, u8, 
 /// transposition table for later export to a policy database.
 pub fn minimax(
     mechanics: &QGameMechanics,
-    data: &mut [u8],
+    data: &mut u64,
     transposition_table: &TranspositionTable,
 ) -> i8 {
     minimax_inner(mechanics, data, transposition_table, None)
@@ -401,27 +372,26 @@ pub fn minimax(
 
 fn minimax_inner(
     mechanics: &QGameMechanics,
-    data: &mut [u8],
+    data: &mut u64,
     transposition_table: &TranspositionTable,
     mut rng: Option<&mut StdRng>,
 ) -> i8 {
-    let key = StateKey::from_slice(data);
-    if let Some(entry) = transposition_table.get(&key) {
+    if let Some(entry) = transposition_table.get(data) {
         return *entry;
     }
 
-    let current_player = mechanics.repr().get_current_player(data);
+    let current_player = mechanics.repr().get_current_player(*data);
     let opponent = 1 - current_player;
 
     // Terminal states: return value directly without storing in transposition table.
-    if mechanics.check_win(data, opponent) {
+    if mechanics.check_win(*data, opponent) {
         return match opponent {
             0 => 1,
             1 => -1,
             _ => panic!("Bad player number ({})", opponent),
         };
     }
-    if mechanics.repr().get_completed_steps(data) >= mechanics.repr().max_steps() {
+    if mechanics.repr().get_completed_steps(*data) >= mechanics.repr().max_steps() {
         return 0;
     }
 
@@ -442,12 +412,12 @@ fn minimax_inner(
     let mut best_value: i8 = if is_maximizing { -1 } else { 1 };
 
     for &(row, col, action_type) in &actions {
-        let mut new_data = data.to_vec();
+        let mut new_data = *data;
         let (r, c, t) = (row as usize, col as usize, action_type as usize);
         if action_type == 2 {
             mechanics.execute_move(
                 &mut new_data,
-                mechanics.repr().get_current_player(data),
+                mechanics.repr().get_current_player(*data),
                 r,
                 c,
             );
@@ -475,7 +445,7 @@ fn minimax_inner(
         }
     }
 
-    transposition_table.insert(key, best_value);
+    transposition_table.insert(*data, best_value);
 
     best_value
 }
@@ -485,15 +455,15 @@ fn minimax_inner(
 /// transposition table. Returns the root value.
 pub fn minimax_lazy_smp(
     mechanics: &QGameMechanics,
-    data: &mut [u8],
+    data: &mut u64,
     transposition_table: &TranspositionTable,
     num_threads: usize,
 ) -> i8 {
-    let data_snapshot = data.to_vec();
+    let data_snapshot = *data;
     let result = std::thread::scope(|s| {
         let mut handles = Vec::with_capacity(num_threads);
         for i in 0..num_threads {
-            let mut thread_data = data_snapshot.clone();
+            let mut thread_data = data_snapshot;
             let tt = &transposition_table;
             let mech = &mechanics;
             handles.push(s.spawn(move || {

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -2,60 +2,149 @@
 ///
 /// Uses i8 values (1 = P0 wins, 0 = tie, -1 = P1 wins)
 /// with a transposition table.
+///
+/// Storage: Parquet file with two columns (`state`, `value`), sorted by
+/// `state`. The footer holds key/value metadata (board_size, max_walls,
+/// max_steps, num_states). Row-group min/max statistics on `state` are
+/// used to prune lookups; we never load the entire DB into memory.
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Array, Int64Array, Int8Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use dashmap::DashMap;
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ParquetRecordBatchReaderBuilder};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::{Compression, ZstdLevel};
+use parquet::file::properties::WriterProperties;
+use parquet::file::statistics::Statistics;
+use parquet::format::KeyValue;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
-use rusqlite::{params, Connection};
-use std::path::Path;
 
 use super::q_game_mechanics::QGameMechanics;
 
 /// Transposition table type alias.
 pub type TranspositionTable = DashMap<u64, i8>;
 
-/// SQLite-backed policy database for storing and querying pre-computed minimax values.
+/// Number of rows per Parquet row group. Larger means fewer groups (less
+/// per-group overhead) but larger decode units. 1M is a good general default.
+const ROW_GROUP_SIZE: usize = 1_000_000;
+
+/// Per-batch chunk size when streaming rows into the writer. Each chunk
+/// becomes one Arrow `RecordBatch`; the writer buffers them up to a row
+/// group and then flushes.
+const WRITE_CHUNK_SIZE: usize = 65_536;
+
+/// Per-row-group statistics cached at open time, used to prune lookups.
+/// State values are stored in the Parquet file as `Int64` (the same 64
+/// bits as the underlying `u64`). All comparisons here are signed `i64`,
+/// matching the Parquet sort/statistics ordering. Callers convert to/from
+/// `u64` via `as` casts at the boundary.
+#[derive(Clone, Debug)]
+struct RowGroupStats {
+    idx: usize,
+    min: i64,
+    max: i64,
+    num_rows: u64,
+}
+
+/// Decoded contents of one row group, kept around when we want to reuse
+/// it across nearby lookups in the same call.
+struct DecodedRowGroup {
+    states: Vec<i64>,
+    values: Vec<i8>,
+}
+
+/// Parquet-backed policy database for storing and querying pre-computed
+/// minimax values. Single file per DB; sorted by `state` for efficient
+/// row-group pruning on point lookups.
 pub struct PolicyDb {
-    conn: Connection,
+    path: String,
+    metadata: ArrowReaderMetadata,
+    row_groups: Vec<RowGroupStats>,
+    /// `cum_rows[i]` = sum of `num_rows` over row groups `0..i`.
+    /// Length `row_groups.len() + 1`. `cum_rows.last()` = total rows.
+    cum_rows: Vec<u64>,
     mechanics: QGameMechanics,
+    board_size: usize,
+    max_walls: usize,
+    max_steps: usize,
+    num_states: usize,
+}
+
+fn schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("state", DataType::Int64, false),
+        Field::new("value", DataType::Int8, false),
+    ]))
+}
+
+fn parse_meta(kv: Option<&Vec<KeyValue>>, key: &str) -> Option<usize> {
+    kv?.iter()
+        .find(|e| e.key == key)
+        .and_then(|e| e.value.as_ref())
+        .and_then(|v| v.parse().ok())
 }
 
 impl PolicyDb {
     /// Open an existing policy database for reading.
-    ///
-    /// Reads metadata to initialize game mechanics for state interpretation.
     pub fn open(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let conn = Connection::open_with_flags(
-            Path::new(path),
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )?;
+        let file = File::open(Path::new(path))?;
+        let metadata = ArrowReaderMetadata::load(&file, Default::default())?;
 
-        // Read metadata to create mechanics.
-        let mut stmt = conn.prepare("SELECT key, value FROM metadata")?;
-        let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
-        })?;
-        let mut board_size = None;
-        let mut max_walls = None;
-        let mut max_steps = None;
-        for row in rows {
-            let (key, value) = row?;
-            match key.as_str() {
-                "board_size" => board_size = Some(value as usize),
-                "max_walls" => max_walls = Some(value as usize),
-                "max_steps" => max_steps = Some(value as usize),
-                _ => {}
-            }
+        let kv = metadata.metadata().file_metadata().key_value_metadata();
+        let board_size = parse_meta(kv, "board_size")
+            .ok_or("missing board_size in parquet metadata")?;
+        let max_walls = parse_meta(kv, "max_walls")
+            .ok_or("missing max_walls in parquet metadata")?;
+        let max_steps = parse_meta(kv, "max_steps")
+            .ok_or("missing max_steps in parquet metadata")?;
+        let num_states_meta = parse_meta(kv, "num_states");
+
+        let mechanics = QGameMechanics::new(board_size, max_walls, max_steps);
+
+        let pq_meta = metadata.metadata();
+        let num_row_groups = pq_meta.num_row_groups();
+        let mut row_groups = Vec::with_capacity(num_row_groups);
+        let mut cum_rows = Vec::with_capacity(num_row_groups + 1);
+        cum_rows.push(0u64);
+        let mut total = 0u64;
+        for i in 0..num_row_groups {
+            let rg = pq_meta.row_group(i);
+            let num_rows = rg.num_rows() as u64;
+            let stats = rg.column(0).statistics().ok_or_else(|| {
+                format!("row group {i} missing statistics on state column")
+            })?;
+            let (min, max) = match stats {
+                Statistics::Int64(s) => (
+                    *s.min_opt().ok_or("missing min stat on state")?,
+                    *s.max_opt().ok_or("missing max stat on state")?,
+                ),
+                _ => return Err(format!("unexpected stats variant for state column: {stats:?}").into()),
+            };
+            row_groups.push(RowGroupStats { idx: i, min, max, num_rows });
+            total += num_rows;
+            cum_rows.push(total);
         }
-        drop(stmt);
 
-        let mechanics = QGameMechanics::new(
-            board_size.ok_or("missing board_size in metadata")?,
-            max_walls.ok_or("missing max_walls in metadata")?,
-            max_steps.ok_or("missing max_steps in metadata")?,
-        );
+        // Prefer the cached count from metadata, fall back to summed row counts.
+        let num_states = num_states_meta.unwrap_or(total as usize);
 
-        Ok(Self { conn, mechanics })
+        Ok(Self {
+            path: path.to_string(),
+            metadata,
+            row_groups,
+            cum_rows,
+            mechanics,
+            board_size,
+            max_walls,
+            max_steps,
+            num_states,
+        })
     }
 
     /// Get a reference to the game mechanics.
@@ -63,11 +152,44 @@ impl PolicyDb {
         &self.mechanics
     }
 
+    /// Read metadata: `(board_size, max_walls, max_steps, num_states)`.
+    pub fn read_metadata(
+        &self,
+    ) -> Result<(usize, usize, usize, Option<usize>), Box<dyn std::error::Error>> {
+        Ok((self.board_size, self.max_walls, self.max_steps, Some(self.num_states)))
+    }
+
+    /// Count the total number of states.
+    pub fn count_states(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        Ok(self.num_states)
+    }
+
+    /// Decode a single row group into `(states, values)` columns.
+    /// Reopens the file so this is safe to call from a `&self` context
+    /// without interior mutability or sync.
+    fn decode_row_group(
+        &self,
+        rg_idx: usize,
+    ) -> Result<DecodedRowGroup, Box<dyn std::error::Error>> {
+        let file = File::open(&self.path)?;
+        let mut reader = ParquetRecordBatchReaderBuilder::new_with_metadata(file, self.metadata.clone())
+            .with_row_groups(vec![rg_idx])
+            .with_batch_size(self.row_groups[rg_idx].num_rows as usize)
+            .build()?;
+
+        let mut states = Vec::with_capacity(self.row_groups[rg_idx].num_rows as usize);
+        let mut values = Vec::with_capacity(self.row_groups[rg_idx].num_rows as usize);
+        while let Some(batch) = reader.next() {
+            let batch = batch?;
+            append_batch(&batch, &mut states, &mut values)?;
+        }
+        Ok(DecodedRowGroup { states, values })
+    }
+
     /// Look up values for all actions reachable from the given state.
     ///
     /// Returns `None` if there are no valid actions or no DB entries were found.
-    /// Otherwise returns `(actions, values)` where values are from the acting
-    /// player's perspective (positive = good for the acting player).
+    /// Values are returned from the acting player's perspective.
     pub fn lookup_action_values(
         &self,
         data: u64,
@@ -83,22 +205,16 @@ impl PolicyDb {
             .into_iter()
             .map(|(r, c)| (r as u8, c as u8, 2))
             .collect();
-        actions.extend(
-            walls
-                .into_iter()
-                .map(|(r, c, t)| (r as u8, c as u8, t as u8)),
-        );
+        actions.extend(walls.into_iter().map(|(r, c, t)| (r as u8, c as u8, t as u8)));
 
         if actions.is_empty() {
             return Ok(None);
         }
 
-        let mut stmt = self
-            .conn
-            .prepare_cached("SELECT value FROM policy WHERE state = ?1")?;
-
-        let mut values = Vec::with_capacity(actions.len());
-        let mut any_found = false;
+        // Compute child states and classify each as terminal-or-DB-lookup.
+        // P0-perspective values: 1 = P0 wins, 0 = tie, -1 = P1 wins.
+        let mut child_states = Vec::with_capacity(actions.len());
+        let mut terminal_p0: Vec<Option<i32>> = Vec::with_capacity(actions.len());
 
         for &(row, col, action_type) in &actions {
             let mut child_data = data;
@@ -111,42 +227,51 @@ impl PolicyDb {
             mechanics.switch_player(&mut child_data);
 
             let child_cp = mechanics.repr().get_current_player(child_data);
-            let child_opponent = 1 - child_cp;
+            let child_opp = 1 - child_cp;
 
-            // P0-perspective value for this child state.
-            let value_p0: i32 = if mechanics.check_win(child_data, child_opponent) {
-                // child_opponent just won
-                any_found = true;
-                if child_opponent == 0 {
-                    1
-                } else {
-                    -1
-                }
+            let term = if mechanics.check_win(child_data, child_opp) {
+                Some(if child_opp == 0 { 1 } else { -1 })
             } else if mechanics.repr().get_completed_steps(child_data)
                 >= mechanics.repr().max_steps()
             {
-                any_found = true;
-                0
+                Some(0)
             } else {
-                let result: Result<i32, _> = stmt.query_row(
-                    rusqlite::params![child_data.to_le_bytes().as_ref()],
-                    |row| row.get(0),
-                );
-                match result {
-                    Ok(v) => {
-                        any_found = true;
-                        v
-                    }
-                    Err(rusqlite::Error::QueryReturnedNoRows) => {
-                        panic!("No DB entry found for child state")
-                    }
-                    Err(e) => return Err(e.into()),
-                }
+                None
             };
 
-            // Convert from P0 perspective to acting player's perspective.
-            let value = if cp == 0 { value_p0 } else { -value_p0 };
-            values.push(value);
+            child_states.push(child_data);
+            terminal_p0.push(term);
+        }
+
+        // Batch-look up all non-terminal children in one sorted sweep.
+        let need_lookup: Vec<u64> = child_states
+            .iter()
+            .zip(terminal_p0.iter())
+            .filter(|(_, t)| t.is_none())
+            .map(|(s, _)| *s)
+            .collect();
+
+        let lookup_pairs = self.lookup_values_by_state(&need_lookup)?;
+        let lookup_map: HashMap<u64, i32> = lookup_pairs.into_iter().collect();
+
+        let mut values = Vec::with_capacity(actions.len());
+        let mut any_found = false;
+        for (child, term) in child_states.iter().zip(terminal_p0.iter()) {
+            let value_p0: i32 = match term {
+                Some(v) => {
+                    any_found = true;
+                    *v
+                }
+                None => match lookup_map.get(child) {
+                    Some(v) => {
+                        any_found = true;
+                        *v
+                    }
+                    None => panic!("No DB entry found for child state"),
+                },
+            };
+            // Convert P0-perspective to acting-player perspective.
+            values.push(if cp == 0 { value_p0 } else { -value_p0 });
         }
 
         if !any_found {
@@ -156,100 +281,111 @@ impl PolicyDb {
         Ok(Some((actions, values)))
     }
 
-    /// Read metadata from the database.
+    /// Fetch states and values by 1-based rowid (matches old SQLite ROWID
+    /// semantics: row N is the Nth entry in sorted-state order).
     ///
-    /// Returns `(board_size, max_walls, max_steps, num_states)` where
-    /// `num_states` is `None` if not present in the metadata table.
-    pub fn read_metadata(&self) -> Result<(usize, usize, usize, Option<usize>), Box<dyn std::error::Error>> {
-        let mut stmt = self.conn.prepare("SELECT key, value FROM metadata")?;
-        let rows = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
-        })?;
-
-        let mut board_size = None;
-        let mut max_walls = None;
-        let mut max_steps = None;
-        let mut num_states = None;
-
-        for row in rows {
-            let (key, value) = row?;
-            match key.as_str() {
-                "board_size" => board_size = Some(value as usize),
-                "max_walls" => max_walls = Some(value as usize),
-                "max_steps" => max_steps = Some(value as usize),
-                "num_states" => num_states = Some(value as usize),
-                _ => {}
-            }
-        }
-
-        Ok((
-            board_size.ok_or("missing board_size in metadata")?,
-            max_walls.ok_or("missing max_walls in metadata")?,
-            max_steps.ok_or("missing max_steps in metadata")?,
-            num_states,
-        ))
-    }
-
-    /// Count the total number of states in the policy table.
-    pub fn count_states(&self) -> Result<usize, Box<dyn std::error::Error>> {
-        let count: i64 = self.conn.query_row("SELECT COUNT(*) FROM policy", [], |row| row.get(0))?;
-        Ok(count as usize)
-    }
-
-    /// Fetch states and values by rowid.
-    ///
-    /// Returns a list of `(state, value)` tuples for each found rowid, where
-    /// `state` is the u64 packed state.
-    pub fn fetch_states_by_rowid(&self, rowids: &[i64]) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
+    /// Returns one `(state, value)` per requested rowid, in ascending rowid
+    /// order. Rowids out of range are silently dropped.
+    pub fn fetch_states_by_rowid(
+        &self,
+        rowids: &[i64],
+    ) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
         if rowids.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders: String = std::iter::repeat("?").take(rowids.len()).collect::<Vec<_>>().join(",");
-        let sql = format!("SELECT state, value FROM policy WHERE rowid IN ({})", placeholders);
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(rowids.iter()), |row| {
-            let bytes: Vec<u8> = row.get(0)?;
-            let mut arr = [0u8; 8];
-            arr[..bytes.len()].copy_from_slice(&bytes);
-            Ok((u64::from_le_bytes(arr), row.get::<_, i32>(1)?))
-        })?;
-        let mut results = Vec::with_capacity(rowids.len());
-        for row in rows {
-            results.push(row?);
+        let total_rows = *self.cum_rows.last().unwrap_or(&0);
+
+        let mut sorted: Vec<u64> = rowids
+            .iter()
+            .filter_map(|&r| {
+                if r >= 1 && (r as u64) <= total_rows {
+                    Some((r - 1) as u64)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        sorted.sort_unstable();
+
+        let mut results = Vec::with_capacity(sorted.len());
+        let mut current_rg: Option<usize> = None;
+        let mut decoded: Option<DecodedRowGroup> = None;
+
+        for r0 in sorted {
+            // cum_rows is sorted ascending; find the row group whose range
+            // [cum_rows[i], cum_rows[i+1]) contains r0.
+            let rg_idx = match self.cum_rows.binary_search(&r0) {
+                Ok(i) => i,        // r0 is the first row of group i
+                Err(i) => i - 1,   // r0 falls in group i-1
+            };
+            let row_in_group = (r0 - self.cum_rows[rg_idx]) as usize;
+
+            if current_rg != Some(rg_idx) {
+                decoded = Some(self.decode_row_group(rg_idx)?);
+                current_rg = Some(rg_idx);
+            }
+            let dec = decoded.as_ref().unwrap();
+            let s = dec.states[row_in_group] as u64;
+            let v = dec.values[row_in_group] as i32;
+            results.push((s, v));
         }
+
         Ok(results)
     }
 
     /// Look up values for the given states.
     ///
-    /// Returns a list of `(state, value)` for each state found in the DB.
-    /// States not present in the DB are omitted from the result.
-    pub fn lookup_values_by_state(&self, states: &[u64]) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
+    /// Returns `(state, value)` for each state found in the DB. States
+    /// not present are omitted. Internally walks row groups in sorted
+    /// order, decoding each at most once.
+    pub fn lookup_values_by_state(
+        &self,
+        states: &[u64],
+    ) -> Result<Vec<(u64, i32)>, Box<dyn std::error::Error>> {
         if states.is_empty() {
             return Ok(Vec::new());
         }
-        let placeholders: String = std::iter::repeat("?").take(states.len()).collect::<Vec<_>>().join(",");
-        let sql = format!("SELECT state, value FROM policy WHERE state IN ({})", placeholders);
-        let mut stmt = self.conn.prepare(&sql)?;
-        let blobs: Vec<Vec<u8>> = states.iter().map(|s| s.to_le_bytes().to_vec()).collect();
-        let params: Vec<&dyn rusqlite::ToSql> = blobs.iter().map(|b| b as &dyn rusqlite::ToSql).collect();
-        let rows = stmt.query_map(params.as_slice(), |row| {
-            let bytes: Vec<u8> = row.get(0)?;
-            let mut arr = [0u8; 8];
-            arr[..bytes.len()].copy_from_slice(&bytes);
-            Ok((u64::from_le_bytes(arr), row.get::<_, i32>(1)?))
-        })?;
-        let mut results = Vec::with_capacity(states.len());
-        for row in rows {
-            results.push(row?);
+        let mut sorted: Vec<i64> = states.iter().map(|&s| s as i64).collect();
+        sorted.sort_unstable();
+        sorted.dedup();
+
+        let mut results = Vec::new();
+        let mut q_idx = 0usize;
+        let mut rg_idx = 0usize;
+
+        while q_idx < sorted.len() && rg_idx < self.row_groups.len() {
+            let q = sorted[q_idx];
+            let rg = &self.row_groups[rg_idx];
+
+            if q < rg.min {
+                // Sorted file: q can't appear in any later row group either.
+                q_idx += 1;
+            } else if q > rg.max {
+                rg_idx += 1;
+            } else {
+                // q is in [min, max]; decode this row group once and
+                // resolve every query whose value falls in the same range.
+                let decoded = self.decode_row_group(rg.idx)?;
+                while q_idx < sorted.len() && sorted[q_idx] <= rg.max {
+                    let q2 = sorted[q_idx];
+                    if q2 >= rg.min {
+                        if let Ok(pos) = decoded.states.binary_search(&q2) {
+                            results.push((q2 as u64, decoded.values[pos] as i32));
+                        }
+                    }
+                    q_idx += 1;
+                }
+                rg_idx += 1;
+            }
         }
+
         Ok(results)
     }
 
     /// Create a new policy database from a transposition table.
     ///
     /// Only states where `completed_steps % step_interval == 0` are saved.
-    /// Returns the number of entries written.
+    /// Returns the number of entries written (after filtering).
     pub fn write(
         mechanics: &QGameMechanics,
         entries: TranspositionTable,
@@ -259,82 +395,87 @@ impl PolicyDb {
         max_walls: usize,
         step_interval: usize,
     ) -> Result<usize, Box<dyn std::error::Error>> {
-        let mut conn = Connection::open(Path::new(path))?;
-
-        // Performance pragmas: disable journaling and syncs during bulk insert.
-        conn.execute_batch(
-            "PRAGMA journal_mode = OFF;
-             PRAGMA synchronous = OFF;
-             PRAGMA locking_mode = EXCLUSIVE;
-             PRAGMA temp_store = MEMORY;
-             PRAGMA cache_size = -64000;",
-        )?;
-
-        conn.execute("DROP TABLE IF EXISTS policy", [])?;
-        conn.execute("DROP TABLE IF EXISTS metadata", [])?;
-
-        conn.execute(
-            "CREATE TABLE metadata (
-                key TEXT PRIMARY KEY,
-                value FLOAT NOT NULL
-            )",
-            [],
-        )?;
-
-        conn.execute(
-            "INSERT INTO metadata (key, value) VALUES ('board_size', ?1)",
-            params![board_size as f32],
-        )?;
-        conn.execute(
-            "INSERT INTO metadata (key, value) VALUES ('max_steps', ?1)",
-            params![max_steps as f32],
-        )?;
-        conn.execute(
-            "INSERT INTO metadata (key, value) VALUES ('max_walls', ?1)",
-            params![max_walls as f32],
-        )?;
-
-        // Create table with autoincrementing ID for efficient random sampling.
-        conn.execute(
-            "CREATE TABLE policy (
-                state BLOB,
-                value INTEGER NOT NULL
-            )",
-            [],
-        )?;
-
-        let num_entries = entries.len();
-
-        let tx = conn.transaction()?;
-        {
-            let mut stmt = tx.prepare("INSERT INTO policy (state, value) VALUES (?1, ?2)")?;
-
-            for (key, value) in entries.into_iter() {
-                let steps = mechanics.repr().get_completed_steps(key);
-                if steps % step_interval != 0 {
-                    continue;
+        // Drain DashMap, apply step_interval filter, sort by state.
+        // Sort uses i64 so the on-disk order matches the read-time
+        // statistics ordering (Parquet Int64 stats are signed).
+        let mut rows: Vec<(i64, i8)> = entries
+            .into_iter()
+            .filter_map(|(s, v)| {
+                let steps = mechanics.repr().get_completed_steps(s);
+                if steps % step_interval == 0 {
+                    Some((s as i64, v))
+                } else {
+                    None
                 }
+            })
+            .collect();
+        rows.sort_unstable_by_key(|(s, _)| *s);
 
-                // Store P0-absolute values (1=P0 wins, -1=P0 loses).
-                stmt.execute(params![key.to_le_bytes().as_ref(), value as i32])?;
-            }
-            drop(stmt);
+        let num_rows = rows.len();
+        let kv_metadata = vec![
+            KeyValue {
+                key: "board_size".to_string(),
+                value: Some(board_size.to_string()),
+            },
+            KeyValue {
+                key: "max_walls".to_string(),
+                value: Some(max_walls.to_string()),
+            },
+            KeyValue {
+                key: "max_steps".to_string(),
+                value: Some(max_steps.to_string()),
+            },
+            KeyValue {
+                key: "num_states".to_string(),
+                value: Some(num_rows.to_string()),
+            },
+        ];
+
+        let props = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(ZstdLevel::try_new(3)?))
+            .set_max_row_group_size(ROW_GROUP_SIZE)
+            .set_key_value_metadata(Some(kv_metadata))
+            .build();
+
+        let schema = schema();
+        let file = File::create(Path::new(path))?;
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
+
+        // Stream rows in moderate chunks so we don't allocate one giant batch.
+        for chunk in rows.chunks(WRITE_CHUNK_SIZE) {
+            let states: Vec<i64> = chunk.iter().map(|(s, _)| *s).collect();
+            let values: Vec<i8> = chunk.iter().map(|(_, v)| *v).collect();
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int64Array::from(states)), Arc::new(Int8Array::from(values))],
+            )?;
+            writer.write(&batch)?;
         }
-        tx.commit()?;
+        writer.close()?;
 
-        // Create index after all inserts (much faster than maintaining during insert).
-        conn.execute("CREATE UNIQUE INDEX idx_policy_state ON policy(state)", [])?;
-
-        // Store the number of policy states in metadata for efficient random sampling.
-        let num_policy_rows: i64 =
-            conn.query_row("SELECT COUNT(*) FROM policy", [], |row| row.get(0))?;
-        conn.execute(
-            "INSERT INTO metadata (key, value) VALUES ('num_states', ?1)",
-            params![num_policy_rows as f64],
-        )?;
-
-        Ok(num_entries)
+        Ok(num_rows)
     }
+}
+
+/// Append a record batch's two columns to the running state/value vectors.
+fn append_batch(
+    batch: &RecordBatch,
+    states: &mut Vec<i64>,
+    values: &mut Vec<i8>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let s_col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or("state column is not Int64")?;
+    let v_col = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int8Array>()
+        .ok_or("value column is not Int8")?;
+    states.extend_from_slice(s_col.values());
+    values.extend_from_slice(v_col.values());
+    Ok(())
 }
 
 /// Get all valid actions (moves + wall placements) for the current player.
@@ -483,6 +624,7 @@ pub fn minimax_lazy_smp(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn test_minimax_initial_state_3x3() {
@@ -532,5 +674,96 @@ mod tests {
         minimax(&mechanics, &mut data, &table);
 
         assert!(!table.is_empty(), "Transposition table should have entries");
+    }
+
+    /// End-to-end: write a small DB, reopen it, verify metadata, count, and
+    /// every state we wrote can be looked up by both rowid and state value.
+    #[test]
+    fn test_write_then_read_roundtrip() {
+        let mechanics = QGameMechanics::new(3, 0, 8);
+        let mut root = mechanics.create_initial_state();
+        let table = TranspositionTable::new();
+        minimax(&mechanics, &mut root, &table);
+        assert!(!table.is_empty());
+
+        // Snapshot expected entries before write() drains the DashMap.
+        let expected: Vec<(u64, i8)> =
+            table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.parquet");
+        let path_str = path.to_str().unwrap();
+        let written = PolicyDb::write(
+            &mechanics,
+            table,
+            path_str,
+            3,    // board_size
+            8,    // max_steps
+            0,    // max_walls
+            1,    // step_interval (keep all)
+        )
+        .unwrap();
+        assert_eq!(written, expected.len());
+
+        let db = PolicyDb::open(path_str).unwrap();
+        assert_eq!(
+            db.read_metadata().unwrap(),
+            (3, 0, 8, Some(expected.len()))
+        );
+        assert_eq!(db.count_states().unwrap(), expected.len());
+
+        // Round-trip every entry by state lookup.
+        let states: Vec<u64> = expected.iter().map(|(s, _)| *s).collect();
+        let pairs = db.lookup_values_by_state(&states).unwrap();
+        assert_eq!(pairs.len(), expected.len());
+        let got_map: HashMap<u64, i32> = pairs.into_iter().collect();
+        for (s, v) in &expected {
+            assert_eq!(got_map.get(s), Some(&(*v as i32)));
+        }
+
+        // Round-trip every entry by sequential rowid scan.
+        let all_ids: Vec<i64> = (1..=expected.len() as i64).collect();
+        let by_id = db.fetch_states_by_rowid(&all_ids).unwrap();
+        assert_eq!(by_id.len(), expected.len());
+        let by_id_map: HashMap<u64, i32> = by_id.into_iter().collect();
+        for (s, v) in &expected {
+            assert_eq!(by_id_map.get(s), Some(&(*v as i32)));
+        }
+    }
+
+    /// `lookup_action_values` should resolve terminal child states inline
+    /// (without DB lookup) and DB-resident children via the Parquet sweep.
+    #[test]
+    fn test_lookup_action_values_terminal() {
+        let mechanics = QGameMechanics::new(3, 0, 8);
+        let mut root = mechanics.create_initial_state();
+        let table = TranspositionTable::new();
+        minimax(&mechanics, &mut root, &table);
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.parquet");
+        let path_str = path.to_str().unwrap();
+        PolicyDb::write(&mechanics, table, path_str, 3, 8, 0, 1).unwrap();
+
+        let db = PolicyDb::open(path_str).unwrap();
+
+        // Construct a state where P0 is one row from goal — at least one
+        // child action wins immediately (terminal child, no DB lookup).
+        let mut state = mechanics.create_initial_state();
+        mechanics.repr().set_player_position(&mut state, 0, 1, 1);
+        mechanics.repr().set_player_position(&mut state, 1, 2, 0);
+        mechanics.repr().set_current_player(&mut state, 0);
+        mechanics.repr().set_completed_steps(&mut state, 2);
+
+        let result = db.lookup_action_values(state).unwrap();
+        let (actions, values) = result.expect("should have valid actions");
+        assert_eq!(actions.len(), values.len());
+        assert!(!actions.is_empty());
+        // At least one action should yield a winning value (1) from the
+        // acting player's perspective.
+        assert!(
+            values.iter().any(|&v| v == 1),
+            "expected at least one winning action value, got {values:?}"
+        );
     }
 }

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -54,16 +54,50 @@ pub type TranspositionTable = DashMap<StateKey, i8>;
 /// SQLite-backed policy database for storing and querying pre-computed minimax values.
 pub struct PolicyDb {
     conn: Connection,
+    mechanics: QGameMechanics,
 }
 
 impl PolicyDb {
     /// Open an existing policy database for reading.
+    ///
+    /// Reads metadata to initialize game mechanics for state interpretation.
     pub fn open(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let conn = Connection::open_with_flags(
             Path::new(path),
             rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
-        Ok(Self { conn })
+
+        // Read metadata to create mechanics.
+        let mut stmt = conn.prepare("SELECT key, value FROM metadata")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+        })?;
+        let mut board_size = None;
+        let mut max_walls = None;
+        let mut max_steps = None;
+        for row in rows {
+            let (key, value) = row?;
+            match key.as_str() {
+                "board_size" => board_size = Some(value as usize),
+                "max_walls" => max_walls = Some(value as usize),
+                "max_steps" => max_steps = Some(value as usize),
+                _ => {}
+            }
+        }
+        drop(stmt);
+
+        let mechanics = QGameMechanics::new(
+            board_size.ok_or("missing board_size in metadata")?,
+            max_walls.ok_or("missing max_walls in metadata")?,
+            max_steps.ok_or("missing max_steps in metadata")?,
+        );
+
+        Ok(Self { conn, mechanics })
+    }
+
+    /// Get a reference to the game mechanics.
+    pub fn mechanics(&self) -> &QGameMechanics {
+        &self.mechanics
     }
 
     /// Look up values for all actions reachable from the given state.
@@ -73,9 +107,9 @@ impl PolicyDb {
     /// player's perspective (positive = good for the acting player).
     pub fn lookup_action_values(
         &self,
-        mechanics: &QGameMechanics,
         data: &[u8],
     ) -> Result<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>, Box<dyn std::error::Error>> {
+        let mechanics = &self.mechanics;
         let cp = mechanics.repr().get_current_player(data);
 
         let mut data_mut = data.to_vec();
@@ -155,6 +189,88 @@ impl PolicyDb {
         }
 
         Ok(Some((actions, values)))
+    }
+
+    /// Read metadata from the database.
+    ///
+    /// Returns `(board_size, max_walls, max_steps, num_states)` where
+    /// `num_states` is `None` if not present in the metadata table.
+    pub fn read_metadata(&self) -> Result<(usize, usize, usize, Option<usize>), Box<dyn std::error::Error>> {
+        let mut stmt = self.conn.prepare("SELECT key, value FROM metadata")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+        })?;
+
+        let mut board_size = None;
+        let mut max_walls = None;
+        let mut max_steps = None;
+        let mut num_states = None;
+
+        for row in rows {
+            let (key, value) = row?;
+            match key.as_str() {
+                "board_size" => board_size = Some(value as usize),
+                "max_walls" => max_walls = Some(value as usize),
+                "max_steps" => max_steps = Some(value as usize),
+                "num_states" => num_states = Some(value as usize),
+                _ => {}
+            }
+        }
+
+        Ok((
+            board_size.ok_or("missing board_size in metadata")?,
+            max_walls.ok_or("missing max_walls in metadata")?,
+            max_steps.ok_or("missing max_steps in metadata")?,
+            num_states,
+        ))
+    }
+
+    /// Count the total number of states in the policy table.
+    pub fn count_states(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        let count: i64 = self.conn.query_row("SELECT COUNT(*) FROM policy", [], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    /// Fetch states and values by rowid.
+    ///
+    /// Returns a list of `(state_bytes, value)` tuples for each found rowid.
+    pub fn fetch_states_by_rowid(&self, rowids: &[i64]) -> Result<Vec<(Vec<u8>, i32)>, Box<dyn std::error::Error>> {
+        if rowids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = std::iter::repeat("?").take(rowids.len()).collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT state, value FROM policy WHERE rowid IN ({})", placeholders);
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(rusqlite::params_from_iter(rowids.iter()), |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i32>(1)?))
+        })?;
+        let mut results = Vec::with_capacity(rowids.len());
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
+    }
+
+    /// Look up values for the given state blobs.
+    ///
+    /// Returns a list of `(state_bytes, value)` for each state found in the DB.
+    /// States not present in the DB are omitted from the result.
+    pub fn lookup_values_by_state(&self, states: &[&[u8]]) -> Result<Vec<(Vec<u8>, i32)>, Box<dyn std::error::Error>> {
+        if states.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders: String = std::iter::repeat("?").take(states.len()).collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT state, value FROM policy WHERE state IN ({})", placeholders);
+        let mut stmt = self.conn.prepare(&sql)?;
+        let params: Vec<&dyn rusqlite::ToSql> = states.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+        let rows = stmt.query_map(params.as_slice(), |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i32>(1)?))
+        })?;
+        let mut results = Vec::with_capacity(states.len());
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
     }
 
     /// Create a new policy database from a transposition table.

--- a/deep_quoridor/rust/src/compact/policy_db.rs
+++ b/deep_quoridor/rust/src/compact/policy_db.rs
@@ -118,12 +118,12 @@ impl PolicyDb {
         let metadata = ArrowReaderMetadata::load(&file, Default::default())?;
 
         let kv = metadata.metadata().file_metadata().key_value_metadata();
-        let board_size = parse_meta(kv, "board_size")
-            .ok_or("missing board_size in parquet metadata")?;
-        let max_walls = parse_meta(kv, "max_walls")
-            .ok_or("missing max_walls in parquet metadata")?;
-        let max_steps = parse_meta(kv, "max_steps")
-            .ok_or("missing max_steps in parquet metadata")?;
+        let board_size =
+            parse_meta(kv, "board_size").ok_or("missing board_size in parquet metadata")?;
+        let max_walls =
+            parse_meta(kv, "max_walls").ok_or("missing max_walls in parquet metadata")?;
+        let max_steps =
+            parse_meta(kv, "max_steps").ok_or("missing max_steps in parquet metadata")?;
         let num_states_meta = parse_meta(kv, "num_states");
 
         let mechanics = QGameMechanics::new(board_size, max_walls, max_steps);
@@ -137,17 +137,27 @@ impl PolicyDb {
         for i in 0..num_row_groups {
             let rg = pq_meta.row_group(i);
             let num_rows = rg.num_rows() as u64;
-            let stats = rg.column(0).statistics().ok_or_else(|| {
-                format!("row group {i} missing statistics on state column")
-            })?;
+            let stats = rg
+                .column(0)
+                .statistics()
+                .ok_or_else(|| format!("row group {i} missing statistics on state column"))?;
             let (min, max) = match stats {
                 Statistics::Int64(s) => (
                     *s.min_opt().ok_or("missing min stat on state")?,
                     *s.max_opt().ok_or("missing max stat on state")?,
                 ),
-                _ => return Err(format!("unexpected stats variant for state column: {stats:?}").into()),
+                _ => {
+                    return Err(
+                        format!("unexpected stats variant for state column: {stats:?}").into(),
+                    )
+                }
             };
-            row_groups.push(RowGroupStats { idx: i, min, max, num_rows });
+            row_groups.push(RowGroupStats {
+                idx: i,
+                min,
+                max,
+                num_rows,
+            });
             total += num_rows;
             cum_rows.push(total);
         }
@@ -167,11 +177,8 @@ impl PolicyDb {
             // RecordBatch into the running ordered Vec, then build the
             // O(1) lookup HashMap from it.
             let file = File::open(Path::new(path))?;
-            let reader = ParquetRecordBatchReaderBuilder::new_with_metadata(
-                file,
-                metadata.clone(),
-            )
-            .build()?;
+            let reader = ParquetRecordBatchReaderBuilder::new_with_metadata(file, metadata.clone())
+                .build()?;
 
             let mut state_buf: Vec<i64> = Vec::with_capacity(num_states);
             let mut value_buf: Vec<i8> = Vec::with_capacity(num_states);
@@ -210,7 +217,12 @@ impl PolicyDb {
     pub fn read_metadata(
         &self,
     ) -> Result<(usize, usize, usize, Option<usize>), Box<dyn std::error::Error>> {
-        Ok((self.board_size, self.max_walls, self.max_steps, Some(self.num_states)))
+        Ok((
+            self.board_size,
+            self.max_walls,
+            self.max_steps,
+            Some(self.num_states),
+        ))
     }
 
     /// Count the total number of states.
@@ -260,7 +272,11 @@ impl PolicyDb {
             .into_iter()
             .map(|(r, c)| (r as u8, c as u8, 2))
             .collect();
-        actions.extend(walls.into_iter().map(|(r, c, t)| (r as u8, c as u8, t as u8)));
+        actions.extend(
+            walls
+                .into_iter()
+                .map(|(r, c, t)| (r as u8, c as u8, t as u8)),
+        );
 
         if actions.is_empty() {
             return Ok(None);
@@ -398,17 +414,14 @@ impl PolicyDb {
                     // cum_rows is sorted ascending; find the row group whose
                     // range [cum_rows[i], cum_rows[i+1]) contains r0.
                     let rg_idx = match cum_rows.binary_search(&r0) {
-                        Ok(i) => i,        // r0 is the first row of group i
-                        Err(i) => i - 1,   // r0 falls in group i-1
+                        Ok(i) => i,      // r0 is the first row of group i
+                        Err(i) => i - 1, // r0 falls in group i-1
                     };
                     let row_in_group = (r0 - cum_rows[rg_idx]) as usize;
 
                     if current_rg != Some(rg_idx) {
-                        decoded = Some(Self::decode_row_group(
-                            path,
-                            metadata,
-                            &row_groups[rg_idx],
-                        )?);
+                        decoded =
+                            Some(Self::decode_row_group(path, metadata, &row_groups[rg_idx])?);
                         current_rg = Some(rg_idx);
                     }
                     let dec = decoded.as_ref().unwrap();
@@ -551,7 +564,10 @@ impl PolicyDb {
             let values: Vec<i8> = chunk.iter().map(|(_, v)| *v).collect();
             let batch = RecordBatch::try_new(
                 schema.clone(),
-                vec![Arc::new(Int64Array::from(states)), Arc::new(Int8Array::from(values))],
+                vec![
+                    Arc::new(Int64Array::from(states)),
+                    Arc::new(Int8Array::from(values)),
+                ],
             )?;
             writer.write(&batch)?;
         }
@@ -791,29 +807,22 @@ mod tests {
         assert!(!table.is_empty());
 
         // Snapshot expected entries before write() drains the DashMap.
-        let expected: Vec<(u64, i8)> =
-            table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
+        let expected: Vec<(u64, i8)> = table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
 
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.parquet");
         let path_str = path.to_str().unwrap();
         let written = PolicyDb::write(
-            &mechanics,
-            table,
-            path_str,
-            3,    // board_size
-            8,    // max_steps
-            0,    // max_walls
-            1,    // step_interval (keep all)
+            &mechanics, table, path_str, 3, // board_size
+            8, // max_steps
+            0, // max_walls
+            1, // step_interval (keep all)
         )
         .unwrap();
         assert_eq!(written, expected.len());
 
         let db = PolicyDb::open(path_str, false).unwrap();
-        assert_eq!(
-            db.read_metadata().unwrap(),
-            (3, 0, 8, Some(expected.len()))
-        );
+        assert_eq!(db.read_metadata().unwrap(), (3, 0, 8, Some(expected.len())));
         assert_eq!(db.count_states().unwrap(), expected.len());
 
         // Round-trip every entry by state lookup.
@@ -879,8 +888,7 @@ mod tests {
         let mut root = mechanics.create_initial_state();
         let table = TranspositionTable::new();
         minimax(&mechanics, &mut root, &table);
-        let expected: Vec<(u64, i8)> =
-            table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
+        let expected: Vec<(u64, i8)> = table.iter().map(|kv| (*kv.key(), *kv.value())).collect();
 
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.parquet");
@@ -891,7 +899,10 @@ mod tests {
         let lazy = PolicyDb::open(path_str, true).unwrap();
 
         // Same metadata.
-        assert_eq!(eager.read_metadata().unwrap(), lazy.read_metadata().unwrap());
+        assert_eq!(
+            eager.read_metadata().unwrap(),
+            lazy.read_metadata().unwrap()
+        );
         assert_eq!(eager.count_states().unwrap(), lazy.count_states().unwrap());
 
         // Same lookup_values_by_state results (sort both since order isn't
@@ -935,10 +946,8 @@ mod tests {
             .unwrap()
             .expect("lazy: action values");
 
-        let mut e_pairs: Vec<((u8, u8, u8), i32)> =
-            e_actions.into_iter().zip(e_values).collect();
-        let mut l_pairs: Vec<((u8, u8, u8), i32)> =
-            l_actions.into_iter().zip(l_values).collect();
+        let mut e_pairs: Vec<((u8, u8, u8), i32)> = e_actions.into_iter().zip(e_values).collect();
+        let mut l_pairs: Vec<((u8, u8, u8), i32)> = l_actions.into_iter().zip(l_values).collect();
         e_pairs.sort_unstable_by_key(|(a, _)| *a);
         l_pairs.sort_unstable_by_key(|(a, _)| *a);
         assert_eq!(e_pairs, l_pairs);

--- a/deep_quoridor/rust/src/compact/q_bit_repr.rs
+++ b/deep_quoridor/rust/src/compact/q_bit_repr.rs
@@ -1,8 +1,9 @@
 /// Compact bit-packed representation accessor for game states.
 ///
 /// This struct doesn't store the game state data itself - it only stores the
-/// parameters and computed offsets needed to interpret byte arrays as packed game states.
-/// The data is passed to each method, allowing flexible storage (stack or heap).
+/// parameters and computed offsets needed to interpret a u64 as a packed game state.
+/// The data is passed to each method by value (read) or mutable reference (write).
+/// Boards requiring more than 64 bits are not supported.
 
 // Wall orientations
 pub const WALL_VERTICAL: usize = 0;
@@ -33,7 +34,6 @@ pub struct QBitRepr {
     walls_remaining_bits: usize,
     completed_steps_bits: usize,
     total_bits: usize,
-    total_bytes: usize,
 
     // Bit offsets for each field
     walls_offset: usize,
@@ -63,7 +63,10 @@ impl QBitRepr {
         let completed_steps_offset = current_player_offset + 1;
 
         let total_bits = completed_steps_offset + completed_steps_bits;
-        let total_bytes = (total_bits + 7) / 8;
+        assert!(
+            total_bits <= 64,
+            "QBitRepr: state requires {total_bits} bits, which exceeds u64 capacity"
+        );
 
         Self {
             board_size,
@@ -75,19 +78,12 @@ impl QBitRepr {
             walls_remaining_bits,
             completed_steps_bits,
             total_bits,
-            total_bytes,
             walls_offset,
             player_pos_offsets,
             walls_remaining_offsets,
             current_player_offset,
             completed_steps_offset,
         }
-    }
-
-    /// Get the size of the packed representation in bytes
-    #[allow(dead_code)]
-    pub fn size_bytes(&self) -> usize {
-        self.total_bytes
     }
 
     #[allow(dead_code)]
@@ -106,55 +102,44 @@ impl QBitRepr {
         self.num_player_positions
     }
 
-    /// Create a new byte array for storing a packed state
-    pub fn create_data(&self) -> Vec<u8> {
-        vec![0u8; self.total_bytes]
+    /// Create a zero-initialized packed state value.
+    pub fn create_data(&self) -> u64 {
+        0u64
     }
 
     /// Get a bit at the specified position in the data
     #[inline]
-    fn get_bit(&self, data: &[u8], bit_index: usize) -> bool {
-        debug_assert!(data.len() >= self.total_bytes);
-        let byte_index = bit_index / 8;
-        let bit_offset = bit_index % 8;
-        (data[byte_index] >> bit_offset) & 1 == 1
+    fn get_bit(&self, data: u64, bit_index: usize) -> bool {
+        debug_assert!(bit_index < self.total_bits);
+        (data >> bit_index) & 1 == 1
     }
 
     /// Set a bit at the specified position in the data
     #[inline]
-    fn set_bit(&self, data: &mut [u8], bit_index: usize, value: bool) {
-        debug_assert!(data.len() >= self.total_bytes);
-        let byte_index = bit_index / 8;
-        let bit_offset = bit_index % 8;
+    fn set_bit(&self, data: &mut u64, bit_index: usize, value: bool) {
+        debug_assert!(bit_index < self.total_bits);
         if value {
-            data[byte_index] |= 1 << bit_offset;
+            *data |= 1u64 << bit_index;
         } else {
-            data[byte_index] &= !(1 << bit_offset);
+            *data &= !(1u64 << bit_index);
         }
     }
 
     /// Get an integer value starting at bit_offset with num_bits bits
     #[inline]
-    fn get_bits(&self, data: &[u8], bit_offset: usize, num_bits: usize) -> usize {
-        let mut value = 0usize;
-        for i in 0..num_bits {
-            if self.get_bit(data, bit_offset + i) {
-                value |= 1 << i;
-            }
-        }
-        value
+    fn get_bits(&self, data: u64, bit_offset: usize, num_bits: usize) -> usize {
+        ((data >> bit_offset) & ((1u64 << num_bits) - 1)) as usize
     }
 
     /// Set an integer value starting at bit_offset with num_bits bits
     #[inline]
-    fn set_bits(&self, data: &mut [u8], bit_offset: usize, num_bits: usize, value: usize) {
-        for i in 0..num_bits {
-            self.set_bit(data, bit_offset + i, (value >> i) & 1 == 1);
-        }
+    fn set_bits(&self, data: &mut u64, bit_offset: usize, num_bits: usize, value: usize) {
+        let mask = (1u64 << num_bits) - 1;
+        *data = (*data & !(mask << bit_offset)) | ((value as u64 & mask) << bit_offset);
     }
 
     /// Check if a wall is present at the given position
-    pub fn get_wall(&self, data: &[u8], row: usize, col: usize, orientation: usize) -> bool {
+    pub fn get_wall(&self, data: u64, row: usize, col: usize, orientation: usize) -> bool {
         let wall_index = self.wall_position_to_index(row, col, orientation);
         self.get_bit(data, self.walls_offset + wall_index)
     }
@@ -162,7 +147,7 @@ impl QBitRepr {
     /// Set a wall at the given position
     pub fn set_wall(
         &self,
-        data: &mut [u8],
+        data: &mut u64,
         row: usize,
         col: usize,
         orientation: usize,
@@ -173,14 +158,14 @@ impl QBitRepr {
     }
 
     /// Get a player's position
-    pub fn get_player_position(&self, data: &[u8], player: usize) -> (usize, usize) {
+    pub fn get_player_position(&self, data: u64, player: usize) -> (usize, usize) {
         debug_assert!(player < 2);
         let index = self.get_bits(data, self.player_pos_offsets[player], self.position_bits);
         self.index_to_position(index)
     }
 
     /// Set a player's position
-    pub fn set_player_position(&self, data: &mut [u8], player: usize, row: usize, col: usize) {
+    pub fn set_player_position(&self, data: &mut u64, player: usize, row: usize, col: usize) {
         debug_assert!(player < 2);
         let new_index = self.position_to_index(row, col);
         debug_assert!(new_index < self.num_player_positions);
@@ -193,7 +178,7 @@ impl QBitRepr {
     }
 
     /// Get player 1's remaining walls
-    pub fn get_walls_remaining(&self, data: &[u8], player: usize) -> usize {
+    pub fn get_walls_remaining(&self, data: u64, player: usize) -> usize {
         debug_assert!(player < 2);
         self.get_bits(
             data,
@@ -203,7 +188,7 @@ impl QBitRepr {
     }
 
     /// Set player 1's remaining walls
-    pub fn set_walls_remaining(&self, data: &mut [u8], player: usize, walls: usize) {
+    pub fn set_walls_remaining(&self, data: &mut u64, player: usize, walls: usize) {
         debug_assert!(player < 2);
         debug_assert!(walls <= self.max_walls);
         self.set_bits(
@@ -215,7 +200,7 @@ impl QBitRepr {
     }
 
     /// Get the current player (0 or 1)
-    pub fn get_current_player(&self, data: &[u8]) -> usize {
+    pub fn get_current_player(&self, data: u64) -> usize {
         if self.get_bit(data, self.current_player_offset) {
             1
         } else {
@@ -224,18 +209,18 @@ impl QBitRepr {
     }
 
     /// Set the current player
-    pub fn set_current_player(&self, data: &mut [u8], player: usize) {
+    pub fn set_current_player(&self, data: &mut u64, player: usize) {
         debug_assert!(player < 2);
         self.set_bit(data, self.current_player_offset, player == 1);
     }
 
     /// Get the number of completed steps
-    pub fn get_completed_steps(&self, data: &[u8]) -> usize {
+    pub fn get_completed_steps(&self, data: u64) -> usize {
         self.get_bits(data, self.completed_steps_offset, self.completed_steps_bits)
     }
 
     /// Set the number of completed steps
-    pub fn set_completed_steps(&self, data: &mut [u8], steps: usize) {
+    pub fn set_completed_steps(&self, data: &mut u64, steps: usize) {
         debug_assert!(steps <= self.max_steps);
         self.set_bits(
             data,
@@ -298,7 +283,7 @@ impl QBitRepr {
     }
 
     /// Display the board state as text art
-    pub fn print(&self, data: &[u8]) {
+    pub fn print(&self, data: u64) {
         println!("{}", self.display(data));
     }
 
@@ -310,7 +295,7 @@ impl QBitRepr {
     /// - '|' for vertical walls
     /// - '-' for horizontal walls
     /// - Metadata (steps, walls) shown on the right side
-    pub fn display(&self, data: &[u8]) -> String {
+    pub fn display(&self, data: u64) -> String {
         let mut output = String::new();
 
         // Get metadata
@@ -410,8 +395,8 @@ mod tests {
         // Walls remaining: ceil(log2(10)) = 4 bits each = 8 bits
         // Current player: 1 bit
         // Steps: ceil(log2(100)) = 7 bits
-        // Total: 32 + 10 + 8 + 1 + 7 = 58 bits = 8 bytes
-        assert_eq!(q.size_bytes(), 8);
+        // Total: 32 + 10 + 8 + 1 + 7 = 58 bits
+        assert_eq!(q.size_bits(), 58);
     }
 
     #[test]
@@ -422,8 +407,8 @@ mod tests {
         q.set_player_position(&mut data, 0, 0, 2);
         q.set_player_position(&mut data, 1, 4, 2);
 
-        assert_eq!(q.get_player_position(&data, 0), (0, 2));
-        assert_eq!(q.get_player_position(&data, 1), (4, 2));
+        assert_eq!(q.get_player_position(data, 0), (0, 2));
+        assert_eq!(q.get_player_position(data, 1), (4, 2));
     }
 
     #[test]
@@ -435,9 +420,9 @@ mod tests {
         q.set_wall(&mut data, 0, 0, WALL_VERTICAL, true);
         // Set vertical wall at (1, 1)
         q.set_wall(&mut data, 1, 1, WALL_VERTICAL, true);
-        assert!(q.get_wall(&data, 0, 0, WALL_VERTICAL));
-        assert!(q.get_wall(&data, 1, 1, WALL_VERTICAL));
-        assert!(!q.get_wall(&data, 0, 1, WALL_VERTICAL));
+        assert!(q.get_wall(data, 0, 0, WALL_VERTICAL));
+        assert!(q.get_wall(data, 1, 1, WALL_VERTICAL));
+        assert!(!q.get_wall(data, 0, 1, WALL_VERTICAL));
     }
 
     #[test]
@@ -446,7 +431,7 @@ mod tests {
         let mut data = q.create_data();
 
         q.set_walls_remaining(&mut data, 0, 10);
-        assert_eq!(q.get_walls_remaining(&data, 0), 10);
+        assert_eq!(q.get_walls_remaining(data, 0), 10);
     }
 
     #[test]
@@ -454,13 +439,13 @@ mod tests {
         let q = QBitRepr::new(5, 10, 100);
         let mut data = q.create_data();
 
-        assert_eq!(q.get_current_player(&data), 0);
+        assert_eq!(q.get_current_player(data), 0);
 
         q.set_current_player(&mut data, 1);
-        assert_eq!(q.get_current_player(&data), 1);
+        assert_eq!(q.get_current_player(data), 1);
 
         q.set_current_player(&mut data, 0);
-        assert_eq!(q.get_current_player(&data), 0);
+        assert_eq!(q.get_current_player(data), 0);
     }
 
     #[test]
@@ -468,10 +453,10 @@ mod tests {
         let q = QBitRepr::new(5, 10, 100);
         let mut data = q.create_data();
 
-        assert_eq!(q.get_completed_steps(&data), 0);
+        assert_eq!(q.get_completed_steps(data), 0);
 
         q.set_completed_steps(&mut data, 42);
-        assert_eq!(q.get_completed_steps(&data), 42);
+        assert_eq!(q.get_completed_steps(data), 42);
     }
 
     #[test]

--- a/deep_quoridor/rust/src/compact/q_bit_repr_conversions.rs
+++ b/deep_quoridor/rust/src/compact/q_bit_repr_conversions.rs
@@ -17,7 +17,7 @@ impl QBitRepr {
     /// * `completed_steps` - Number of steps completed so far
     pub fn from_game_state(
         &self,
-        data: &mut [u8],
+        data: &mut u64,
         grid: &ArrayView2<i8>,
         player_positions: &ArrayView2<i32>,
         walls_remaining: &ArrayView1<i32>,
@@ -71,7 +71,7 @@ impl QBitRepr {
     /// Extract player positions as a 2x2 array (format used by minimax)
     /// Returns [[p1_row, p1_col], [p2_row, p2_col]]
     #[allow(dead_code)]
-    pub fn to_player_positions(&self, data: &[u8]) -> Array2<i32> {
+    pub fn to_player_positions(&self, data: u64) -> Array2<i32> {
         let (p1_row, p1_col) = self.get_player_position(data, 0);
         let (p2_row, p2_col) = self.get_player_position(data, 1);
 
@@ -85,7 +85,7 @@ impl QBitRepr {
     /// Extract walls remaining as a 1D array (format used by minimax)
     /// Returns [p1_walls, p2_walls]
     #[allow(dead_code)]
-    pub fn to_walls_remaining(&self, data: &[u8]) -> Array1<i32> {
+    pub fn to_walls_remaining(&self, data: u64) -> Array1<i32> {
         Array1::from_vec(vec![
             self.get_walls_remaining(data, 0) as i32,
             self.get_walls_remaining(data, 1) as i32,
@@ -95,7 +95,7 @@ impl QBitRepr {
     /// Reconstruct the full grid with walls and player positions
     /// This creates a grid in the format used by minimax: (2*board_size + 3) x (2*board_size + 3)
     #[allow(dead_code)]
-    pub fn to_grid(&self, data: &[u8]) -> Array2<i8> {
+    pub fn to_grid(&self, data: u64) -> Array2<i8> {
         use crate::grid::{CELL_FREE, CELL_PLAYER1, CELL_PLAYER2, CELL_WALL};
 
         let grid_size = 2 * self.board_size() + 3;
@@ -197,19 +197,19 @@ mod tests {
         );
 
         // Verify we can extract the same data back
-        let extracted_positions = q.to_player_positions(&data);
+        let extracted_positions = q.to_player_positions(data);
         assert_eq!(extracted_positions[[0, 0]], 0);
         assert_eq!(extracted_positions[[0, 1]], 2);
         assert_eq!(extracted_positions[[1, 0]], 4);
         assert_eq!(extracted_positions[[1, 1]], 2);
 
-        let extracted_walls = q.to_walls_remaining(&data);
+        let extracted_walls = q.to_walls_remaining(data);
         assert_eq!(extracted_walls[0], 8);
 
         // P2 walls are computed: p1_used=2, total_on_board=2, so p2_used=0, p2_remaining=10
         assert_eq!(extracted_walls[1], 10, "P2 should have 10 walls remaining");
 
-        assert_eq!(q.get_current_player(&data), current_player as usize);
-        assert_eq!(q.get_completed_steps(&data), completed_steps as usize);
+        assert_eq!(q.get_current_player(data), current_player as usize);
+        assert_eq!(q.get_completed_steps(data), completed_steps as usize);
     }
 }

--- a/deep_quoridor/rust/src/compact/q_game_mechanics.rs
+++ b/deep_quoridor/rust/src/compact/q_game_mechanics.rs
@@ -61,7 +61,7 @@ impl QGameMechanics {
 
     /// Create initial game state
     #[allow(dead_code)]
-    pub fn create_initial_state(&self) -> Vec<u8> {
+    pub fn create_initial_state(&self) -> u64 {
         let mut data = self.repr.create_data();
         let board_size = self.repr.board_size();
 
@@ -90,7 +90,7 @@ impl QGameMechanics {
     /// Doesn't check that players can reach their goal still.
     pub fn is_wall_placement_free(
         &self,
-        data: &[u8],
+        data: u64,
         row: usize,
         col: usize,
         orientation: usize,
@@ -149,21 +149,21 @@ impl QGameMechanics {
 
     /// Place a wall (no validation - use is_wall_placement_valid first)
     #[inline]
-    pub fn place_wall(&self, data: &mut [u8], row: usize, col: usize, orientation: usize) {
+    pub fn place_wall(&self, data: &mut u64, row: usize, col: usize, orientation: usize) {
         self.repr.set_wall(data, row, col, orientation, true);
     }
 
     /// Remove a wall
     #[inline]
     #[allow(dead_code)]
-    pub fn remove_wall(&self, data: &mut [u8], row: usize, col: usize, orientation: usize) {
+    pub fn remove_wall(&self, data: &mut u64, row: usize, col: usize, orientation: usize) {
         self.repr.set_wall(data, row, col, orientation, false);
     }
 
     /// Check if there's a wall blocking movement between two adjacent cells
     fn is_wall_between(
         &self,
-        data: &[u8],
+        data: u64,
         from_row: usize,
         from_col: usize,
         to_row: usize,
@@ -264,7 +264,7 @@ impl QGameMechanics {
 
     /// Check if a player can reach their goal row using BFS.
     /// Uses a reusable BfsBuffer to avoid allocations.
-    fn can_reach_goal(&self, data: &[u8], player: usize, buf: &mut BfsBuffer) -> bool {
+    fn can_reach_goal(&self, data: u64, player: usize, buf: &mut BfsBuffer) -> bool {
         let board_size = self.repr.board_size();
         let goal_row = self.goal_rows[player];
 
@@ -328,27 +328,27 @@ impl QGameMechanics {
     /// Temporarily mutates `data` in-place (places then removes the wall) to avoid cloning.
     pub fn is_wall_placement_valid(
         &self,
-        data: &mut [u8],
+        data: &mut u64,
         row: usize,
         col: usize,
         orientation: usize,
         buf: &mut BfsBuffer,
     ) -> bool {
         // First check if placement is physically possible
-        if !self.is_wall_placement_free(data, row, col, orientation) {
+        if !self.is_wall_placement_free(*data, row, col, orientation) {
             return false;
         }
 
         // Temporarily place the wall, check reachability, then remove it
         self.place_wall(data, row, col, orientation);
-        let valid = self.can_reach_goal(data, 0, buf) && self.can_reach_goal(data, 1, buf);
+        let valid = self.can_reach_goal(*data, 0, buf) && self.can_reach_goal(*data, 1, buf);
         self.remove_wall(data, row, col, orientation);
 
         valid
     }
 
     /// Execute a move action
-    pub fn execute_move(&self, data: &mut [u8], player: usize, dest_row: usize, dest_col: usize) {
+    pub fn execute_move(&self, data: &mut u64, player: usize, dest_row: usize, dest_col: usize) {
         self.repr
             .set_player_position(data, player, dest_row, dest_col);
     }
@@ -356,7 +356,7 @@ impl QGameMechanics {
     /// Execute a wall placement action
     pub fn execute_wall_placement(
         &self,
-        data: &mut [u8],
+        data: &mut u64,
         player: usize,
         row: usize,
         col: usize,
@@ -365,40 +365,40 @@ impl QGameMechanics {
         self.place_wall(data, row, col, orientation);
 
         // Decrement walls remaining for the player
-        let current_walls = self.repr.get_walls_remaining(data, player);
+        let current_walls = self.repr.get_walls_remaining(*data, player);
 
         self.repr
             .set_walls_remaining(data, player, current_walls.saturating_sub(1));
     }
 
     /// Switch to the next player
-    pub fn switch_player(&self, data: &mut [u8]) {
-        let current = self.repr.get_current_player(data);
+    pub fn switch_player(&self, data: &mut u64) {
+        let current = self.repr.get_current_player(*data);
         self.repr.set_current_player(data, 1 - current);
 
         // Increment step counter
-        let steps = self.repr.get_completed_steps(data);
+        let steps = self.repr.get_completed_steps(*data);
         self.repr.set_completed_steps(data, steps + 1);
     }
 
     /// Check if a player has won
-    pub fn check_win(&self, data: &[u8], player: usize) -> bool {
+    pub fn check_win(&self, data: u64, player: usize) -> bool {
         let (row, _col) = self.repr.get_player_position(data, player);
         row == self.goal_rows[player]
     }
 
     /// Check if the game is a draw (max steps reached)
     #[allow(dead_code)]
-    pub fn is_draw(&self, data: &[u8]) -> bool {
+    pub fn is_draw(&self, data: u64) -> bool {
         self.repr.get_completed_steps(data) >= self.repr.max_steps()
     }
 
     /// Get all valid wall placements for the current player
-    pub fn get_valid_wall_placements(&self, data: &mut [u8]) -> Vec<(usize, usize, usize)> {
-        let current_player = self.repr.get_current_player(data);
+    pub fn get_valid_wall_placements(&self, data: &mut u64) -> Vec<(usize, usize, usize)> {
+        let current_player = self.repr.get_current_player(*data);
 
         // Check if player has walls remaining
-        let walls_remaining = self.repr.get_walls_remaining(data, current_player);
+        let walls_remaining = self.repr.get_walls_remaining(*data, current_player);
 
         if walls_remaining == 0 {
             return Vec::new();
@@ -422,7 +422,7 @@ impl QGameMechanics {
     }
 
     /// Get all valid moves for the current player
-    pub fn get_valid_moves(&self, data: &[u8]) -> Vec<(usize, usize)> {
+    pub fn get_valid_moves(&self, data: u64) -> Vec<(usize, usize)> {
         let current_player = self.repr.get_current_player(data);
         let board_size = self.repr.board_size();
 
@@ -581,11 +581,11 @@ impl QGameMechanics {
     }
 
     /// Display the board state as text art
-    pub fn print(&self, data: &[u8]) {
+    pub fn print(&self, data: u64) {
         println!("{}", self.display(data));
     }
 
-    pub fn display(&self, data: &[u8]) -> String {
+    pub fn display(&self, data: u64) -> String {
         self.repr.display(data)
     }
 }
@@ -596,97 +596,96 @@ mod tests {
 
     #[test]
     fn test_create_initial_state() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let state = mechanics.create_initial_state();
 
         // Check player positions
-        let (p1_row, p1_col) = mechanics.repr.get_player_position(&state, 0);
-        let (p2_row, p2_col) = mechanics.repr.get_player_position(&state, 1);
+        let (p1_row, p1_col) = mechanics.repr.get_player_position(state, 0);
+        let (p2_row, p2_col) = mechanics.repr.get_player_position(state, 1);
 
         assert_eq!(p1_row, 0); // Top
-        assert_eq!(p1_col, 4); // Center
-        assert_eq!(p2_row, 8); // Bottom
-        assert_eq!(p2_col, 4); // Center
+        assert_eq!(p1_col, 2); // Center
+        assert_eq!(p2_row, 4); // Bottom
+        assert_eq!(p2_col, 2); // Center
 
         // Check walls
-        assert_eq!(mechanics.repr.get_walls_remaining(&state, 0), 10);
-        assert_eq!(mechanics.repr.get_walls_remaining(&state, 0), 10);
+        assert_eq!(mechanics.repr.get_walls_remaining(state, 0), 10);
+        assert_eq!(mechanics.repr.get_walls_remaining(state, 0), 10);
 
         // Check current player
-        assert_eq!(mechanics.repr.get_current_player(&state), 0);
+        assert_eq!(mechanics.repr.get_current_player(state), 0);
     }
 
     #[test]
     fn test_wall_placement_overlap() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
         // Place a wall
-        assert!(mechanics.is_wall_placement_free(&state, 4, 4, WALL_VERTICAL));
-        mechanics.place_wall(&mut state, 4, 4, WALL_VERTICAL);
+        assert!(mechanics.is_wall_placement_free(state, 2, 2, WALL_VERTICAL));
+        mechanics.place_wall(&mut state, 2, 2, WALL_VERTICAL);
 
         // Same position should not be free anymore
-        assert!(!mechanics.is_wall_placement_free(&state, 4, 4, WALL_VERTICAL));
+        assert!(!mechanics.is_wall_placement_free(state, 2, 2, WALL_VERTICAL));
 
         // Perpendicular position should not be free
-        assert!(!mechanics.is_wall_placement_free(&state, 4, 4, WALL_HORIZONTAL));
+        assert!(!mechanics.is_wall_placement_free(state, 2, 2, WALL_HORIZONTAL));
     }
 
     #[test]
     fn test_wall_placement_extension() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
         // Place a vertical wall
-        mechanics.place_wall(&mut state, 4, 4, WALL_VERTICAL);
+        mechanics.place_wall(&mut state, 2, 2, WALL_VERTICAL);
 
         // Adjacent vertical walls should conflict
-        assert!(!mechanics.is_wall_placement_free(&state, 3, 4, WALL_VERTICAL));
-        assert!(!mechanics.is_wall_placement_free(&state, 5, 4, WALL_VERTICAL));
+        assert!(!mechanics.is_wall_placement_free(state, 1, 2, WALL_VERTICAL));
+        assert!(!mechanics.is_wall_placement_free(state, 3, 2, WALL_VERTICAL));
 
         // Non-adjacent should be fine
-        assert!(mechanics.is_wall_placement_free(&state, 2, 4, WALL_VERTICAL));
-        assert!(mechanics.is_wall_placement_free(&state, 6, 4, WALL_VERTICAL));
+        assert!(mechanics.is_wall_placement_free(state, 0, 2, WALL_VERTICAL));
     }
 
     #[test]
     fn test_win_condition() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
         // Move player 1 to goal row
-        mechanics.execute_move(&mut state, 0, 8, 4);
-        assert!(mechanics.check_win(&state, 0));
-        assert!(!mechanics.check_win(&state, 1));
+        mechanics.execute_move(&mut state, 0, 4, 2);
+        assert!(mechanics.check_win(state, 0));
+        assert!(!mechanics.check_win(state, 1));
     }
 
     #[test]
     fn test_execute_wall_placement() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
-        let initial_walls = mechanics.repr.get_walls_remaining(&state, 0);
-        mechanics.execute_wall_placement(&mut state, 0, 4, 4, WALL_VERTICAL);
+        let initial_walls = mechanics.repr.get_walls_remaining(state, 0);
+        mechanics.execute_wall_placement(&mut state, 0, 2, 2, WALL_VERTICAL);
 
         assert_eq!(
-            mechanics.repr.get_walls_remaining(&state, 0),
+            mechanics.repr.get_walls_remaining(state, 0),
             initial_walls - 1
         );
-        assert!(mechanics.repr.get_wall(&state, 4, 4, WALL_VERTICAL));
+        assert!(mechanics.repr.get_wall(state, 2, 2, WALL_VERTICAL));
     }
 
     #[test]
     fn test_switch_player() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
-        assert_eq!(mechanics.repr.get_current_player(&state), 0);
-        assert_eq!(mechanics.repr.get_completed_steps(&state), 0);
+        assert_eq!(mechanics.repr.get_current_player(state), 0);
+        assert_eq!(mechanics.repr.get_completed_steps(state), 0);
 
         mechanics.switch_player(&mut state);
 
-        assert_eq!(mechanics.repr.get_current_player(&state), 1);
-        assert_eq!(mechanics.repr.get_completed_steps(&state), 1);
+        assert_eq!(mechanics.repr.get_current_player(state), 1);
+        assert_eq!(mechanics.repr.get_completed_steps(state), 1);
     }
 
     #[test]
@@ -711,19 +710,16 @@ mod tests {
 
     #[test]
     fn test_pathfinding_allows_valid_walls() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let mut state = mechanics.create_initial_state();
 
-        // Place a horizontal wall that doesn't block the path (leaves room to go around)
-        // Place walls with gaps (every other position) to avoid extension conflicts
-        for col in (0..6).step_by(2) {
-            mechanics.place_wall(&mut state, 4, col, WALL_HORIZONTAL);
-        }
+        // Place horizontal walls with a gap so players can still reach goals
+        mechanics.place_wall(&mut state, 2, 0, WALL_HORIZONTAL);
 
-        // This wall should still be valid because players can go around via the sides
-        let mut buf = BfsBuffer::new(9);
+        // This wall should still be valid because players can go around via the right side
+        let mut buf = BfsBuffer::new(5);
         let is_valid =
-            mechanics.is_wall_placement_valid(&mut state, 4, 7, WALL_HORIZONTAL, &mut buf);
+            mechanics.is_wall_placement_valid(&mut state, 2, 2, WALL_HORIZONTAL, &mut buf);
         assert!(
             is_valid,
             "Wall should be valid as players can still reach goals"
@@ -732,26 +728,26 @@ mod tests {
 
     #[test]
     fn test_can_reach_goal_direct() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let state = mechanics.create_initial_state();
-        let mut buf = BfsBuffer::new(9);
+        let mut buf = BfsBuffer::new(5);
 
         // Both players should be able to reach their goals in initial state
         assert!(
-            mechanics.can_reach_goal(&state, 0, &mut buf),
+            mechanics.can_reach_goal(state, 0, &mut buf),
             "Player 1 should reach goal"
         );
         assert!(
-            mechanics.can_reach_goal(&state, 1, &mut buf),
+            mechanics.can_reach_goal(state, 1, &mut buf),
             "Player 2 should reach goal"
         );
     }
 
     #[test]
     fn test_print() {
-        let mechanics = QGameMechanics::new(9, 10, 100);
+        let mechanics = QGameMechanics::new(5, 10, 100);
         let state = mechanics.create_initial_state();
-        mechanics.print(&state);
+        mechanics.print(state);
     }
 
     /// Helper to parse a board state from a string representation similar to Python tests.
@@ -772,7 +768,7 @@ mod tests {
         board_str: &str,
     ) -> (
         QGameMechanics,
-        Vec<u8>,
+        u64,
         Vec<(usize, usize)>,
         Vec<(usize, usize, usize)>,
     ) {
@@ -837,7 +833,7 @@ mod tests {
                             if row_n > 0
                                 && col_n < size - 1
                                 && mechanics.is_wall_placement_free(
-                                    &state,
+                                    state,
                                     row_n - 1,
                                     col_n,
                                     WALL_HORIZONTAL,
@@ -906,7 +902,7 @@ mod tests {
                             if ch == '|'
                                 && row_n < size - 1
                                 && mechanics.is_wall_placement_free(
-                                    &state,
+                                    state,
                                     row_n,
                                     wall_col_n,
                                     WALL_VERTICAL,
@@ -937,7 +933,7 @@ mod tests {
     fn test_pawn_movements(board_str: &str) {
         let (mechanics, state, expected_moves, _) = parse_board(board_str);
 
-        let actual_moves = mechanics.get_valid_moves(&state);
+        let actual_moves = mechanics.get_valid_moves(state);
 
         assert_eq!(
             actual_moves.len(),
@@ -947,7 +943,7 @@ mod tests {
             actual_moves.len(),
             expected_moves,
             actual_moves,
-            mechanics.display(&state),
+            mechanics.display(state),
         );
 
         for expected in &expected_moves {

--- a/deep_quoridor/rust/src/compact/q_minimax.rs
+++ b/deep_quoridor/rust/src/compact/q_minimax.rs
@@ -21,7 +21,7 @@ pub struct TranspositionEntry {
 }
 
 /// Compute distance to goal for a player using QBitRepr state
-fn distance_to_goal(mechanics: &QGameMechanics, data: &[u8], player: usize) -> i32 {
+fn distance_to_goal(mechanics: &QGameMechanics, data: u64, player: usize) -> i32 {
     let (row, col) = mechanics.repr().get_player_position(data, player);
     let board_size = mechanics.repr().board_size();
     let goal_row = mechanics.get_goal_row(player);
@@ -96,7 +96,7 @@ fn distance_to_goal(mechanics: &QGameMechanics, data: &[u8], player: usize) -> i
 /// Compute heuristic for QBitRepr state
 fn compute_heuristic(
     mechanics: &QGameMechanics,
-    data: &[u8],
+    data: u64,
     agent_player: usize,
     heuristic: i32,
 ) -> f32 {
@@ -130,13 +130,13 @@ fn compute_heuristic(
 /// rather than validating all possible wall placements upfront.
 fn sample_actions(
     mechanics: &QGameMechanics,
-    data: &mut [u8],
+    data: &mut u64,
     branching_factor: usize,
 ) -> Vec<(usize, usize, usize)> {
     let mut rng = rand::thread_rng();
 
     // Get valid moves (type 2 = pawn move)
-    let moves = mechanics.get_valid_moves(data);
+    let moves = mechanics.get_valid_moves(*data);
     let mut actions: Vec<(usize, usize, usize)> =
         moves.into_iter().map(|(row, col)| (row, col, 2)).collect();
 
@@ -147,8 +147,8 @@ fn sample_actions(
     }
 
     // Check if the current player has walls remaining
-    let current_player = mechanics.repr().get_current_player(data);
-    let walls_remaining = mechanics.repr().get_walls_remaining(data, current_player);
+    let current_player = mechanics.repr().get_current_player(*data);
+    let walls_remaining = mechanics.repr().get_walls_remaining(*data, current_player);
     if walls_remaining == 0 {
         return actions;
     }
@@ -184,7 +184,7 @@ fn sample_actions(
 #[allow(clippy::too_many_arguments)]
 fn minimax(
     mechanics: &QGameMechanics,
-    data: &mut [u8],
+    data: &mut u64,
     current_player: usize,
     agent_player: usize,
     search_depth: usize,
@@ -194,7 +194,7 @@ fn minimax(
     heuristic: i32,
     mut alpha: f32,
     mut beta: f32,
-    transposition_table: Arc<DashMap<Vec<u8>, TranspositionEntry>>,
+    transposition_table: Arc<DashMap<u64, TranspositionEntry>>,
 ) -> f32 {
     // Check transposition table for cached result
     if let Some(entry) = transposition_table.get(data) {
@@ -204,7 +204,7 @@ fn minimax(
     let opponent = 1 - current_player;
 
     // We're checking for the player that just finished their move.
-    if mechanics.check_win(data, opponent) {
+    if mechanics.check_win(*data, opponent) {
         return if opponent == agent_player {
             WINNING_REWARD
         } else {
@@ -212,12 +212,12 @@ fn minimax(
         };
     }
 
-    if mechanics.repr().get_completed_steps(data) >= mechanics.repr().max_steps() {
+    if mechanics.repr().get_completed_steps(*data) >= mechanics.repr().max_steps() {
         return 0.0; // Tie
     }
 
     if search_depth >= max_search_depth {
-        return compute_heuristic(mechanics, data, agent_player, heuristic);
+        return compute_heuristic(mechanics, *data, agent_player, heuristic);
     }
 
     let actions = sample_actions(mechanics, data, branching_factor);
@@ -237,7 +237,7 @@ fn minimax(
 
     for (row, col, action_type) in actions.iter() {
         // Copy state
-        let mut new_data = data.to_vec();
+        let mut new_data = *data;
 
         // Apply action
         if *action_type == 2 {
@@ -297,7 +297,7 @@ fn minimax(
         .unzip();
 
     transposition_table.insert(
-        data.to_vec(),
+        *data,
         TranspositionEntry {
             agent_player,
             actions: actions_vec,
@@ -312,7 +312,7 @@ fn minimax(
 /// Evaluate actions using QBitRepr-based minimax (parallelized)
 pub fn evaluate_actions(
     mechanics: &QGameMechanics,
-    data: &[u8],
+    data: u64,
     max_search_depth: usize,
     branching_factor: usize,
     discount_factor: f32,
@@ -320,13 +320,13 @@ pub fn evaluate_actions(
 ) -> (
     Vec<(usize, usize, usize)>,
     Vec<f32>,
-    DashMap<Vec<u8>, TranspositionEntry>,
+    DashMap<u64, TranspositionEntry>,
 ) {
     let current_player = mechanics.repr().get_current_player(data);
     let agent_player = current_player;
 
     // Sample actions (needs mutable data for in-place wall validation)
-    let mut data_mut = data.to_vec();
+    let mut data_mut = data;
     let actions = sample_actions(mechanics, &mut data_mut, branching_factor);
     if actions.is_empty() {
         return (Vec::new(), Vec::new(), DashMap::new());
@@ -339,7 +339,7 @@ pub fn evaluate_actions(
         .par_iter()
         .map(|(row, col, action_type)| {
             // Copy state
-            let mut new_data = data.to_vec();
+            let mut new_data = data;
 
             // Apply action
             if *action_type == 2 {
@@ -383,7 +383,7 @@ pub fn evaluate_actions(
 
     let best_value = values.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
     result_table.insert(
-        data.to_vec(),
+        data,
         TranspositionEntry {
             agent_player,
             actions: actions.clone(),
@@ -407,7 +407,7 @@ mod tests {
 
         // Evaluate actions
         let (actions, values, _logs) = evaluate_actions(
-            &mechanics, &data, 6,    // max_depth
+            &mechanics, data, 6,    // max_depth
             5,    // branching_factor
             0.95, // discount_factor
             1,    // heuristic
@@ -441,7 +441,7 @@ mod tests {
         mechanics.switch_player(&mut data);
 
         // P2 can win in 1 move
-        let (_, values, _) = evaluate_actions(&mechanics, &data, 1, 999, 1.0, 0);
+        let (_, values, _) = evaluate_actions(&mechanics, data, 1, 999, 1.0, 0);
         assert!(
             values.contains(&WINNING_REWARD),
             "Minimax failed to find viable win in one move"
@@ -460,14 +460,14 @@ mod tests {
         mechanics.switch_player(&mut data);
 
         // P2 can win in 3 more moves
-        let (_, values, _) = evaluate_actions(&mechanics, &data, 3, 999, 1.0, 0);
+        let (_, values, _) = evaluate_actions(&mechanics, data, 3, 999, 1.0, 0);
         assert!(
             values.contains(&WINNING_REWARD),
             "Minimax failed to find viable win"
         );
 
         // P2 cannot win in 2 more moves.
-        let (_, values, _) = evaluate_actions(&mechanics, &data, 2, 999, 1.0, 0);
+        let (_, values, _) = evaluate_actions(&mechanics, data, 2, 999, 1.0, 0);
         assert!(
             !values.contains(&WINNING_REWARD),
             "Minimax foud a win where there shouldn't be one",
@@ -480,11 +480,11 @@ mod tests {
         let data = mechanics.create_initial_state();
 
         // Player 0 starts at top (row 0), goal is bottom (row 4)
-        let dist_p0 = distance_to_goal(&mechanics, &data, 0);
+        let dist_p0 = distance_to_goal(&mechanics, data, 0);
         assert!(dist_p0 > 0, "Player 0 should have distance > 0 to goal");
 
         // Player 1 starts at bottom (row 4), goal is top (row 0)
-        let dist_p1 = distance_to_goal(&mechanics, &data, 1);
+        let dist_p1 = distance_to_goal(&mechanics, data, 1);
         assert!(dist_p1 > 0, "Player 1 should have distance > 0 to goal");
     }
 

--- a/deep_quoridor/rust/src/lib.rs
+++ b/deep_quoridor/rust/src/lib.rs
@@ -575,25 +575,29 @@ impl PyPolicyDb {
 
     /// Read metadata: returns (board_size, max_walls, max_steps, num_states).
     fn read_metadata(&self) -> PyResult<(usize, usize, usize, Option<usize>)> {
-        self.db.read_metadata()
+        self.db
+            .read_metadata()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
     /// Count total states in the policy table.
     fn count_states(&self) -> PyResult<usize> {
-        self.db.count_states()
+        self.db
+            .count_states()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
     /// Fetch (state, value) tuples by rowid. State is a u64 packed integer.
     fn fetch_states_by_rowid(&self, rowids: Vec<i64>) -> PyResult<Vec<(u64, i32)>> {
-        self.db.fetch_states_by_rowid(&rowids)
+        self.db
+            .fetch_states_by_rowid(&rowids)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
     /// Look up (state, value) for the given states.
     fn lookup_values_by_state(&self, states: Vec<u64>) -> PyResult<Vec<(u64, i32)>> {
-        self.db.lookup_values_by_state(&states)
+        self.db
+            .lookup_values_by_state(&states)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
@@ -603,7 +607,8 @@ impl PyPolicyDb {
     /// (actions, values) where actions is a list of (row, col, action_type)
     /// and values are from the acting player's perspective.
     fn lookup_action_values(&self, state: u64) -> PyResult<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>> {
-        self.db.lookup_action_values(state)
+        self.db
+            .lookup_action_values(state)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 }

--- a/deep_quoridor/rust/src/lib.rs
+++ b/deep_quoridor/rust/src/lib.rs
@@ -550,6 +550,20 @@ fn get_compact_child_states(
     children
 }
 
+/// Return a text-art display string for a compact state.
+#[cfg(feature = "python")]
+#[pyfunction]
+fn compact_state_display(
+    state: &[u8],
+    board_size: usize,
+    max_walls: usize,
+    max_steps: usize,
+) -> String {
+    use compact::q_bit_repr::QBitRepr;
+    let repr = QBitRepr::new(board_size, max_walls, max_steps);
+    repr.display(state)
+}
+
 /// A Python module implemented in Rust.
 #[cfg(feature = "python")]
 #[pymodule]
@@ -588,6 +602,7 @@ fn quoridor_rs(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Compact state utilities for training
     m.add_function(wrap_pyfunction!(compact_state_to_game_state, m)?)?;
     m.add_function(wrap_pyfunction!(get_compact_child_states, m)?)?;
+    m.add_function(wrap_pyfunction!(compact_state_display, m)?)?;
 
     // Export constants to match qgrid.py
     m.add("CELL_FREE", grid::CELL_FREE)?;

--- a/deep_quoridor/rust/src/lib.rs
+++ b/deep_quoridor/rust/src/lib.rs
@@ -409,18 +409,18 @@ fn policy_db_lookup<'py>(
     walls_remaining: PyReadonlyArray1<i32>,
     current_player: i32,
     completed_steps: i32,
-    board_size: usize,
-    max_walls: usize,
-    max_steps: usize,
+    _board_size: usize,
+    _max_walls: usize,
+    _max_steps: usize,
     db_path: &str,
 ) -> PyResult<Option<(Bound<'py, PyArray2<i32>>, Bound<'py, numpy::PyArray1<i32>>)>> {
     use compact::policy_db::PolicyDb;
-    use compact::q_game_mechanics::QGameMechanics;
 
-    let mechanics = QGameMechanics::new(board_size, max_walls, max_steps);
+    let db = PolicyDb::open(db_path)
+        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to open DB: {e}")))?;
 
-    let mut data = mechanics.repr().create_data();
-    mechanics.repr().from_game_state(
+    let mut data = db.mechanics().repr().create_data();
+    db.mechanics().repr().from_game_state(
         &mut data,
         &grid.as_array(),
         &player_positions.as_array(),
@@ -429,11 +429,8 @@ fn policy_db_lookup<'py>(
         completed_steps,
     );
 
-    let db = PolicyDb::open(db_path)
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to open DB: {e}")))?;
-
     match db
-        .lookup_action_values(&mechanics, &data)
+        .lookup_action_values(&data)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("DB query error: {e}")))?
     {
         None => Ok(None),
@@ -550,6 +547,59 @@ fn get_compact_child_states(
     children
 }
 
+/// Python wrapper around PolicyDb for database access from Python.
+#[cfg(feature = "python")]
+#[pyclass]
+struct PyPolicyDb {
+    db: compact::policy_db::PolicyDb,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyPolicyDb {
+    #[new]
+    fn new(path: &str) -> PyResult<Self> {
+        let db = compact::policy_db::PolicyDb::open(path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to open DB: {e}")))?;
+        Ok(Self { db })
+    }
+
+    /// Read metadata: returns (board_size, max_walls, max_steps, num_states).
+    fn read_metadata(&self) -> PyResult<(usize, usize, usize, Option<usize>)> {
+        self.db.read_metadata()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    /// Count total states in the policy table.
+    fn count_states(&self) -> PyResult<usize> {
+        self.db.count_states()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    /// Fetch (state_bytes, value) tuples by rowid.
+    fn fetch_states_by_rowid(&self, rowids: Vec<i64>) -> PyResult<Vec<(Vec<u8>, i32)>> {
+        self.db.fetch_states_by_rowid(&rowids)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    /// Look up (state_bytes, value) for the given state blobs.
+    fn lookup_values_by_state(&self, states: Vec<Vec<u8>>) -> PyResult<Vec<(Vec<u8>, i32)>> {
+        let refs: Vec<&[u8]> = states.iter().map(|s| s.as_slice()).collect();
+        self.db.lookup_values_by_state(&refs)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    /// Look up action values for a compact state.
+    ///
+    /// Returns None if no valid actions, otherwise returns
+    /// (actions, values) where actions is a list of (row, col, action_type)
+    /// and values are from the acting player's perspective.
+    fn lookup_action_values(&self, state: Vec<u8>) -> PyResult<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>> {
+        self.db.lookup_action_values(&state)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+    }
+}
+
 /// Return a text-art display string for a compact state.
 #[cfg(feature = "python")]
 #[pyfunction]
@@ -603,6 +653,9 @@ fn quoridor_rs(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compact_state_to_game_state, m)?)?;
     m.add_function(wrap_pyfunction!(get_compact_child_states, m)?)?;
     m.add_function(wrap_pyfunction!(compact_state_display, m)?)?;
+
+    // PolicyDb class
+    m.add_class::<PyPolicyDb>()?;
 
     // Export constants to match qgrid.py
     m.add("CELL_FREE", grid::CELL_FREE)?;

--- a/deep_quoridor/rust/src/lib.rs
+++ b/deep_quoridor/rust/src/lib.rs
@@ -416,7 +416,9 @@ fn policy_db_lookup<'py>(
 ) -> PyResult<Option<(Bound<'py, PyArray2<i32>>, Bound<'py, numpy::PyArray1<i32>>)>> {
     use compact::policy_db::PolicyDb;
 
-    let db = PolicyDb::open(db_path)
+    // One-shot per-move agent path: always lazy so a single move never
+    // pays the cost of loading the whole DB into RAM.
+    let db = PolicyDb::open(db_path, true)
         .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to open DB: {e}")))?;
 
     let mut data = db.mechanics().repr().create_data();
@@ -557,9 +559,16 @@ struct PyPolicyDb {
 #[cfg(feature = "python")]
 #[pymethods]
 impl PyPolicyDb {
+    /// Open a Parquet policy DB.
+    ///
+    /// `lazy=False` (default) loads the entire dataset into a HashMap at
+    /// open time for O(1) state lookups — best for training. `lazy=True`
+    /// keeps the file on disk and walks Parquet row groups on demand —
+    /// use this for DBs too large to fit in memory.
     #[new]
-    fn new(path: &str) -> PyResult<Self> {
-        let db = compact::policy_db::PolicyDb::open(path)
+    #[pyo3(signature = (path, lazy = false))]
+    fn new(path: &str, lazy: bool) -> PyResult<Self> {
+        let db = compact::policy_db::PolicyDb::open(path, lazy)
             .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("Failed to open DB: {e}")))?;
         Ok(Self { db })
     }

--- a/deep_quoridor/rust/src/lib.rs
+++ b/deep_quoridor/rust/src/lib.rs
@@ -370,7 +370,7 @@ fn q_evaluate_actions<'py>(
     // Evaluate actions using QBitRepr minimax
     let (actions, values, _logs) = compact::q_minimax::evaluate_actions(
         &mechanics,
-        &data,
+        data,
         max_search_depth,
         branching_factor,
         discount_factor,
@@ -430,7 +430,7 @@ fn policy_db_lookup<'py>(
     );
 
     match db
-        .lookup_action_values(&data)
+        .lookup_action_values(data)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("DB query error: {e}")))?
     {
         None => Ok(None),
@@ -459,7 +459,7 @@ fn policy_db_lookup<'py>(
 #[pyfunction]
 fn compact_state_to_game_state<'py>(
     py: Python<'py>,
-    state: &[u8],
+    state: u64,
     board_size: usize,
     max_walls: usize,
     max_steps: usize,
@@ -513,23 +513,23 @@ fn compact_state_to_game_state<'py>(
 #[cfg(feature = "python")]
 #[pyfunction]
 fn get_compact_child_states(
-    state: &[u8],
+    state: u64,
     board_size: usize,
     max_walls: usize,
     max_steps: usize,
-) -> Vec<(usize, usize, usize, Vec<u8>)> {
+) -> Vec<(usize, usize, usize, u64)> {
     use compact::q_game_mechanics::QGameMechanics;
 
     let mechanics = QGameMechanics::new(board_size, max_walls, max_steps);
     let current_player = mechanics.repr().get_current_player(state);
-    let mut data = state.to_vec();
+    let mut data = state;
 
     let mut children = Vec::new();
 
     // Pawn moves (action_type = 2)
-    let moves = mechanics.get_valid_moves(&data);
+    let moves = mechanics.get_valid_moves(data);
     for (row, col) in moves {
-        let mut child = data.clone();
+        let mut child = data;
         mechanics.execute_move(&mut child, current_player, row, col);
         mechanics.switch_player(&mut child);
         children.push((row, col, 2usize, child));
@@ -538,7 +538,7 @@ fn get_compact_child_states(
     // Wall placements (action_type = 0 or 1)
     let wall_placements = mechanics.get_valid_wall_placements(&mut data);
     for (row, col, orientation) in wall_placements {
-        let mut child = data.clone();
+        let mut child = data;
         mechanics.execute_wall_placement(&mut child, current_player, row, col, orientation);
         mechanics.switch_player(&mut child);
         children.push((row, col, orientation, child));
@@ -576,16 +576,15 @@ impl PyPolicyDb {
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
-    /// Fetch (state_bytes, value) tuples by rowid.
-    fn fetch_states_by_rowid(&self, rowids: Vec<i64>) -> PyResult<Vec<(Vec<u8>, i32)>> {
+    /// Fetch (state, value) tuples by rowid. State is a u64 packed integer.
+    fn fetch_states_by_rowid(&self, rowids: Vec<i64>) -> PyResult<Vec<(u64, i32)>> {
         self.db.fetch_states_by_rowid(&rowids)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
-    /// Look up (state_bytes, value) for the given state blobs.
-    fn lookup_values_by_state(&self, states: Vec<Vec<u8>>) -> PyResult<Vec<(Vec<u8>, i32)>> {
-        let refs: Vec<&[u8]> = states.iter().map(|s| s.as_slice()).collect();
-        self.db.lookup_values_by_state(&refs)
+    /// Look up (state, value) for the given states.
+    fn lookup_values_by_state(&self, states: Vec<u64>) -> PyResult<Vec<(u64, i32)>> {
+        self.db.lookup_values_by_state(&states)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 
@@ -594,8 +593,8 @@ impl PyPolicyDb {
     /// Returns None if no valid actions, otherwise returns
     /// (actions, values) where actions is a list of (row, col, action_type)
     /// and values are from the acting player's perspective.
-    fn lookup_action_values(&self, state: Vec<u8>) -> PyResult<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>> {
-        self.db.lookup_action_values(&state)
+    fn lookup_action_values(&self, state: u64) -> PyResult<Option<(Vec<(u8, u8, u8)>, Vec<i32>)>> {
+        self.db.lookup_action_values(state)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
     }
 }
@@ -604,7 +603,7 @@ impl PyPolicyDb {
 #[cfg(feature = "python")]
 #[pyfunction]
 fn compact_state_display(
-    state: &[u8],
+    state: u64,
     board_size: usize,
     max_walls: usize,
     max_steps: usize,

--- a/deep_quoridor/src/quoridor.py
+++ b/deep_quoridor/src/quoridor.py
@@ -551,7 +551,15 @@ class Quoridor:
         )
 
     def __str__(self):
-        return str(self.board)
+        p1_walls = self.board.get_walls_remaining(Player.ONE)
+        p2_walls = self.board.get_walls_remaining(Player.TWO)
+        return (
+            f"{self.board}\n"
+            f"Current player: {self.current_player + 1}  |  "
+            f"Walls remaining: P1={p1_walls} P2={p2_walls}  |  "
+            f"Steps: {self.completed_steps} | "
+            f"Rotated: {self._rotated}"
+        )
 
     def get_fast_hash(self):
         # Use a fast, unique hash based on the board, player positions, walls, and current player.

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -247,6 +247,12 @@ def parse_args():
         choices=[1, 2],
         help="Only evaluate test loss and accuracy on positions where this player is to move (1 or 2)",
     )
+    p.add_argument(
+        "--exclude-test-set",
+        action="store_true",
+        default=False,
+        help="Exclude test set IDs from training batches (default: allow overlap)",
+    )
     return p.parse_args()
 
 
@@ -318,11 +324,12 @@ def main():
     batch_size = az_params.batch_size
 
     for step in range(1, args.num_steps + 1):
-        # Oversample to account for test ID removal, player filtering, and states
-        # dropped by build_policy_from_children (missing children in DB).
+        # Oversample to account for player filtering and states dropped by
+        # build_policy_from_children (missing children in DB).
         oversample = 4 if test_player is None else 8
         batch_ids = random.sample(range(1, num_states + 1), min(batch_size * oversample, num_states))
-        batch_ids = [i for i in batch_ids if i not in test_id_set]
+        if args.exclude_test_set:
+            batch_ids = [i for i in batch_ids if i not in test_id_set]
         batch_samples = fetch_batch(conn, batch_ids, evaluator, board_size, max_walls, max_steps)
         if test_player is not None:
             batch_samples = [s for s in batch_samples if s["current_player"] == test_player]

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -13,6 +13,7 @@ Two metrics are logged during training:
 """
 
 import argparse
+import os
 import random
 import sqlite3
 import sys
@@ -21,6 +22,7 @@ from dataclasses import asdict
 import numpy as np
 import quoridor_rs
 import torch
+import wandb
 from agents.alphazero.alphazero import AlphaZeroParams
 from agents.alphazero.nn_evaluator import NNConfig, NNEvaluator
 from quoridor import ActionEncoder, Board, Player, Quoridor
@@ -253,6 +255,15 @@ def parse_args():
         default=False,
         help="Exclude test set IDs from training batches (default: allow overlap)",
     )
+    p.add_argument(
+        "-w",
+        "--wandb",
+        nargs="?",
+        const="",
+        default=None,
+        type=str,
+        help="Enable wandb logging. Optionally pass project name (default: policydb_evaluator)",
+    )
     return p.parse_args()
 
 
@@ -268,6 +279,28 @@ def main():
     az_params = parse_subargs(args.params, AlphaZeroParams)
     nn_config = NNConfig.from_alphazero_params(az_params)
     print(f"AlphaZero params: {az_params}")
+
+    # ------------------------------------------------------------------
+    # Wandb
+    # ------------------------------------------------------------------
+    use_wandb = args.wandb is not None
+    if use_wandb:
+        wandb_project = args.wandb if args.wandb else "policydb_evaluator"
+        wandb.init(
+            project=wandb_project,
+            config={
+                "db_path": os.path.basename(args.db_path),
+                "num_steps": args.num_steps,
+                "test_fraction": args.test_fraction,
+                "test_player": args.test_player,
+                "exclude_test_set": args.exclude_test_set,
+                "output": args.output,
+                **asdict(az_params),
+            },
+        )
+        wandb.define_metric("step", hidden=True)
+        wandb.define_metric("train/*", step_metric="step")
+        wandb.define_metric("test/*", step_metric="step")
 
     # ------------------------------------------------------------------
     # Open DB and read metadata
@@ -317,6 +350,17 @@ def main():
     feature_dim = test_samples[0]["input_array"].shape[0]
     print(f"Feature dim: {feature_dim}")
 
+    if use_wandb:
+        wandb.config.update({
+            "board_size": board_size,
+            "max_walls": max_walls,
+            "max_steps": max_steps,
+            "num_states": num_states,
+            "train_size": num_states - test_size,
+            "test_size": len(test_samples),
+            "feature_dim": feature_dim,
+        })
+
     # ------------------------------------------------------------------
     # Training loop
     # ------------------------------------------------------------------
@@ -334,12 +378,20 @@ def main():
         if test_player is not None:
             batch_samples = [s for s in batch_samples if s["current_player"] == test_player]
         batch_samples = batch_samples[:batch_size]
-        _, train_value_loss, train_total_loss = evaluator.train_iteration_v2(batch_samples)
+        train_policy_loss, train_value_loss, train_total_loss = evaluator.train_iteration_v2(batch_samples)
+
+        if use_wandb:
+            wandb.log({
+                "train/value_loss": train_value_loss,
+                "train/policy_loss": train_policy_loss,
+                "train/total_loss": train_total_loss,
+                "step": step,
+            })
 
         if step % args.log_interval == 0 or step == 1:
             evaluator.network.eval()
             with torch.no_grad():
-                _, test_value_loss, _ = evaluator.compute_losses(test_samples)
+                test_policy_loss, test_value_loss, test_total_loss = evaluator.compute_losses(test_samples)
             test_loss = test_value_loss.item()
             evaluator.network.train()
 
@@ -359,6 +411,15 @@ def main():
             )
             sys.stdout.flush()
 
+            if use_wandb:
+                wandb.log({
+                    "test/value_loss": test_loss,
+                    "test/policy_loss": test_policy_loss.item(),
+                    "test/total_loss": test_total_loss.item(),
+                    "test/accuracy": acc,
+                    "step": step,
+                })
+
             if test_loss < best_test_loss:
                 best_test_loss = test_loss
                 torch.save(
@@ -374,6 +435,10 @@ def main():
 
     conn.close()
     print(f"Training complete. Best test loss: {best_test_loss:.4f}. Model saved to {args.output}")
+
+    if use_wandb:
+        wandb.summary["best_test_loss"] = best_test_loss
+        wandb.finish()
 
 
 if __name__ == "__main__":

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -362,7 +362,7 @@ def main():
     # ------------------------------------------------------------------
     # Open DB and read metadata
     # ------------------------------------------------------------------
-    db = quoridor_rs.PyPolicyDb(args.db_path)
+    db = quoridor_rs.PyPolicyDb(args.db_path, lazy=False)
     board_size, max_walls, max_steps, num_states = db.read_metadata()
     print(f"Board size: {board_size}, max_walls: {max_walls}, max_steps: {max_steps}")
 

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -27,7 +27,7 @@ from agents.alphazero.nn_evaluator import NNConfig, NNEvaluator
 from quoridor import ActionEncoder, Board, Player, Quoridor
 from utils.subargs import parse_subargs
 
-DEBUG = True
+DEBUG = False
 
 # ---------------------------------------------------------------------------
 # Utilities
@@ -51,7 +51,7 @@ def print_policy(policy, action_encoder):
 
 def compact_state_to_game(state_bytes, board_size, max_walls, max_steps):
     """Convert compact state bytes to a Quoridor game object."""
-    grid, player_positions, walls_remaining, old_style_walls, current_player, _completed_steps = (
+    grid, player_positions, walls_remaining, old_style_walls, current_player, completed_steps = (
         quoridor_rs.compact_state_to_game_state(state_bytes, board_size, max_walls, max_steps)
     )
     board = Board.from_arrays(
@@ -62,7 +62,7 @@ def compact_state_to_game(state_bytes, board_size, max_walls, max_steps):
         np.asarray(walls_remaining),
         np.asarray(old_style_walls),
     )
-    return Quoridor(board, Player(current_player))
+    return Quoridor(board, Player(current_player), completed_steps=completed_steps)
 
 
 def child_action_index(row, col, action_type, board_size):
@@ -333,7 +333,7 @@ def main():
     # Create NNEvaluator and set up optimizer
     # ------------------------------------------------------------------
     action_encoder = ActionEncoder(board_size)
-    evaluator = NNEvaluator(action_encoder, device, nn_config, max_cache_size=1000)
+    evaluator = NNEvaluator(action_encoder, device, nn_config, max_cache_size=100000)
     evaluator.train_prepare(az_params.learning_rate, az_params.batch_size, args.num_steps, az_params.weight_decay)
 
     # ------------------------------------------------------------------
@@ -434,7 +434,10 @@ def main():
             )
 
             print(
-                f"step {step:6d} | train_loss {train_total_loss:.4f} | test_loss {test_total_loss:.4f} | accuracy {acc:.3f}"
+                f"step {step:6d} | "
+                f"train: pol={train_policy_loss:.4f} val={train_value_loss:.4f} tot={train_total_loss:.4f} | "
+                f"test: pol={test_policy_loss:.4f} val={test_value_loss:.4f} tot={test_total_loss:.4f} | "
+                f"accuracy {acc:.3f}"
             )
             sys.stdout.flush()
 

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -113,7 +113,7 @@ def fetch_batch(db, ids, evaluator, board_size, max_walls, max_steps):
         samples.append(
             {
                 "input_array": evaluator.game_to_input_array(game),
-                "value": value,
+                "value": value if current_player == 0 else -value,
                 "action_mask": action_mask,
                 "mcts_policy": mcts_policy,
                 "current_player": current_player,

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -198,7 +198,7 @@ def compute_accuracy(
         if db_policy[model_pick] == best_db_action_prob:
             correct += 1
         else:
-            if (DEBUG or True) and inaccurate_printed < 3:
+            if DEBUG and inaccurate_printed < 3:
                 inaccurate_printed += 1
 
                 print("")
@@ -247,6 +247,12 @@ def parse_args():
         help="Exclude test set IDs from training batches (default: allow overlap)",
     )
     p.add_argument(
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Enable verbose debug output",
+    )
+    p.add_argument(
         "-w",
         "--wandb",
         nargs="?",
@@ -260,6 +266,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    global DEBUG
+    DEBUG = args.debug
 
     if args.device is None:
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -196,9 +196,7 @@ def compute_test_metrics_batched(
                 end = min(ids_idx + batch_size, n_test_ids)
                 next_ids = test_ids[ids_idx:end]
                 ids_idx = end
-                new_samples = fetch_batch(
-                    db, next_ids, evaluator, board_size, max_walls, max_steps
-                )
+                new_samples = fetch_batch(db, next_ids, evaluator, board_size, max_walls, max_steps)
                 if test_player is not None:
                     new_samples = [s for s in new_samples if s["current_player"] == test_player]
                 buffer.extend(new_samples)
@@ -210,7 +208,6 @@ def compute_test_metrics_batched(
             if n == 0:
                 break
 
-            print(f"Evaluating test batch {total + 1}-{total + n} of ~{n_test_ids}")
             pol, val, tot = evaluator.compute_losses(batch)
             total_pol += pol.item() * n
             total_val += val.item() * n
@@ -218,10 +215,7 @@ def compute_test_metrics_batched(
 
             # Run model inference for the whole batch at once so accuracy
             # picks the same code path the deployed agent uses.
-            games = [
-                compact_state_to_game(s["state"], board_size, max_walls, max_steps)
-                for s in batch
-            ]
+            games = [compact_state_to_game(s["state"], board_size, max_walls, max_steps) for s in batch]
             _, model_policies = evaluator.evaluate_batch(games)
             for s, model_policy in zip(batch, model_policies):
                 db_policy = s["db_policy_original"]
@@ -231,7 +225,6 @@ def compute_test_metrics_batched(
                     correct += 1
                 total += 1
 
-            Timer.log_totals()
     evaluator.network.train()
 
     assert total > 0, "No test samples found (check test_player filter?)"
@@ -362,10 +355,7 @@ def main():
     test_size = min(max(1, int(num_states * args.test_fraction)), MAX_TEST_SIZE)
     test_id_set = set(random.sample(range(1, num_states + 1), test_size))
     test_ids = sorted(test_id_set)
-    print(
-        f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}, "
-        f"test batch size: {args.test_batch_size}"
-    )
+    print(f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}, test batch size: {args.test_batch_size}")
 
     # ------------------------------------------------------------------
     # Create NNEvaluator and set up optimizer
@@ -410,7 +400,6 @@ def main():
         )
 
     for step in range(1, args.num_steps + 1):
-        print(f"Step {step}/{args.num_steps}")
         if step % 100000 == 0:
             learning_rate = learning_rate / 2.0
             print(f"Lowering learning rate to {learning_rate}")
@@ -488,6 +477,8 @@ def main():
                     },
                     args.output,
                 )
+
+        Timer.log_cumulative("step", step)
 
     print(f"Training complete. Best test loss: {best_test_loss:.4f}. Model saved to {args.output}")
 

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -70,8 +70,7 @@ def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
     Returns the policy array, or None if no valid actions.
     """
     result = db.lookup_action_values(state_bytes)
-    if result is None:
-        return None
+    assert result is not None
 
     actions, values = result
     best_value = max(values)
@@ -108,8 +107,7 @@ def fetch_batch(db, ids, evaluator, board_size, max_walls, max_steps):
             board_size,
             num_actions,
         )
-        if mcts_policy is None:
-            continue
+        assert mcts_policy is not None
 
         action_mask = game.get_action_mask().astype(np.float32)
         samples.append(
@@ -134,6 +132,8 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
 
     If test_player is 0 or 1, only states where the current player matches are counted.
     """
+    assert len(test_ids) > 0
+    assert num_samples > 0
     sample_ids = random.sample(test_ids, min(num_samples, len(test_ids)))
 
     # Fetch the state blobs and values for the sampled test IDs.
@@ -157,8 +157,8 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
             # DB action values (handles terminal child states correctly).
             # Values are from the acting player's perspective (positive = good).
             result = db.lookup_action_values(state_bytes)
-            if result is None:
-                continue
+            assert result is not None
+
             _actions, db_action_vals = result
             db_action_vals = list(db_action_vals)
 
@@ -192,7 +192,7 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
                     )
             total += 1
 
-    return correct / total if total > 0 else float("nan")
+    return correct / total
 
 
 # ---------------------------------------------------------------------------
@@ -346,24 +346,26 @@ def main():
     batch_size = az_params.batch_size
 
     learning_rate = az_params.learning_rate
-    wandb.log(
-        {
-            "learning_rate": learning_rate,
-            "step": 0,
-        }
-    )
+    if use_wandb:
+        wandb.log(
+            {
+                "learning_rate": learning_rate,
+                "step": 0,
+            }
+        )
 
     for step in range(1, args.num_steps + 1):
         if step % 100000 == 0:
             learning_rate = learning_rate / 2.0
             print(f"Lowering learning rate to {learning_rate}")
             evaluator.train_prepare(learning_rate, az_params.batch_size, args.num_steps, az_params.weight_decay)
-            wandb.log(
-                {
-                    "learning_rate": learning_rate,
-                    "step": step,
-                }
-            )
+            if use_wandb:
+                wandb.log(
+                    {
+                        "learning_rate": learning_rate,
+                        "step": step,
+                    }
+                )
 
         # Oversample to account for player filtering and states dropped by
         # build_policy_from_children (missing children in DB).

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -65,9 +65,9 @@ def child_action_index(row, col, action_type, board_size):
     if action_type == 2:  # pawn move
         return row * board_size + col
     elif action_type == 0:  # vertical wall
-        return board_size ** 2 + row * wall_size + col
+        return board_size**2 + row * wall_size + col
     elif action_type == 1:  # horizontal wall
-        return board_size ** 2 + wall_size ** 2 + row * wall_size + col
+        return board_size**2 + wall_size**2 + row * wall_size + col
     raise ValueError(f"Unknown action_type {action_type}")
 
 
@@ -100,7 +100,7 @@ def build_policy_from_children(conn, state_bytes, current_player, board_size, ma
 
     # Assign equal probability to all actions achieving the best value.
     policy = np.zeros(num_actions, dtype=np.float32)
-    for (row, col, action_type, child_state) in children:
+    for row, col, action_type, child_state in children:
         if child_db_vals[bytes(child_state)] == best_value:
             idx = child_action_index(row, col, action_type, board_size)
             policy[idx] = 1.0
@@ -132,7 +132,13 @@ def fetch_batch(conn, ids, evaluator, board_size, max_walls, max_steps):
         current_player = int(game.current_player)
 
         mcts_policy = build_policy_from_children(
-            conn, state_bytes, current_player, board_size, max_walls, max_steps, num_actions,
+            conn,
+            state_bytes,
+            current_player,
+            board_size,
+            max_walls,
+            max_steps,
+            num_actions,
         )
         if mcts_policy is None:
             continue
@@ -171,6 +177,7 @@ def compute_accuracy(test_ids, conn, evaluator, board_size, max_walls, max_steps
 
     correct = 0
     total = 0
+    inaccurate_printed = 0
     evaluator.network.eval()
     device = evaluator.device
     with torch.no_grad():
@@ -214,6 +221,16 @@ def compute_accuracy(test_ids, conn, evaluator, board_size, max_walls, max_steps
             model_pick = np.argmax(model_vals) if current_player == 0 else np.argmin(model_vals)
             if db_vals[model_pick] == best_db_val:
                 correct += 1
+            else:
+                if inaccurate_printed < 3:
+                    inaccurate_printed += 1
+                    print(f"  Inaccurate state {inaccurate_printed}:")
+                    print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))
+                    print(f"    DB values:    {db_vals}")
+                    print(f"    Model values: {model_vals.tolist()}")
+                    print(
+                        f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_vals[model_pick]})"
+                    )
             total += 1
 
     return correct / total if total > 0 else float("nan")
@@ -351,15 +368,17 @@ def main():
     print(f"Feature dim: {feature_dim}")
 
     if use_wandb:
-        wandb.config.update({
-            "board_size": board_size,
-            "max_walls": max_walls,
-            "max_steps": max_steps,
-            "num_states": num_states,
-            "train_size": num_states - test_size,
-            "test_size": len(test_samples),
-            "feature_dim": feature_dim,
-        })
+        wandb.config.update(
+            {
+                "board_size": board_size,
+                "max_walls": max_walls,
+                "max_steps": max_steps,
+                "num_states": num_states,
+                "train_size": num_states - test_size,
+                "test_size": len(test_samples),
+                "feature_dim": feature_dim,
+            }
+        )
 
     # ------------------------------------------------------------------
     # Training loop
@@ -367,7 +386,26 @@ def main():
     best_test_loss = float("inf")
     batch_size = az_params.batch_size
 
+    learning_rate = az_params.learning_rate
+    wandb.log(
+        {
+            "learning_rate": learning_rate,
+            "step": 0,
+        }
+    )
+
     for step in range(1, args.num_steps + 1):
+        if step % 100000 == 0:
+            learning_rate = learning_rate / 2.0
+            print(f"Lowering learning rate to {learning_rate}")
+            evaluator.train_prepare(learning_rate, az_params.batch_size, args.num_steps, az_params.weight_decay)
+            wandb.log(
+                {
+                    "learning_rate": learning_rate,
+                    "step": step,
+                }
+            )
+
         # Oversample to account for player filtering and states dropped by
         # build_policy_from_children (missing children in DB).
         oversample = 4 if test_player is None else 8
@@ -381,18 +419,22 @@ def main():
         train_policy_loss, train_value_loss, train_total_loss = evaluator.train_iteration_v2(batch_samples)
 
         if use_wandb:
-            wandb.log({
-                "train/value_loss": train_value_loss,
-                "train/policy_loss": train_policy_loss,
-                "train/total_loss": train_total_loss,
-                "step": step,
-            })
+            wandb.log(
+                {
+                    "train/value_loss": train_value_loss,
+                    "train/policy_loss": train_policy_loss,
+                    "train/total_loss": train_total_loss,
+                    "step": step,
+                }
+            )
 
         if step % args.log_interval == 0 or step == 1:
             evaluator.network.eval()
             with torch.no_grad():
                 test_policy_loss, test_value_loss, test_total_loss = evaluator.compute_losses(test_samples)
-            test_loss = test_value_loss.item()
+                test_policy_loss = test_policy_loss.item()
+                test_value_loss = test_value_loss.item()
+                test_total_loss = test_total_loss.item()
             evaluator.network.train()
 
             acc = compute_accuracy(
@@ -407,21 +449,23 @@ def main():
             )
 
             print(
-                f"step {step:6d} | train_loss {train_value_loss:.4f} | test_loss {test_loss:.4f} | accuracy {acc:.3f}"
+                f"step {step:6d} | train_loss {train_total_loss:.4f} | test_loss {test_total_loss:.4f} | accuracy {acc:.3f}"
             )
             sys.stdout.flush()
 
             if use_wandb:
-                wandb.log({
-                    "test/value_loss": test_loss,
-                    "test/policy_loss": test_policy_loss.item(),
-                    "test/total_loss": test_total_loss.item(),
-                    "test/accuracy": acc,
-                    "step": step,
-                })
+                wandb.log(
+                    {
+                        "test/value_loss": test_value_loss,
+                        "test/policy_loss": test_policy_loss,
+                        "test/total_loss": test_total_loss,
+                        "test/accuracy": acc,
+                        "step": step,
+                    }
+                )
 
-            if test_loss < best_test_loss:
-                best_test_loss = test_loss
+            if test_total_loss < best_test_loss:
+                best_test_loss = test_total_loss
                 torch.save(
                     {
                         "network_state_dict": evaluator.network.state_dict(),

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -216,9 +216,14 @@ def compute_test_metrics_batched(
             total_val += val.item() * n
             total_tot += tot.item() * n
 
-            for s in batch:
-                original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
-                _, model_policy = evaluator.evaluate(original_game)
+            # Run model inference for the whole batch at once so accuracy
+            # picks the same code path the deployed agent uses.
+            games = [
+                compact_state_to_game(s["state"], board_size, max_walls, max_steps)
+                for s in batch
+            ]
+            _, model_policies = evaluator.evaluate_batch(games)
+            for s, model_policy in zip(batch, model_policies):
                 db_policy = s["db_policy_original"]
                 best_db_prob = max(db_policy)
                 model_pick = int(np.argmax(model_policy))

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -143,54 +143,50 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
     total = 0
     inaccurate_printed = 0
     evaluator.network.eval()
-    device = evaluator.device
-    with torch.no_grad():
-        for state_blob, _value in rows:
-            state_bytes = bytes(state_blob)
-            game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
-            current_player = int(game.current_player)
+    for state_blob, _value in rows:
+        state_bytes = bytes(state_blob)
+        game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
+        current_player = int(game.current_player)
 
-            # Filter by player if requested.
-            if test_player is not None and current_player != test_player:
-                continue
+        # Filter by player if requested.
+        if test_player is not None and current_player != test_player:
+            continue
 
-            # DB action values (handles terminal child states correctly).
-            # Values are from the acting player's perspective (positive = good).
-            result = db.lookup_action_values(state_bytes)
-            assert result is not None
+        # DB action values (handles terminal child states correctly).
+        # Values are from the acting player's perspective (positive = good).
+        result = db.lookup_action_values(state_bytes)
+        assert result is not None
 
-            _actions, db_action_vals = result
-            db_action_vals = list(db_action_vals)
+        _actions, db_action_vals = result
+        db_action_vals = list(db_action_vals)
 
-            # Model predictions for children (same action ordering as lookup_action_values).
-            children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
-            child_features = []
-            for _row, _col, _action_type, child_state in children:
-                child_game = compact_state_to_game(bytes(child_state), board_size, max_walls, max_steps)
-                child_features.append(evaluator.game_to_input_array(child_game))
-            x = torch.tensor(np.stack(child_features), dtype=torch.float32, device=device)
-            _, model_vals = evaluator.network(x)
-            # Model predicts P0-absolute values; convert to acting player's perspective.
-            model_vals = model_vals.squeeze(-1).cpu().numpy()
-            if current_player == 1:
-                model_vals = -model_vals
+        # Model predictions for children (same action ordering as lookup_action_values).
+        children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
+        child_games = [
+            compact_state_to_game(bytes(child_state), board_size, max_walls, max_steps)
+            for _row, _col, _action_type, child_state in children
+        ]
+        # evaluate_batch returns values from the child's current player's perspective
+        # (i.e. the opponent). Negate to get acting player's perspective.
+        child_values, _ = evaluator.evaluate_batch(child_games)
+        model_vals = [-v for v in child_values]
 
-            # DB action values and model values are both from acting player's perspective.
-            best_db_val = max(db_action_vals)
-            model_pick = int(np.argmax(model_vals))
-            if db_action_vals[model_pick] == best_db_val:
-                correct += 1
-            else:
-                if inaccurate_printed < 3:
-                    inaccurate_printed += 1
-                    print(f"  Inaccurate state {inaccurate_printed}:")
-                    print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))
-                    print(f"    DB values:    {db_action_vals}")
-                    print(f"    Model values: {model_vals.tolist()}")
-                    print(
-                        f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_action_vals[model_pick]})"
-                    )
-            total += 1
+        # DB action values and model values are both from acting player's perspective.
+        best_db_val = max(db_action_vals)
+        model_pick = int(np.argmax(model_vals))
+        if db_action_vals[model_pick] == best_db_val:
+            correct += 1
+        else:
+            if inaccurate_printed < 3:
+                inaccurate_printed += 1
+                print(f"  Inaccurate state {inaccurate_printed}:")
+                print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))
+                print(f"    DB values:    {db_action_vals}")
+                print(f"    Model values: {model_vals}")
+                print(
+                    f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_action_vals[model_pick]})"
+                )
+        total += 1
 
     return correct / total
 
@@ -309,7 +305,7 @@ def main():
     # Create NNEvaluator and set up optimizer
     # ------------------------------------------------------------------
     action_encoder = ActionEncoder(board_size)
-    evaluator = NNEvaluator(action_encoder, device, nn_config, max_cache_size=0)
+    evaluator = NNEvaluator(action_encoder, device, nn_config, max_cache_size=1000)
     evaluator.train_prepare(az_params.learning_rate, az_params.batch_size, args.num_steps, az_params.weight_decay)
 
     # ------------------------------------------------------------------

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -27,6 +27,23 @@ from agents.alphazero.nn_evaluator import NNConfig, NNEvaluator
 from quoridor import ActionEncoder, Board, Player, Quoridor
 from utils.subargs import parse_subargs
 
+DEBUG = True
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+
+def print_policy(policy, action_encoder):
+    """Print non-zero entries of a policy array as human-readable actions."""
+    nonzero = np.nonzero(policy)[0]
+    parts = []
+    for idx in nonzero:
+        action = action_encoder.index_to_action(idx)
+        parts.append(f"{action}: {policy[idx]:.3f}")
+    print("  ".join(parts))
+
+
 # ---------------------------------------------------------------------------
 # Data helpers
 # ---------------------------------------------------------------------------
@@ -84,7 +101,7 @@ def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
     return policy
 
 
-def fetch_batch(db, ids, evaluator, board_size, max_walls, max_steps):
+def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_steps):
     """Fetch rows by rowid from the policy table and compute features on the fly.
 
     Returns a list of sample dicts compatible with NNEvaluator.compute_losses.
@@ -109,10 +126,21 @@ def fetch_batch(db, ids, evaluator, board_size, max_walls, max_steps):
         )
         assert mcts_policy is not None
 
-        action_mask = game.get_action_mask().astype(np.float32)
+        # Do the rotation, in the same way AlphaZeroAgent.store_training_data() does
+        game, is_rotated = evaluator.rotate_if_needed_to_point_downwards(game)
+        input_array = evaluator.game_to_input_array(game)
+        action_mask = game.get_action_mask()
+        if is_rotated:
+            mcts_policy = evaluator.rotate_policy_from_original(mcts_policy)
+
+        if DEBUG:
+            print("")
+            print(game)
+            print_policy(mcts_policy, evaluator.action_encoder)
+
         samples.append(
             {
-                "input_array": evaluator.game_to_input_array(game),
+                "input_array": input_array,
                 "value": value if current_player == 0 else -value,
                 "action_mask": action_mask,
                 "mcts_policy": mcts_policy,
@@ -177,7 +205,7 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
         if db_action_vals[model_pick] == best_db_val:
             correct += 1
         else:
-            if inaccurate_printed < 3:
+            if DEBUG and inaccurate_printed < 3:
                 inaccurate_printed += 1
                 print(f"  Inaccurate state {inaccurate_printed}:")
                 print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -15,7 +15,6 @@ Two metrics are logged during training:
 import argparse
 import os
 import random
-import sqlite3
 import sys
 from dataclasses import asdict
 
@@ -31,16 +30,6 @@ from utils.subargs import parse_subargs
 # ---------------------------------------------------------------------------
 # Data helpers
 # ---------------------------------------------------------------------------
-
-
-def read_metadata(conn):
-    rows = conn.execute("SELECT key, value FROM metadata").fetchall()
-    meta = {k: v for k, v in rows}
-    board_size = int(meta["board_size"])
-    max_walls = int(meta["max_walls"])
-    max_steps = int(meta["max_steps"])
-    num_states = int(meta["num_states"]) if "num_states" in meta else None
-    return board_size, max_walls, max_steps, num_states
 
 
 def compact_state_to_game(state_bytes, board_size, max_walls, max_steps):
@@ -71,59 +60,41 @@ def child_action_index(row, col, action_type, board_size):
     raise ValueError(f"Unknown action_type {action_type}")
 
 
-def build_policy_from_children(conn, state_bytes, current_player, board_size, max_walls, max_steps, num_actions):
-    """Build a policy vector from DB child state values.
+def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
+    """Build a policy vector from DB action values.
 
-    Finds the optimal child value (max for P0, min for P1) and assigns
-    uniform probability across all actions that achieve that value.
-    All other actions get zero probability.
+    Uses lookup_action_values which correctly handles terminal child states.
+    Assigns uniform probability across all actions with the best value
+    (values are from acting player's perspective, so best = max).
 
-    Returns the policy array, or None if some children are missing from the DB.
+    Returns the policy array, or None if no valid actions.
     """
-    children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
-    if not children:
+    result = db.lookup_action_values(state_bytes)
+    if result is None:
         return None
 
-    child_blobs = [bytes(c[3]) for c in children]
-    placeholders = ",".join("?" * len(child_blobs))
-    child_rows = conn.execute(
-        f"SELECT state, value FROM policy WHERE state IN ({placeholders})",
-        child_blobs,
-    ).fetchall()
-    if len(child_rows) != len(child_blobs):
-        return None  # Some children not in DB.
-    child_db_vals = {bytes(s): v for s, v in child_rows}
+    actions, values = result
+    best_value = max(values)
 
-    # Find optimal value from current player's perspective.
-    child_values = [child_db_vals[bytes(c[3])] for c in children]
-    best_value = max(child_values) if current_player == 0 else min(child_values)
-
-    # Assign equal probability to all actions achieving the best value.
     policy = np.zeros(num_actions, dtype=np.float32)
-    for row, col, action_type, child_state in children:
-        if child_db_vals[bytes(child_state)] == best_value:
+    for (row, col, action_type), value in zip(actions, values):
+        if value == best_value:
             idx = child_action_index(row, col, action_type, board_size)
             policy[idx] = 1.0
     policy /= policy.sum()
     return policy
 
 
-def fetch_batch(conn, ids, evaluator, board_size, max_walls, max_steps):
+def fetch_batch(db, ids, evaluator, board_size, max_walls, max_steps):
     """Fetch rows by rowid from the policy table and compute features on the fly.
 
     Returns a list of sample dicts compatible with NNEvaluator.compute_losses.
     Each dict has keys: input_array, value, action_mask, mcts_policy, current_player.
 
-    mcts_policy is derived from the DB values of child states: uniform over
-    actions that lead to the optimal child value (max for P0, min for P1),
-    zero for all others. States whose children are not all present in the
-    DB are skipped.
+    mcts_policy is derived from lookup_action_values: uniform over actions
+    with the best value, zero for all others.
     """
-    placeholders = ",".join("?" * len(ids))
-    rows = conn.execute(
-        f"SELECT state, value FROM policy WHERE rowid IN ({placeholders})",
-        ids,
-    ).fetchall()
+    rows = db.fetch_states_by_rowid(ids)
     num_actions = evaluator.action_encoder.num_actions
     samples = []
     for state, value in rows:
@@ -131,13 +102,10 @@ def fetch_batch(conn, ids, evaluator, board_size, max_walls, max_steps):
         game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
         current_player = int(game.current_player)
 
-        mcts_policy = build_policy_from_children(
-            conn,
+        mcts_policy = build_policy_from_action_values(
+            db,
             state_bytes,
-            current_player,
             board_size,
-            max_walls,
-            max_steps,
             num_actions,
         )
         if mcts_policy is None:
@@ -161,7 +129,7 @@ def fetch_batch(conn, ids, evaluator, board_size, max_walls, max_steps):
 # ---------------------------------------------------------------------------
 
 
-def compute_accuracy(test_ids, conn, evaluator, board_size, max_walls, max_steps, num_samples, test_player=None):
+def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, num_samples, test_player=None):
     """Fraction of sampled states where model picks the same best child as DB.
 
     If test_player is 0 or 1, only states where the current player matches are counted.
@@ -169,11 +137,7 @@ def compute_accuracy(test_ids, conn, evaluator, board_size, max_walls, max_steps
     sample_ids = random.sample(test_ids, min(num_samples, len(test_ids)))
 
     # Fetch the state blobs and values for the sampled test IDs.
-    placeholders = ",".join("?" * len(sample_ids))
-    rows = conn.execute(
-        f"SELECT state, value FROM policy WHERE rowid IN ({placeholders})",
-        sample_ids,
-    ).fetchall()
+    rows = db.fetch_states_by_rowid(sample_ids)
 
     correct = 0
     total = 0
@@ -190,46 +154,41 @@ def compute_accuracy(test_ids, conn, evaluator, board_size, max_walls, max_steps
             if test_player is not None and current_player != test_player:
                 continue
 
-            children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
-            if not children:
+            # DB action values (handles terminal child states correctly).
+            # Values are from the acting player's perspective (positive = good).
+            result = db.lookup_action_values(state_bytes)
+            if result is None:
                 continue
+            _actions, db_action_vals = result
+            db_action_vals = list(db_action_vals)
 
-            child_blobs = [bytes(c[3]) for c in children]
-
-            # Look up DB values for all children via the state index.
-            child_placeholders = ",".join("?" * len(child_blobs))
-            child_rows = conn.execute(
-                f"SELECT state, value FROM policy WHERE state IN ({child_placeholders})",
-                child_blobs,
-            ).fetchall()
-            if len(child_rows) != len(child_blobs):
-                continue  # Some children not in DB (e.g. terminal states).
-            child_db_vals = {bytes(s): v for s, v in child_rows}
-            db_vals = [child_db_vals[cb] for cb in child_blobs]
-
-            # Model predictions for children.
+            # Model predictions for children (same action ordering as lookup_action_values).
+            children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
             child_features = []
-            for cb in child_blobs:
-                child_game = compact_state_to_game(cb, board_size, max_walls, max_steps)
+            for _row, _col, _action_type, child_state in children:
+                child_game = compact_state_to_game(bytes(child_state), board_size, max_walls, max_steps)
                 child_features.append(evaluator.game_to_input_array(child_game))
             x = torch.tensor(np.stack(child_features), dtype=torch.float32, device=device)
             _, model_vals = evaluator.network(x)
+            # Model predicts P0-absolute values; convert to acting player's perspective.
             model_vals = model_vals.squeeze(-1).cpu().numpy()
+            if current_player == 1:
+                model_vals = -model_vals
 
-            # The model's pick is correct if it leads to a child with the best DB value.
-            best_db_val = max(db_vals) if current_player == 0 else min(db_vals)
-            model_pick = np.argmax(model_vals) if current_player == 0 else np.argmin(model_vals)
-            if db_vals[model_pick] == best_db_val:
+            # DB action values and model values are both from acting player's perspective.
+            best_db_val = max(db_action_vals)
+            model_pick = int(np.argmax(model_vals))
+            if db_action_vals[model_pick] == best_db_val:
                 correct += 1
             else:
                 if inaccurate_printed < 3:
                     inaccurate_printed += 1
                     print(f"  Inaccurate state {inaccurate_printed}:")
                     print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))
-                    print(f"    DB values:    {db_vals}")
+                    print(f"    DB values:    {db_action_vals}")
                     print(f"    Model values: {model_vals.tolist()}")
                     print(
-                        f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_vals[model_pick]})"
+                        f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_action_vals[model_pick]})"
                     )
             total += 1
 
@@ -322,13 +281,13 @@ def main():
     # ------------------------------------------------------------------
     # Open DB and read metadata
     # ------------------------------------------------------------------
-    conn = sqlite3.connect(args.db_path)
-    board_size, max_walls, max_steps, num_states = read_metadata(conn)
+    db = quoridor_rs.PyPolicyDb(args.db_path)
+    board_size, max_walls, max_steps, num_states = db.read_metadata()
     print(f"Board size: {board_size}, max_walls: {max_walls}, max_steps: {max_steps}")
 
     if num_states is None:
         # Fallback for DBs created before autoincrement ID was added.
-        num_states = conn.execute("SELECT COUNT(*) FROM policy").fetchone()[0]
+        num_states = db.count_states()
         print(f"(num_states not in metadata, counted {num_states} rows)")
     print(f"Policy DB contains {num_states} states")
 
@@ -357,7 +316,7 @@ def main():
     # Pre-compute test samples (test set is small / capped)
     # ------------------------------------------------------------------
     print("Computing test features...")
-    test_samples = fetch_batch(conn, test_ids, evaluator, board_size, max_walls, max_steps)
+    test_samples = fetch_batch(db, test_ids, evaluator, board_size, max_walls, max_steps)
 
     # Filter test set by player if requested.
     if test_player is not None:
@@ -412,7 +371,7 @@ def main():
         batch_ids = random.sample(range(1, num_states + 1), min(batch_size * oversample, num_states))
         if args.exclude_test_set:
             batch_ids = [i for i in batch_ids if i not in test_id_set]
-        batch_samples = fetch_batch(conn, batch_ids, evaluator, board_size, max_walls, max_steps)
+        batch_samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
         if test_player is not None:
             batch_samples = [s for s in batch_samples if s["current_player"] == test_player]
         batch_samples = batch_samples[:batch_size]
@@ -439,7 +398,7 @@ def main():
 
             acc = compute_accuracy(
                 test_ids,
-                conn,
+                db,
                 evaluator,
                 board_size,
                 max_walls,
@@ -477,7 +436,6 @@ def main():
                     args.output,
                 )
 
-    conn.close()
     print(f"Training complete. Best test loss: {best_test_loss:.4f}. Model saved to {args.output}")
 
     if use_wandb:

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -132,12 +132,14 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
         )
         db_policy_original = mcts_policy.copy()
 
+        Timer.start("game_rotation_and_features")
         # Do the rotation, in the same way AlphaZeroAgent.store_training_data() does
         game, is_rotated = evaluator.rotate_if_needed_to_point_downwards(game)
         input_array = evaluator.game_to_input_array(game)
         action_mask = game.get_action_mask()
         if is_rotated:
             mcts_policy = evaluator.rotate_policy_from_original(mcts_policy)
+        Timer.finish("game_rotation_and_features")
 
         if DEBUG:
             print("")
@@ -228,32 +230,34 @@ def compute_test_metrics_batched(
     total_pol = total_val = total_tot = 0.0
     correct = total = 0
 
-    evaluator.network.eval()
-    with torch.no_grad():
-        for start in range(1, num_states + 1, batch_size):
-            batch_ids = list(range(start, min(start + batch_size, num_states + 1)))
-            samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
-            if test_player is not None:
-                samples = [s for s in samples if s["current_player"] == test_player]
-            assert samples is not None, "fetch_batch should never return None"
+    for start in range(1, num_states + 1, batch_size):
+        print(f"Evaluating test batch {start} to {min(start + batch_size - 1, num_states)} out of {num_states}")
+        batch_ids = list(range(start, min(start + batch_size, num_states + 1)))
+        samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
+        if test_player is not None:
+            samples = [s for s in samples if s["current_player"] == test_player]
+        assert samples is not None, "fetch_batch should never return None"
+        print("Batch size after filtering: ", len(samples))
 
-            n = len(samples)
-            pol, val, tot = evaluator.compute_losses(samples)
-            total_pol += pol.item() * n
-            total_val += val.item() * n
-            total_tot += tot.item() * n
+        n = len(samples)
+        if n == 0:
+            continue
+        pol, val, tot = evaluator.compute_losses(samples)
+        total_pol += pol.item() * n
+        total_val += val.item() * n
+        total_tot += tot.item() * n
 
-            for s in samples:
-                original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
-                _, model_policy = evaluator.evaluate(original_game)
-                db_policy = s["db_policy_original"]
-                best_db_prob = max(db_policy)
-                model_pick = int(np.argmax(model_policy))
-                if db_policy[model_pick] == best_db_prob:
-                    correct += 1
-                total += 1
+        for s in samples:
+            original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
+            _, model_policy = evaluator.evaluate(original_game)
+            db_policy = s["db_policy_original"]
+            best_db_prob = max(db_policy)
+            model_pick = int(np.argmax(model_policy))
+            if db_policy[model_pick] == best_db_prob:
+                correct += 1
+            total += 1
 
-    evaluator.network.train()
+        Timer.log_totals()
 
     assert total > 0, "No test samples found (check test_player filter?)"
     return total_pol / total, total_val / total, total_tot / total, correct / total

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -17,6 +17,7 @@ import os
 import random
 import sys
 from dataclasses import asdict
+from pathlib import Path
 
 import numpy as np
 import quoridor_rs
@@ -232,6 +233,34 @@ def compute_test_metrics_batched(
 
 
 # ---------------------------------------------------------------------------
+# DB source resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_db_path(db_path: str) -> str:
+    """If `db_path` is `wandb:<entity>/<project>/<name>:<alias>`, fetch the
+    artifact and return the local path to the `.parquet` file inside it.
+    Otherwise return `db_path` unchanged. wandb's API caches downloads in
+    `~/.cache/wandb/` so repeat invocations are local-disk cheap.
+    """
+    if not db_path.startswith("wandb:"):
+        return db_path
+    artifact_ref = db_path[len("wandb:"):]
+    print(f"Fetching wandb artifact: {artifact_ref}")
+    api = wandb.Api()
+    artifact = api.artifact(artifact_ref, type="policy_db")
+    download_dir = artifact.download()
+    parquet_files = list(Path(download_dir).glob("*.parquet"))
+    if len(parquet_files) != 1:
+        raise RuntimeError(
+            f"Expected exactly one .parquet in artifact {artifact_ref}, "
+            f"found {parquet_files}"
+        )
+    print(f"Using downloaded DB: {parquet_files[0]}")
+    return str(parquet_files[0])
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -240,7 +269,13 @@ MAX_TEST_SIZE = 10000
 
 def parse_args():
     p = argparse.ArgumentParser(description="Train a neural network evaluator from a policy DB.")
-    p.add_argument("db_path", help="Path to .sqlite policy DB")
+    p.add_argument(
+        "db_path",
+        help=(
+            "Path to a .parquet policy DB, or "
+            "'wandb:<entity>/<project>/<name>:<alias>' to fetch from a wandb artifact"
+        ),
+    )
     p.add_argument(
         "-p",
         "--params",
@@ -333,7 +368,8 @@ def main():
     # ------------------------------------------------------------------
     # Open DB and read metadata
     # ------------------------------------------------------------------
-    db = quoridor_rs.PyPolicyDb(args.db_path, lazy=False)
+    db_path = resolve_db_path(args.db_path)
+    db = quoridor_rs.PyPolicyDb(db_path, lazy=False)
     board_size, max_walls, max_steps, num_states = db.read_metadata()
     print(f"Board size: {board_size}, max_walls: {max_walls}, max_steps: {max_steps}")
 

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -163,101 +163,71 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
 
 
 # ---------------------------------------------------------------------------
-# Accuracy metric
+# Test metrics
 # ---------------------------------------------------------------------------
-
-
-@timer("compute_accuracy")
-def compute_accuracy(
-    test_ids, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, num_samples, test_player=None
-):
-    """Fraction of sampled states where model picks the same best action as DB.
-
-    If test_player is 0 or 1, only states where the current player matches are counted.
-    """
-    assert len(test_ids) > 0
-    assert num_samples > 0
-    sample_ids = random.sample(test_ids, min(num_samples, len(test_ids)))
-
-    # Fetch the state blobs and values for the sampled test IDs.
-    rows = db.fetch_states_by_rowid(sample_ids)
-
-    correct = 0
-    total = 0
-    inaccurate_printed = 0
-    for state, _value in rows:
-        game = compact_state_to_game(state, board_size, max_walls, max_steps)
-        current_player = int(game.current_player)
-        if test_player is not None and current_player != test_player:
-            continue
-
-        db_policy = build_policy_from_action_values(
-            db,
-            state,
-            board_size,
-            evaluator.action_encoder.num_actions,
-        )
-
-        _, model_policy = evaluator.evaluate(game)
-
-        best_db_action_prob = max(db_policy)
-        model_pick = int(np.argmax(model_policy))
-        if db_policy[model_pick] == best_db_action_prob:
-            correct += 1
-        else:
-            if DEBUG and inaccurate_printed < 3:
-                inaccurate_printed += 1
-
-                print("")
-                print(game)
-                print(f"DB optimal actions: {policy_to_str(db_policy, evaluator.action_encoder)}")
-                print(f"Model optimal actions: {policy_to_str(model_policy, evaluator.action_encoder)}")
-
-        Timer.log_totals()
-        total += 1
-
-    return correct / total
 
 
 @timer("compute_test_metrics_batched")
 def compute_test_metrics_batched(
-    num_states, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, batch_size, test_player=None
+    test_ids, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, batch_size, test_player=None
 ):
-    """Compute test loss and accuracy over all states by iterating in batches.
+    """Iterate `test_ids` in chunks, emitting batches of exactly `batch_size`
+    samples (post player filter). Only the final batch may be smaller.
+
+    When `test_player` filtering drops samples below `batch_size`, we keep
+    fetching more `test_ids` and refilling a buffer until the batch is full
+    or `test_ids` is exhausted.
 
     Returns (policy_loss, value_loss, total_loss, accuracy) as floats.
     """
     total_pol = total_val = total_tot = 0.0
     correct = total = 0
 
-    for start in range(1, num_states + 1, batch_size):
-        print(f"Evaluating test batch {start} to {min(start + batch_size - 1, num_states)} out of {num_states}")
-        batch_ids = list(range(start, min(start + batch_size, num_states + 1)))
-        samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
-        if test_player is not None:
-            samples = [s for s in samples if s["current_player"] == test_player]
-        assert samples is not None, "fetch_batch should never return None"
-        print("Batch size after filtering: ", len(samples))
+    n_test_ids = len(test_ids)
+    ids_idx = 0
+    buffer = []
 
-        n = len(samples)
-        if n == 0:
-            continue
-        pol, val, tot = evaluator.compute_losses(samples)
-        total_pol += pol.item() * n
-        total_val += val.item() * n
-        total_tot += tot.item() * n
+    evaluator.network.eval()
+    with torch.no_grad():
+        while ids_idx < n_test_ids or buffer:
+            # Top up the buffer until it has at least one full batch worth
+            # of samples (or test_ids is exhausted).
+            while len(buffer) < batch_size and ids_idx < n_test_ids:
+                end = min(ids_idx + batch_size, n_test_ids)
+                next_ids = test_ids[ids_idx:end]
+                ids_idx = end
+                new_samples = fetch_batch(
+                    db, next_ids, evaluator, board_size, max_walls, max_steps
+                )
+                if test_player is not None:
+                    new_samples = [s for s in new_samples if s["current_player"] == test_player]
+                buffer.extend(new_samples)
 
-        for s in samples:
-            original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
-            _, model_policy = evaluator.evaluate(original_game)
-            db_policy = s["db_policy_original"]
-            best_db_prob = max(db_policy)
-            model_pick = int(np.argmax(model_policy))
-            if db_policy[model_pick] == best_db_prob:
-                correct += 1
-            total += 1
+            # Emit a batch from the front of the buffer.
+            batch = buffer[:batch_size]
+            buffer = buffer[batch_size:]
+            n = len(batch)
+            if n == 0:
+                break
 
-        Timer.log_totals()
+            print(f"Evaluating test batch {total + 1}-{total + n} of ~{n_test_ids}")
+            pol, val, tot = evaluator.compute_losses(batch)
+            total_pol += pol.item() * n
+            total_val += val.item() * n
+            total_tot += tot.item() * n
+
+            for s in batch:
+                original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
+                _, model_policy = evaluator.evaluate(original_game)
+                db_policy = s["db_policy_original"]
+                best_db_prob = max(db_policy)
+                model_pick = int(np.argmax(model_policy))
+                if db_policy[model_pick] == best_db_prob:
+                    correct += 1
+                total += 1
+
+            Timer.log_totals()
+    evaluator.network.train()
 
     assert total > 0, "No test samples found (check test_player filter?)"
     return total_pol / total, total_val / total, total_tot / total, correct / total
@@ -284,12 +254,11 @@ def parse_args():
     p.add_argument(
         "--test-batch-size",
         type=int,
-        default=None,
-        help="If set, test on all states using sequential batches of this size (ignores --test-fraction and --exclude-test-set)",
+        default=256,
+        help="Per-batch sample count for test evaluation (only the last batch may be smaller)",
     )
     p.add_argument("--num-steps", type=int, default=10000)
     p.add_argument("--log-interval", type=int, default=200)
-    p.add_argument("--accuracy-states", type=int, default=200)
     p.add_argument("--output", default="evaluator.pt")
     p.add_argument("--device", default=None, help="cpu or cuda (default: auto)")
     p.add_argument(
@@ -385,14 +354,13 @@ def main():
     # ------------------------------------------------------------------
     # Train/test split by ID (IDs are 1-based, contiguous)
     # ------------------------------------------------------------------
-    if args.test_batch_size is not None:
-        test_id_set = None
-        print(f"Full-DB test mode: {num_states} states, test batch size {args.test_batch_size}")
-    else:
-        test_size = min(max(1, int(num_states * args.test_fraction)), MAX_TEST_SIZE)
-        test_id_set = set(random.sample(range(1, num_states + 1), test_size))
-        test_ids = sorted(test_id_set)
-        print(f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}")
+    test_size = min(max(1, int(num_states * args.test_fraction)), MAX_TEST_SIZE)
+    test_id_set = set(random.sample(range(1, num_states + 1), test_size))
+    test_ids = sorted(test_id_set)
+    print(
+        f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}, "
+        f"test batch size: {args.test_batch_size}"
+    )
 
     # ------------------------------------------------------------------
     # Create NNEvaluator and set up optimizer
@@ -402,19 +370,10 @@ def main():
     evaluator.train_prepare(az_params.learning_rate, az_params.batch_size, args.num_steps, az_params.weight_decay)
 
     # ------------------------------------------------------------------
-    # Pre-compute test samples (test set is small / capped)
+    # Probe one sample for feature_dim
     # ------------------------------------------------------------------
-    if args.test_batch_size is None:
-        print("Computing test features...")
-        test_samples = fetch_batch(db, test_ids, evaluator, board_size, max_walls, max_steps)
-        if test_player is not None:
-            test_samples = [s for s in test_samples if s["current_player"] == test_player]
-            print(f"Filtered test set to {len(test_samples)} states for player {args.test_player}")
-        feature_dim = test_samples[0]["input_array"].shape[0]
-    else:
-        test_samples = None
-        probe = fetch_batch(db, [1], evaluator, board_size, max_walls, max_steps)
-        feature_dim = probe[0]["input_array"].shape[0]
+    probe = fetch_batch(db, [test_ids[0]], evaluator, board_size, max_walls, max_steps)
+    feature_dim = probe[0]["input_array"].shape[0]
     print(f"Feature dim: {feature_dim}")
 
     if use_wandb:
@@ -424,8 +383,8 @@ def main():
                 "max_walls": max_walls,
                 "max_steps": max_steps,
                 "num_states": num_states,
-                "train_size": num_states if args.test_batch_size is not None else num_states - test_size,
-                "test_size": num_states if args.test_batch_size is not None else len(test_samples),
+                "train_size": num_states - test_size,
+                "test_size": len(test_ids),
                 "feature_dim": feature_dim,
             }
         )
@@ -482,38 +441,16 @@ def main():
             )
 
         if step % args.log_interval == 0 or step == 1:
-            if args.test_batch_size is not None:
-                test_policy_loss, test_value_loss, test_total_loss, acc = compute_test_metrics_batched(
-                    num_states,
-                    db,
-                    evaluator,
-                    board_size,
-                    max_walls,
-                    max_steps,
-                    args.test_batch_size,
-                    test_player=test_player,
-                )
-            else:
-                evaluator.network.eval()
-                with torch.no_grad():
-                    test_policy_loss, test_value_loss, test_total_loss = evaluator.compute_losses(test_samples)
-                    test_policy_loss = test_policy_loss.item()
-                    test_value_loss = test_value_loss.item()
-                    test_total_loss = test_total_loss.item()
-                evaluator.network.train()
-
-                Timer.log_totals()
-
-                acc = compute_accuracy(
-                    test_ids,
-                    db,
-                    evaluator,
-                    board_size,
-                    max_walls,
-                    max_steps,
-                    args.accuracy_states,
-                    test_player=test_player,
-                )
+            test_policy_loss, test_value_loss, test_total_loss, acc = compute_test_metrics_batched(
+                test_ids,
+                db,
+                evaluator,
+                board_size,
+                max_walls,
+                max_steps,
+                args.test_batch_size,
+                test_player=test_player,
+            )
 
             print(
                 f"step {step:6d} | "

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -26,6 +26,7 @@ from agents.alphazero.alphazero import AlphaZeroParams
 from agents.alphazero.nn_evaluator import NNConfig, NNEvaluator
 from quoridor import ActionEncoder, Board, Player, Quoridor
 from utils.subargs import parse_subargs
+from utils.timer import Timer, timer
 
 DEBUG = False
 
@@ -49,10 +50,11 @@ def policy_to_str(policy, action_encoder):
 # ---------------------------------------------------------------------------
 
 
-def compact_state_to_game(state_bytes, board_size, max_walls, max_steps):
-    """Convert compact state bytes to a Quoridor game object."""
+@timer("compact_state_to_game")
+def compact_state_to_game(state, board_size, max_walls, max_steps):
+    """Convert a compact state (Python int) to a Quoridor game object."""
     grid, player_positions, walls_remaining, old_style_walls, current_player, completed_steps = (
-        quoridor_rs.compact_state_to_game_state(state_bytes, board_size, max_walls, max_steps)
+        quoridor_rs.compact_state_to_game_state(state, board_size, max_walls, max_steps)
     )
     board = Board.from_arrays(
         board_size,
@@ -77,7 +79,8 @@ def child_action_index(row, col, action_type, board_size):
     raise ValueError(f"Unknown action_type {action_type}")
 
 
-def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
+@timer("build_policy_from_action_values")
+def build_policy_from_action_values(db, state, board_size, num_actions):
     """Build a policy vector from DB action values.
 
     Uses lookup_action_values which correctly handles terminal child states.
@@ -86,7 +89,7 @@ def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
 
     Returns the policy array, or None if no valid actions.
     """
-    result = db.lookup_action_values(state_bytes)
+    result = db.lookup_action_values(state)
     assert result is not None
 
     actions, values = result
@@ -101,6 +104,7 @@ def build_policy_from_action_values(db, state_bytes, board_size, num_actions):
     return policy
 
 
+@timer("fetch_batch")
 def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_steps):
     """Fetch rows by rowid from the policy table and compute features on the fly.
 
@@ -114,8 +118,7 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
     num_actions = evaluator.action_encoder.num_actions
     samples = []
     for state, value in rows:
-        state_bytes = bytes(state)
-        game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
+        game = compact_state_to_game(state, board_size, max_walls, max_steps)
         current_player = int(game.current_player)
         if current_player == 1:
             # DB Values are always from P1 perspective
@@ -123,10 +126,11 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
 
         mcts_policy = build_policy_from_action_values(
             db,
-            state_bytes,
+            state,
             board_size,
             num_actions,
         )
+        db_policy_original = mcts_policy.copy()
 
         # Do the rotation, in the same way AlphaZeroAgent.store_training_data() does
         game, is_rotated = evaluator.rotate_if_needed_to_point_downwards(game)
@@ -149,6 +153,8 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
                 "action_mask": action_mask,
                 "mcts_policy": mcts_policy,
                 "current_player": current_player,
+                "state": state,
+                "db_policy_original": db_policy_original,
             }
         )
     return samples
@@ -159,6 +165,7 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
 # ---------------------------------------------------------------------------
 
 
+@timer("compute_accuracy")
 def compute_accuracy(
     test_ids, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, num_samples, test_player=None
 ):
@@ -176,17 +183,15 @@ def compute_accuracy(
     correct = 0
     total = 0
     inaccurate_printed = 0
-    for state_blob, _value in rows:
-        state_bytes = bytes(state_blob)
-
-        game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
+    for state, _value in rows:
+        game = compact_state_to_game(state, board_size, max_walls, max_steps)
         current_player = int(game.current_player)
         if test_player is not None and current_player != test_player:
             continue
 
         db_policy = build_policy_from_action_values(
             db,
-            state_bytes,
+            state,
             board_size,
             evaluator.action_encoder.num_actions,
         )
@@ -205,9 +210,53 @@ def compute_accuracy(
                 print(game)
                 print(f"DB optimal actions: {policy_to_str(db_policy, evaluator.action_encoder)}")
                 print(f"Model optimal actions: {policy_to_str(model_policy, evaluator.action_encoder)}")
+
+        Timer.log_totals()
         total += 1
 
     return correct / total
+
+
+@timer("compute_test_metrics_batched")
+def compute_test_metrics_batched(
+    num_states, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, batch_size, test_player=None
+):
+    """Compute test loss and accuracy over all states by iterating in batches.
+
+    Returns (policy_loss, value_loss, total_loss, accuracy) as floats.
+    """
+    total_pol = total_val = total_tot = 0.0
+    correct = total = 0
+
+    evaluator.network.eval()
+    with torch.no_grad():
+        for start in range(1, num_states + 1, batch_size):
+            batch_ids = list(range(start, min(start + batch_size, num_states + 1)))
+            samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
+            if test_player is not None:
+                samples = [s for s in samples if s["current_player"] == test_player]
+            assert samples is not None, "fetch_batch should never return None"
+
+            n = len(samples)
+            pol, val, tot = evaluator.compute_losses(samples)
+            total_pol += pol.item() * n
+            total_val += val.item() * n
+            total_tot += tot.item() * n
+
+            for s in samples:
+                original_game = compact_state_to_game(s["state"], board_size, max_walls, max_steps)
+                _, model_policy = evaluator.evaluate(original_game)
+                db_policy = s["db_policy_original"]
+                best_db_prob = max(db_policy)
+                model_pick = int(np.argmax(model_policy))
+                if db_policy[model_pick] == best_db_prob:
+                    correct += 1
+                total += 1
+
+    evaluator.network.train()
+
+    assert total > 0, "No test samples found (check test_player filter?)"
+    return total_pol / total, total_val / total, total_tot / total, correct / total
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +277,12 @@ def parse_args():
         help="AlphaZero params in subargs form (e.g. nn_type=mlp,learning_rate=0.001)",
     )
     p.add_argument("--test-fraction", type=float, default=0.1)
+    p.add_argument(
+        "--test-batch-size",
+        type=int,
+        default=None,
+        help="If set, test on all states using sequential batches of this size (ignores --test-fraction and --exclude-test-set)",
+    )
     p.add_argument("--num-steps", type=int, default=10000)
     p.add_argument("--log-interval", type=int, default=200)
     p.add_argument("--accuracy-states", type=int, default=200)
@@ -286,18 +341,20 @@ def main():
     use_wandb = args.wandb is not None
     if use_wandb:
         wandb_project = args.wandb if args.wandb else "policydb_evaluator"
-        wandb.init(
+        wandb_run = wandb.init(
             project=wandb_project,
             config={
                 "db_path": os.path.basename(args.db_path),
                 "num_steps": args.num_steps,
                 "test_fraction": args.test_fraction,
+                "test_batch_size": args.test_batch_size,
                 "test_player": args.test_player,
                 "exclude_test_set": args.exclude_test_set,
                 "output": args.output,
                 **asdict(az_params),
             },
         )
+        Timer.set_wandb_run(wandb_run)
         wandb.define_metric("step", hidden=True)
         wandb.define_metric("train/*", step_metric="step")
         wandb.define_metric("test/*", step_metric="step")
@@ -324,10 +381,14 @@ def main():
     # ------------------------------------------------------------------
     # Train/test split by ID (IDs are 1-based, contiguous)
     # ------------------------------------------------------------------
-    test_size = min(max(1, int(num_states * args.test_fraction)), MAX_TEST_SIZE)
-    test_id_set = set(random.sample(range(1, num_states + 1), test_size))
-    test_ids = sorted(test_id_set)
-    print(f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}")
+    if args.test_batch_size is not None:
+        test_id_set = None
+        print(f"Full-DB test mode: {num_states} states, test batch size {args.test_batch_size}")
+    else:
+        test_size = min(max(1, int(num_states * args.test_fraction)), MAX_TEST_SIZE)
+        test_id_set = set(random.sample(range(1, num_states + 1), test_size))
+        test_ids = sorted(test_id_set)
+        print(f"Train size: ~{num_states - test_size}, test size: {len(test_ids)}")
 
     # ------------------------------------------------------------------
     # Create NNEvaluator and set up optimizer
@@ -339,15 +400,17 @@ def main():
     # ------------------------------------------------------------------
     # Pre-compute test samples (test set is small / capped)
     # ------------------------------------------------------------------
-    print("Computing test features...")
-    test_samples = fetch_batch(db, test_ids, evaluator, board_size, max_walls, max_steps)
-
-    # Filter test set by player if requested.
-    if test_player is not None:
-        test_samples = [s for s in test_samples if s["current_player"] == test_player]
-        print(f"Filtered test set to {len(test_samples)} states for player {args.test_player}")
-
-    feature_dim = test_samples[0]["input_array"].shape[0]
+    if args.test_batch_size is None:
+        print("Computing test features...")
+        test_samples = fetch_batch(db, test_ids, evaluator, board_size, max_walls, max_steps)
+        if test_player is not None:
+            test_samples = [s for s in test_samples if s["current_player"] == test_player]
+            print(f"Filtered test set to {len(test_samples)} states for player {args.test_player}")
+        feature_dim = test_samples[0]["input_array"].shape[0]
+    else:
+        test_samples = None
+        probe = fetch_batch(db, [1], evaluator, board_size, max_walls, max_steps)
+        feature_dim = probe[0]["input_array"].shape[0]
     print(f"Feature dim: {feature_dim}")
 
     if use_wandb:
@@ -357,8 +420,8 @@ def main():
                 "max_walls": max_walls,
                 "max_steps": max_steps,
                 "num_states": num_states,
-                "train_size": num_states - test_size,
-                "test_size": len(test_samples),
+                "train_size": num_states if args.test_batch_size is not None else num_states - test_size,
+                "test_size": num_states if args.test_batch_size is not None else len(test_samples),
                 "feature_dim": feature_dim,
             }
         )
@@ -379,6 +442,7 @@ def main():
         )
 
     for step in range(1, args.num_steps + 1):
+        print(f"Step {step}/{args.num_steps}")
         if step % 100000 == 0:
             learning_rate = learning_rate / 2.0
             print(f"Lowering learning rate to {learning_rate}")
@@ -395,7 +459,7 @@ def main():
         # build_policy_from_children (missing children in DB).
         oversample = 4 if test_player is None else 8
         batch_ids = random.sample(range(1, num_states + 1), min(batch_size * oversample, num_states))
-        if args.exclude_test_set:
+        if args.exclude_test_set and test_id_set is not None:
             batch_ids = [i for i in batch_ids if i not in test_id_set]
         batch_samples = fetch_batch(db, batch_ids, evaluator, board_size, max_walls, max_steps)
         if test_player is not None:
@@ -414,24 +478,38 @@ def main():
             )
 
         if step % args.log_interval == 0 or step == 1:
-            evaluator.network.eval()
-            with torch.no_grad():
-                test_policy_loss, test_value_loss, test_total_loss = evaluator.compute_losses(test_samples)
-                test_policy_loss = test_policy_loss.item()
-                test_value_loss = test_value_loss.item()
-                test_total_loss = test_total_loss.item()
-            evaluator.network.train()
+            if args.test_batch_size is not None:
+                test_policy_loss, test_value_loss, test_total_loss, acc = compute_test_metrics_batched(
+                    num_states,
+                    db,
+                    evaluator,
+                    board_size,
+                    max_walls,
+                    max_steps,
+                    args.test_batch_size,
+                    test_player=test_player,
+                )
+            else:
+                evaluator.network.eval()
+                with torch.no_grad():
+                    test_policy_loss, test_value_loss, test_total_loss = evaluator.compute_losses(test_samples)
+                    test_policy_loss = test_policy_loss.item()
+                    test_value_loss = test_value_loss.item()
+                    test_total_loss = test_total_loss.item()
+                evaluator.network.train()
 
-            acc = compute_accuracy(
-                test_ids,
-                db,
-                evaluator,
-                board_size,
-                max_walls,
-                max_steps,
-                args.accuracy_states,
-                test_player=test_player,
-            )
+                Timer.log_totals()
+
+                acc = compute_accuracy(
+                    test_ids,
+                    db,
+                    evaluator,
+                    board_size,
+                    max_walls,
+                    max_steps,
+                    args.accuracy_states,
+                    test_player=test_player,
+                )
 
             print(
                 f"step {step:6d} | "

--- a/deep_quoridor/src/train_policy_db_evaluator.py
+++ b/deep_quoridor/src/train_policy_db_evaluator.py
@@ -34,14 +34,14 @@ DEBUG = False
 # ---------------------------------------------------------------------------
 
 
-def print_policy(policy, action_encoder):
+def policy_to_str(policy, action_encoder):
     """Print non-zero entries of a policy array as human-readable actions."""
     nonzero = np.nonzero(policy)[0]
     parts = []
     for idx in nonzero:
         action = action_encoder.index_to_action(idx)
         parts.append(f"{action}: {policy[idx]:.3f}")
-    print("  ".join(parts))
+    return "  ".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -117,6 +117,9 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
         state_bytes = bytes(state)
         game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
         current_player = int(game.current_player)
+        if current_player == 1:
+            # DB Values are always from P1 perspective
+            value = -value
 
         mcts_policy = build_policy_from_action_values(
             db,
@@ -124,7 +127,6 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
             board_size,
             num_actions,
         )
-        assert mcts_policy is not None
 
         # Do the rotation, in the same way AlphaZeroAgent.store_training_data() does
         game, is_rotated = evaluator.rotate_if_needed_to_point_downwards(game)
@@ -136,12 +138,14 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
         if DEBUG:
             print("")
             print(game)
-            print_policy(mcts_policy, evaluator.action_encoder)
+            print(f"Value: {value}")
+            print(f"Optimal actions: {policy_to_str(mcts_policy, evaluator.action_encoder)}")
+            print(f"Valid actions: {policy_to_str(action_mask, evaluator.action_encoder)}")
 
         samples.append(
             {
                 "input_array": input_array,
-                "value": value if current_player == 0 else -value,
+                "value": value,
                 "action_mask": action_mask,
                 "mcts_policy": mcts_policy,
                 "current_player": current_player,
@@ -155,8 +159,10 @@ def fetch_batch(db, ids, evaluator: NNEvaluator, board_size, max_walls, max_step
 # ---------------------------------------------------------------------------
 
 
-def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, num_samples, test_player=None):
-    """Fraction of sampled states where model picks the same best child as DB.
+def compute_accuracy(
+    test_ids, db, evaluator: NNEvaluator, board_size, max_walls, max_steps, num_samples, test_player=None
+):
+    """Fraction of sampled states where model picks the same best action as DB.
 
     If test_player is 0 or 1, only states where the current player matches are counted.
     """
@@ -170,50 +176,35 @@ def compute_accuracy(test_ids, db, evaluator, board_size, max_walls, max_steps, 
     correct = 0
     total = 0
     inaccurate_printed = 0
-    evaluator.network.eval()
     for state_blob, _value in rows:
         state_bytes = bytes(state_blob)
+
         game = compact_state_to_game(state_bytes, board_size, max_walls, max_steps)
         current_player = int(game.current_player)
-
-        # Filter by player if requested.
         if test_player is not None and current_player != test_player:
             continue
 
-        # DB action values (handles terminal child states correctly).
-        # Values are from the acting player's perspective (positive = good).
-        result = db.lookup_action_values(state_bytes)
-        assert result is not None
+        db_policy = build_policy_from_action_values(
+            db,
+            state_bytes,
+            board_size,
+            evaluator.action_encoder.num_actions,
+        )
 
-        _actions, db_action_vals = result
-        db_action_vals = list(db_action_vals)
+        _, model_policy = evaluator.evaluate(game)
 
-        # Model predictions for children (same action ordering as lookup_action_values).
-        children = quoridor_rs.get_compact_child_states(state_bytes, board_size, max_walls, max_steps)
-        child_games = [
-            compact_state_to_game(bytes(child_state), board_size, max_walls, max_steps)
-            for _row, _col, _action_type, child_state in children
-        ]
-        # evaluate_batch returns values from the child's current player's perspective
-        # (i.e. the opponent). Negate to get acting player's perspective.
-        child_values, _ = evaluator.evaluate_batch(child_games)
-        model_vals = [-v for v in child_values]
-
-        # DB action values and model values are both from acting player's perspective.
-        best_db_val = max(db_action_vals)
-        model_pick = int(np.argmax(model_vals))
-        if db_action_vals[model_pick] == best_db_val:
+        best_db_action_prob = max(db_policy)
+        model_pick = int(np.argmax(model_policy))
+        if db_policy[model_pick] == best_db_action_prob:
             correct += 1
         else:
-            if DEBUG and inaccurate_printed < 3:
+            if (DEBUG or True) and inaccurate_printed < 3:
                 inaccurate_printed += 1
-                print(f"  Inaccurate state {inaccurate_printed}:")
-                print(quoridor_rs.compact_state_display(state_bytes, board_size, max_walls, max_steps))
-                print(f"    DB values:    {db_action_vals}")
-                print(f"    Model values: {model_vals}")
-                print(
-                    f"    Best DB val: {best_db_val}, model picked child {model_pick} (DB val: {db_action_vals[model_pick]})"
-                )
+
+                print("")
+                print(game)
+                print(f"DB optimal actions: {policy_to_str(db_policy, evaluator.action_encoder)}")
+                print(f"Model optimal actions: {policy_to_str(model_policy, evaluator.action_encoder)}")
         total += 1
 
     return correct / total

--- a/deep_quoridor/src/upload_policy_db.py
+++ b/deep_quoridor/src/upload_policy_db.py
@@ -1,0 +1,94 @@
+"""Upload a policy database Parquet file to wandb as an artifact.
+
+The artifact carries the file's footer metadata (board_size, max_walls,
+max_steps, num_states) so collaborators can find/select databases in the
+wandb UI without downloading them. `train_policy_db_evaluator.py` can
+consume the resulting artifact via a `wandb:<entity>/<project>/<name>:<alias>`
+path in place of a local file.
+"""
+
+import argparse
+import os
+import sys
+
+import quoridor_rs
+import wandb
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("path", help="Path to a .parquet policy database file")
+    p.add_argument(
+        "--project",
+        default="policydb",
+        help="wandb project to upload to (default: %(default)s)",
+    )
+    p.add_argument(
+        "--name",
+        default=None,
+        help="Artifact name (default: file basename without .parquet)",
+    )
+    p.add_argument(
+        "--description",
+        default=None,
+        help="Free-form description attached to the artifact",
+    )
+    p.add_argument(
+        "--aliases",
+        default=None,
+        help="Comma-separated extra aliases (in addition to wandb's auto-added 'latest')",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not os.path.isfile(args.path):
+        print(f"error: not a file: {args.path}", file=sys.stderr)
+        sys.exit(1)
+    if not args.path.endswith(".parquet"):
+        print(f"error: expected a .parquet file, got: {args.path}", file=sys.stderr)
+        sys.exit(1)
+
+    name = args.name or os.path.splitext(os.path.basename(args.path))[0]
+
+    # Read footer metadata for tagging. lazy=True avoids loading the full
+    # dataset into memory just to inspect the header.
+    db = quoridor_rs.PyPolicyDb(args.path, lazy=True)
+    board_size, max_walls, max_steps, num_states = db.read_metadata()
+    print(
+        f"Read metadata: board_size={board_size}, max_walls={max_walls}, "
+        f"max_steps={max_steps}, num_states={num_states}"
+    )
+
+    aliases = []
+    if args.aliases:
+        aliases = [a.strip() for a in args.aliases.split(",") if a.strip()]
+
+    run = wandb.init(project=args.project, job_type="upload_policy_db")
+    try:
+        artifact = wandb.Artifact(
+            name=name,
+            type="policy_db",
+            description=args.description,
+            metadata={
+                "board_size": board_size,
+                "max_walls": max_walls,
+                "max_steps": max_steps,
+                "num_states": num_states,
+                "file_basename": os.path.basename(args.path),
+            },
+        )
+        artifact.add_file(args.path)
+        run.log_artifact(artifact, aliases=aliases or None)
+        artifact.wait()  # block until the upload completes
+    finally:
+        wandb.finish()
+
+    full_ref = f"{run.entity}/{args.project}/{name}:latest"
+    print(f"Uploaded. Reference for train_policy_db_evaluator.py:\n  wandb:{full_ref}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Improvements:
- Can now download a precomputed policy database from W&B
- Switched database format from sqlite to parquet, which has made it much much faster.

First build the python extension
```
(cd deep_quoridor/rust && maturin develop --release)
```

Then run the script that trains an evaluator using a policy database. Using the `wandb:` syntax in this command tells it to download the policy database from W&B. I've only uploaded this one so far; it's for 5x5, 2 walls, max_steps=20.

```
python deep_quoridor/src/train_policy_db_evaluator.py wandb:the-lazy-learning-lair/policydb/policydb_5_2_20:latest -p nn_type=resnet,nn_resnet_num_blocks=2,nn_resnet_num_channels=32,learning_rate=0.001,batch_size=2048,weight_decay=0.0001 -w --test-batch-size 2048 --log-interval 10
```

Training stats will be logged to W&B where you can look at them.